### PR TITLE
Add LINQ-Extensions using Option<T>

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,3 +7,4 @@ Alex.Stuecker@digitecgalaxus.ch
 Christian.Hinder@digitecgalaxus.ch
 luca.schneider@gmx.ch
 thepadawan3@gmail.com
+juri.furer@protonmail.com

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/OptionLinqExtensionsTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/OptionLinqExtensionsTests.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Galaxus.Functional.Tests.OptionExtensions
+{
+    [TestFixture]
+    public class OptionLinqExtensionsTests
+    {
+        [Test]
+        public void ElementAtOrNoneTest()
+        {
+            // Arrange
+            var list = new List<int> {0, 1, 2, 3, 4};
+
+            // Act
+            var some1 = list.ElementAtOrNone(0);
+            var some2 = list.ElementAtOrNone(2);
+            var none1 = list.ElementAtOrNone(5);
+            var none2 = list.ElementAtOrNone(-1);
+
+            // Assert
+            Assert.IsTrue(some1.IsSome);
+            Assert.AreEqual(0, some1.Unwrap());
+
+            Assert.IsTrue(some2.IsSome);
+            Assert.AreEqual(2, some2.Unwrap());
+
+            Assert.IsTrue(none1.IsNone);
+            Assert.IsTrue(none2.IsNone);
+        }
+
+        [Test]
+        public void FirstOrNoneTest()
+        {
+            // Arrange
+            var list = new List<int> {0, 1, 2, 3, 4};
+
+            // Act
+            var some1 = list.FirstOrNone();
+            var some2 = list.FirstOrNone(x => x > 2);
+            var none = list.FirstOrNone(x => x == 10);
+
+            // Assert
+            Assert.IsTrue(some1.IsSome);
+            Assert.AreEqual(0, some1.Unwrap());
+
+            Assert.IsTrue(some2.IsSome);
+            Assert.AreEqual(3, some2.Unwrap());
+
+            Assert.IsTrue(none.IsNone);
+        }
+
+        [Test]
+        public void LastOrNoneTest()
+        {
+            // Arrange
+            var list = new List<int> {0, 1, 2, 3, 4};
+
+            // Act
+            var some1 = list.LastOrNone();
+            var some2 = list.LastOrNone(x => x > 2);
+            var none = list.FirstOrNone(x => x == 10);
+
+            // Assert
+            Assert.IsTrue(some1.IsSome);
+            Assert.AreEqual(4, some1.Unwrap());
+
+            Assert.IsTrue(some2.IsSome);
+            Assert.AreEqual(4, some2.Unwrap());
+
+            Assert.IsTrue(none.IsNone);
+        }
+
+        [Test]
+        public void SingleOrNone()
+        {
+            // Arrange
+            var list1 = new List<int> {0, 1, 2, 3, 4};
+            var list2 = new List<int> {0, 1, 2, 2, 3, 4};
+            var list3 = new List<int> {0};
+            
+            // ReSharper disable once CollectionNeverUpdated.Local
+            // This is intentional
+            var list4 = new List<int>();
+
+            // Act
+            var some1 = list1.SingleOrNone(x => x == 2);
+            var some2 = list3.SingleOrNone();
+            var none = list4.SingleOrNone();
+
+            try
+            {
+                // Act and assert failure
+                list2.SingleOrNone(x => x == 2);
+                Assert.Fail("Calling 'SingleOrNone' on a list with multiple instances of an element should throw an exception");
+            }
+            catch (InvalidOperationException)
+            { }
+
+            try
+            {
+                // Act and assert failure
+                list2.SingleOrNone();
+                Assert.Fail("Calling 'SingleOrNone' on a list with more than 1 element should throw an exception");
+            }
+            catch(InvalidOperationException)
+            { }
+
+            // Assert
+            Assert.IsTrue(some1.IsSome);
+            Assert.AreEqual(2, some1.Unwrap());
+
+            Assert.IsTrue(some2.IsSome);
+            Assert.AreEqual(0, some2.Unwrap());
+
+            Assert.IsTrue(none.IsNone);
+        }
+    }
+}

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/OptionLinqExtensionsTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/OptionLinqExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Galaxus.Functional.Linq;
 using NUnit.Framework;
 
 namespace Galaxus.Functional.Tests.OptionExtensions
@@ -8,111 +9,145 @@ namespace Galaxus.Functional.Tests.OptionExtensions
     public class OptionLinqExtensionsTests
     {
         [Test]
-        public void ElementAtOrNoneTest()
+        public void ElementAtOrNone_IndexIsZero_ReturnsSome()
         {
-            // Arrange
             var list = new List<int> {0, 1, 2, 3, 4};
+            
+            var some = list.ElementAtOrNone(0);
 
-            // Act
-            var some1 = list.ElementAtOrNone(0);
-            var some2 = list.ElementAtOrNone(2);
-            var none1 = list.ElementAtOrNone(5);
-            var none2 = list.ElementAtOrNone(-1);
-
-            // Assert
-            Assert.IsTrue(some1.IsSome);
-            Assert.AreEqual(0, some1.Unwrap());
-
-            Assert.IsTrue(some2.IsSome);
-            Assert.AreEqual(2, some2.Unwrap());
-
-            Assert.IsTrue(none1.IsNone);
-            Assert.IsTrue(none2.IsNone);
+            Assert.IsTrue(some.IsSome);
+            Assert.AreEqual(0, some.Unwrap());
         }
 
         [Test]
-        public void FirstOrNoneTest()
+        public void ElementAtOrNone_IndexIsCount_ReturnsNone()
         {
-            // Arrange
             var list = new List<int> {0, 1, 2, 3, 4};
 
-            // Act
-            var some1 = list.FirstOrNone();
-            var some2 = list.FirstOrNone(x => x > 2);
-            var none = list.FirstOrNone(x => x == 10);
-
-            // Assert
-            Assert.IsTrue(some1.IsSome);
-            Assert.AreEqual(0, some1.Unwrap());
-
-            Assert.IsTrue(some2.IsSome);
-            Assert.AreEqual(3, some2.Unwrap());
+            var none = list.ElementAtOrNone(5);
 
             Assert.IsTrue(none.IsNone);
         }
 
         [Test]
-        public void LastOrNoneTest()
+        public void ElementAtOrNone_IndexIsNegativeOne_ReturnsNone()
         {
-            // Arrange
             var list = new List<int> {0, 1, 2, 3, 4};
 
-            // Act
-            var some1 = list.LastOrNone();
-            var some2 = list.LastOrNone(x => x > 2);
+            var none = list.ElementAtOrNone(-1);
+
+            Assert.IsTrue(none.IsNone);
+        }
+
+        [Test]
+        public void FirstOrNone_NoPredicate_ReturnsSome()
+        {
+            var list = new List<int> {0, 1, 2, 3, 4};
+
+            var some = list.FirstOrNone();
+
+            Assert.IsTrue(some.IsSome);
+            Assert.AreEqual(0, some.Unwrap());
+        }
+
+        [Test]
+        public void FirstOrNone_WithPredicate_ReturnsSome()
+        {
+            var list = new List<int> {0, 1, 2, 3, 4};
+            var some = list.FirstOrNone(x => x > 2);
+
+            Assert.IsTrue(some.IsSome);
+            Assert.AreEqual(3, some.Unwrap());
+        }
+
+        [Test]
+        public void FirstOrNone_PredicateMatchesNone_ReturnsNone()
+        {
+            var list = new List<int> {0, 1, 2, 3, 4};
+
             var none = list.FirstOrNone(x => x == 10);
 
-            // Assert
+            Assert.IsTrue(none.IsNone);
+        }
+
+        [Test]
+        public void LastOrNone_GetLast_ReturnsSome()
+        {
+            var list = new List<int> {0, 1, 2, 3, 4};
+
+            var some1 = list.LastOrNone();
+
             Assert.IsTrue(some1.IsSome);
             Assert.AreEqual(4, some1.Unwrap());
+        }
+
+        [Test]
+        public void LastOrNone_WithPredicate_ReturnsSome()
+        {
+            var list = new List<int> {0, 1, 2, 3, 4};
+
+            var some2 = list.LastOrNone(x => x > 2);
 
             Assert.IsTrue(some2.IsSome);
             Assert.AreEqual(4, some2.Unwrap());
+        }
+
+        [Test]
+        public void LastOrNon_PredicateMatchesNon_ReturnsNone()
+        {
+            var list = new List<int> {0, 1, 2, 3, 4};
+
+            var none = list.FirstOrNone(x => x == 10);
 
             Assert.IsTrue(none.IsNone);
         }
 
         [Test]
-        public void SingleOrNone()
+        public void SingleOrNone_SingleMatchingElement_ReturnsSome()
         {
-            // Arrange
             var list1 = new List<int> {0, 1, 2, 3, 4};
-            var list2 = new List<int> {0, 1, 2, 2, 3, 4};
+
+            var some1 = list1.SingleOrNone(x => x == 2);
+
+            Assert.IsTrue(some1.IsSome);
+            Assert.AreEqual(2, some1.Unwrap());
+        }
+
+        [Test]
+        public void SingleOrNone_SingleElementInCollection_ReturnsSome()
+        {
             var list3 = new List<int> {0};
-            
+
+            var some2 = list3.SingleOrNone();
+
+            Assert.IsTrue(some2.IsSome);
+            Assert.AreEqual(0, some2.Unwrap());
+        }
+
+        [Test]
+        public void SingleOrNone_MultipleMatchingElements_ThrowsException()
+        {
+            var list2 = new List<int> {0, 1, 2, 2, 3, 4};
+
+            Assert.Throws<InvalidOperationException>(() => list2.SingleOrNone(x => x == 2));
+        }
+
+        [Test]
+        public void SingleOrNone_MultipleElements_ThrowsException()
+        {
+            var list2 = new List<int> {0, 1, 2, 2, 3, 4};
+
+            Assert.Throws<InvalidOperationException>(() => list2.SingleOrNone());
+        }
+
+        [Test]
+        public void SingleOrNone_EmptyList_ReturnsNone()
+        {
             // ReSharper disable once CollectionNeverUpdated.Local
             // This is intentional
             var list4 = new List<int>();
 
-            // Act
-            var some1 = list1.SingleOrNone(x => x == 2);
-            var some2 = list3.SingleOrNone();
             var none = list4.SingleOrNone();
-
-            try
-            {
-                // Act and assert failure
-                list2.SingleOrNone(x => x == 2);
-                Assert.Fail("Calling 'SingleOrNone' on a list with multiple instances of an element should throw an exception");
-            }
-            catch (InvalidOperationException)
-            { }
-
-            try
-            {
-                // Act and assert failure
-                list2.SingleOrNone();
-                Assert.Fail("Calling 'SingleOrNone' on a list with more than 1 element should throw an exception");
-            }
-            catch(InvalidOperationException)
-            { }
-
-            // Assert
-            Assert.IsTrue(some1.IsSome);
-            Assert.AreEqual(2, some1.Unwrap());
-
-            Assert.IsTrue(some2.IsSome);
-            Assert.AreEqual(0, some2.Unwrap());
 
             Assert.IsTrue(none.IsNone);
         }

--- a/Galaxus.Functional/(Option)/(Extensions)/OptionLinqExtensions.cs
+++ b/Galaxus.Functional/(Option)/(Extensions)/OptionLinqExtensions.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// Extensions on top of LINQ using <see cref="Option{T}"/>.
+    ///     Extensions on top of LINQ using <see cref="Option{T}" />.
     /// </summary>
     public static class OptionLinqExtensions
     {
@@ -54,7 +54,8 @@ namespace Galaxus.Functional
         ///     <c>predicate</c>; otherwise, the first element in <c>source</c> that passes the test specified by <c>predicate</c>.
         /// </returns>
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
-        public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
+        public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source,
+            Func<TSource, bool> predicate)
         {
             var value = source.FirstOrDefault(predicate);
             return value == null || value.Equals(default) ? Option<TSource>.None : Option<TSource>.Some(value);
@@ -126,7 +127,8 @@ namespace Galaxus.Functional
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException">More than one element satisfies the condition in <c>source</c>.</exception>
-        public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
+        public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source,
+            Func<TSource, bool> predicate)
         {
             var value = source.SingleOrDefault(predicate);
             return value == null ? Option<TSource>.None : Option<TSource>.Some(value);

--- a/Galaxus.Functional/(Option)/(Extensions)/OptionLinqExtensions.cs
+++ b/Galaxus.Functional/(Option)/(Extensions)/OptionLinqExtensions.cs
@@ -23,8 +23,8 @@ namespace Galaxus.Functional
         /// <exception cref="ArgumentNullException"><c>source</c> is <c>null</c>.</exception>
         public static Option<TSource> ElementAtOrNone<TSource>(this IEnumerable<TSource> source, int index)
         {
-            var value = source.ElementAtOrDefault(index);
-            return value == null || value.Equals(default) ? Option<TSource>.None : Option<TSource>.Some(value);
+            var value = source.ToList();
+            return index >= value.Count || index < 0 ? Option<TSource>.None : Option<TSource>.Some(value[index]);
         }
 
         /// <summary>
@@ -38,8 +38,8 @@ namespace Galaxus.Functional
         /// </returns>
         public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source)
         {
-            var value = source.FirstOrDefault();
-            return value == null || value.Equals(default) ? Option<TSource>.None : Option<TSource>.Some(value);
+            var value = source.ToList();
+            return value.Count == 0 ? Option<TSource>.None : Option<TSource>.Some(value[0]);
         }
 
         /// <summary>
@@ -57,8 +57,8 @@ namespace Galaxus.Functional
         public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source,
             Func<TSource, bool> predicate)
         {
-            var value = source.FirstOrDefault(predicate);
-            return value == null || value.Equals(default) ? Option<TSource>.None : Option<TSource>.Some(value);
+            var value = source.Where(predicate).ToList();
+            return value.Count == 0 ? Option<TSource>.None : Option<TSource>.Some(value[0]);
         }
 
         /// <summary>
@@ -73,8 +73,8 @@ namespace Galaxus.Functional
         /// <exception cref="ArgumentNullException"><c>source</c> is <c>null</c>.</exception>
         public static Option<TSource> LastOrNone<TSource>(this IEnumerable<TSource> source)
         {
-            var value = source.LastOrDefault();
-            return value == null ? Option<TSource>.None : Option<TSource>.Some(value);
+            var value = source.ToList();
+            return value.Count == 0 ? Option<TSource>.None : Option<TSource>.Some(value[value.Count - 1]);
         }
 
         /// <summary>
@@ -92,8 +92,10 @@ namespace Galaxus.Functional
         public static Option<TSource> LastOrNone<TSource>(this IEnumerable<TSource> source,
             Func<TSource, bool> predicate)
         {
-            var value = source.LastOrDefault(predicate);
-            return value == null ? Option<TSource>.None : Option<TSource>.Some(value);
+            var value = source.Where(predicate).ToList();
+            return value.Count == 0 ? Option<TSource>.None : Option<TSource>.Some(value[value.Count - 1]);
+            //var value = source.LastOrDefault(predicate);
+            //return value == null ? Option<TSource>.None : Option<TSource>.Some(value);
         }
 
         /// <summary>
@@ -113,8 +115,10 @@ namespace Galaxus.Functional
         /// <exception cref="InvalidOperationException">The input sequence contains more than one element.</exception>
         public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source)
         {
-            var value = source.SingleOrDefault();
-            return value == null ? Option<TSource>.None : Option<TSource>.Some(value);
+            var value = source.ToList();
+            return value.Count == 0 ? Option<TSource>.None :
+                value.Count > 1 ? throw new InvalidOperationException("Sequence contains more than one element") :
+                Option<TSource>.Some(value[0]);
         }
 
         /// <summary>
@@ -130,8 +134,10 @@ namespace Galaxus.Functional
         public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source,
             Func<TSource, bool> predicate)
         {
-            var value = source.SingleOrDefault(predicate);
-            return value == null ? Option<TSource>.None : Option<TSource>.Some(value);
+            var value = source.Where(predicate).ToList();
+            return value.Count == 0 ? Option<TSource>.None :
+                value.Count > 1 ? throw new InvalidOperationException("Sequence contains more than one element") :
+                Option<TSource>.Some(value[0]);
         }
     }
 }

--- a/Galaxus.Functional/(Option)/(Extensions)/OptionLinqExtensions.cs
+++ b/Galaxus.Functional/(Option)/(Extensions)/OptionLinqExtensions.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Galaxus.Functional
+{
+    /// <summary>
+    /// Extensions on top of LINQ using <see cref="Option{T}"/>.
+    /// </summary>
+    public static class OptionLinqExtensions
+    {
+        /// <summary>
+        ///     Returns the element at a specified index in a sequence or <see cref="Option{T}.None" /> if the index is out of
+        ///     range.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <c>source</c>.</typeparam>
+        /// <param name="source">An <see cref="IEnumerable{T}" /> to return an element from.</param>
+        /// <param name="index">The zero-based index of the element to retrieve.</param>
+        /// <returns>
+        ///     <c><see cref="Option{T}" />.None</c> if the index is outside the bounds of the source sequence; otherwise, the
+        ///     element at the specified position in the source sequence.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><c>source</c> is <c>null</c>.</exception>
+        public static Option<TSource> ElementAtOrNone<TSource>(this IEnumerable<TSource> source, int index)
+        {
+            var value = source.ElementAtOrDefault(index);
+            return value == null || value.Equals(default) ? Option<TSource>.None : Option<TSource>.Some(value);
+        }
+
+        /// <summary>
+        ///     Returns the first element of the sequence that satisfies a condition or <see cref="Option{T}.None" /> if the
+        ///     sequence contains no elements.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <c>source</c>.</typeparam>
+        /// <param name="source">An <see cref="IEnumerable{T}" /> to return an element from.</param>
+        /// <returns>
+        ///     <c><see cref="Option{T}" />.None</c> if <c>source</c> is empty; otherwise, the first element in <c>source</c>.
+        /// </returns>
+        public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source)
+        {
+            var value = source.FirstOrDefault();
+            return value == null || value.Equals(default) ? Option<TSource>.None : Option<TSource>.Some(value);
+        }
+
+        /// <summary>
+        ///     Returns the first element of the sequence that satisfies a condition or <see cref="Option{T}.None" /> if the
+        ///     sequence contains no elements.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <c>source</c>.</typeparam>
+        /// <param name="source">An <see cref="IEnumerable{T}" /> to return an element from.</param>
+        /// <param name="predicate">A function to test each element for a condition.</param>
+        /// <returns>
+        ///     <c><see cref="Option{T}" />.None</c> if <c>source</c> is empty or if no element passes the test specified by
+        ///     <c>predicate</c>; otherwise, the first element in <c>source</c> that passes the test specified by <c>predicate</c>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
+        public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
+        {
+            var value = source.FirstOrDefault(predicate);
+            return value == null || value.Equals(default) ? Option<TSource>.None : Option<TSource>.Some(value);
+        }
+
+        /// <summary>
+        ///     Returns the last element of a sequence, or <see cref="Option{T}.None" /> if the sequence contains no elements.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <c>source</c>.</typeparam>
+        /// <param name="source">An <see cref="IEnumerable{T}" /> to return the last element of.</param>
+        /// <returns>
+        ///     <c><see cref="Option{T}" />.None</c> if the source sequence is empty; otherwise, the last element in the
+        ///     <see cref="IEnumerable{T}" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><c>source</c> is <c>null</c>.</exception>
+        public static Option<TSource> LastOrNone<TSource>(this IEnumerable<TSource> source)
+        {
+            var value = source.LastOrDefault();
+            return value == null ? Option<TSource>.None : Option<TSource>.Some(value);
+        }
+
+        /// <summary>
+        ///     Returns the last element of a sequence that satisfies a condition or <see cref="Option{T}.None" /> if no such
+        ///     element is found.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <c>source</c>.</typeparam>
+        /// <param name="source">An <see cref="IEnumerable{T}" /> to return an element from.</param>
+        /// <param name="predicate">A function to test each element for a condition.</param>
+        /// <returns>
+        ///     <c><see cref="Option{T}" />.None</c> if the sequence is empty or if no elements pass the test in the predicate
+        ///     function; otherwise, the last element that passes the test in the predicate function.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
+        public static Option<TSource> LastOrNone<TSource>(this IEnumerable<TSource> source,
+            Func<TSource, bool> predicate)
+        {
+            var value = source.LastOrDefault(predicate);
+            return value == null ? Option<TSource>.None : Option<TSource>.Some(value);
+        }
+
+        /// <summary>
+        ///     Returns the only element of a sequence, or <see cref="Option{T}.None" /> if the sequence is empty; this method
+        ///     throws an exception if there is more than one element in the sequence.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <c>source</c>.</typeparam>
+        /// <param name="source">An <see cref="IEnumerable{T}" /> to return the single element of.</param>
+        /// <returns>
+        ///     The single element of the input sequence, or
+        ///     <c>
+        ///         <see cref="Option{T}.None" />
+        ///     </c>
+        ///     if the sequence contains no elements.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><c>source</c> is <c>null</c>.</exception>
+        /// <exception cref="InvalidOperationException">The input sequence contains more than one element.</exception>
+        public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source)
+        {
+            var value = source.SingleOrDefault();
+            return value == null ? Option<TSource>.None : Option<TSource>.Some(value);
+        }
+
+        /// <summary>
+        ///     Returns the only element of a sequence that satisfies a specified condition or <see cref="Option{T}.None" /> if no
+        ///     such element exists; this method throws an exception if more than one element satisfies the condition.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <c>source</c>.</typeparam>
+        /// <param name="source">An <see cref="IEnumerable{T}" /> to return a single element from.</param>
+        /// <param name="predicate">A function to test an element for a condition.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
+        /// <exception cref="InvalidOperationException">More than one element satisfies the condition in <c>source</c>.</exception>
+        public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
+        {
+            var value = source.SingleOrDefault(predicate);
+            return value == null ? Option<TSource>.None : Option<TSource>.Some(value);
+        }
+    }
+}

--- a/Galaxus.Functional/Linq/OptionLinqExtensions.cs
+++ b/Galaxus.Functional/Linq/OptionLinqExtensions.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Galaxus.Functional
+namespace Galaxus.Functional.Linq
 {
     /// <summary>
     ///     Extensions on top of LINQ using <see cref="Option{T}" />.
@@ -54,8 +54,7 @@ namespace Galaxus.Functional
         ///     <c>predicate</c>; otherwise, the first element in <c>source</c> that passes the test specified by <c>predicate</c>.
         /// </returns>
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
-        public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source,
-            Func<TSource, bool> predicate)
+        public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
             var value = source.Where(predicate).ToList();
             return value.Count == 0 ? Option<TSource>.None : Option<TSource>.Some(value[0]);
@@ -89,13 +88,10 @@ namespace Galaxus.Functional
         ///     function; otherwise, the last element that passes the test in the predicate function.
         /// </returns>
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
-        public static Option<TSource> LastOrNone<TSource>(this IEnumerable<TSource> source,
-            Func<TSource, bool> predicate)
+        public static Option<TSource> LastOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
             var value = source.Where(predicate).ToList();
             return value.Count == 0 ? Option<TSource>.None : Option<TSource>.Some(value[value.Count - 1]);
-            //var value = source.LastOrDefault(predicate);
-            //return value == null ? Option<TSource>.None : Option<TSource>.Some(value);
         }
 
         /// <summary>
@@ -116,9 +112,13 @@ namespace Galaxus.Functional
         public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source)
         {
             var value = source.ToList();
-            return value.Count == 0 ? Option<TSource>.None :
-                value.Count > 1 ? throw new InvalidOperationException("Sequence contains more than one element") :
-                Option<TSource>.Some(value[0]);
+            if (value.Count == 0)
+                return Option<TSource>.None;
+
+            if (value.Count > 1)
+                throw new InvalidOperationException("Sequence contains more than one element");
+
+            return Option<TSource>.Some(value[0]);
         }
 
         /// <summary>
@@ -131,13 +131,16 @@ namespace Galaxus.Functional
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException">More than one element satisfies the condition in <c>source</c>.</exception>
-        public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source,
-            Func<TSource, bool> predicate)
+        public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
             var value = source.Where(predicate).ToList();
-            return value.Count == 0 ? Option<TSource>.None :
-                value.Count > 1 ? throw new InvalidOperationException("Sequence contains more than one element") :
-                Option<TSource>.Some(value[0]);
+            if (value.Count == 0)
+                return Option<TSource>.None;
+
+            if (value.Count > 1)
+                throw new InvalidOperationException("Sequence contains more than one element");
+
+            return Option<TSource>.Some(value[0]);
         }
     }
 }


### PR DESCRIPTION
I added some extensions using `Option<T>`, namely

- `ElementAtOrNone`
- `FirstOrNone`
- `LastOrNone`
- `SingleOrNone`

As well as some unit tests covering these methods