### PR TITLE
Make FirstOrNone, LastOrNone, SingleOrNone and ElementAtOrNone Lazy

### DIFF
--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/OptionLinqExtensionsTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/OptionLinqExtensionsTests.cs
@@ -13,7 +13,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void ElementAtOrNone_IndexIsZero_ReturnsSome()
         {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+            var list = new List<int> {0, 1, 2, 3, 4};
 
             var some = list.ElementAtOrNone(0);
 
@@ -24,7 +24,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void ElementAtOrNone_IndexIsCount_ReturnsNone()
         {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+            var list = new List<int> {0, 1, 2, 3, 4};
 
             var none = list.ElementAtOrNone(5);
 
@@ -34,7 +34,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void ElementAtOrNone_IndexIsNegativeOne_ReturnsNone()
         {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+            var list = new List<int> {0, 1, 2, 3, 4};
 
             var none = list.ElementAtOrNone(-1);
 
@@ -56,7 +56,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void FirstOrNone_NoPredicate_ReturnsSome()
         {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+            var list = new List<int> {0, 1, 2, 3, 4};
 
             var some = list.FirstOrNone();
 
@@ -67,7 +67,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void FirstOrNone_WithPredicate_ReturnsSome()
         {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+            var list = new List<int> {0, 1, 2, 3, 4};
             var some = list.FirstOrNone(x => x > 2);
 
             Assert.IsTrue(some.IsSome);
@@ -77,7 +77,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void FirstOrNone_PredicateMatchesNone_ReturnsNone()
         {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+            var list = new List<int> {0, 1, 2, 3, 4};
 
             var none = list.FirstOrNone(x => x == 10);
 
@@ -98,7 +98,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void LastOrNone_GetLast_ReturnsSome()
         {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+            var list = new List<int> {0, 1, 2, 3, 4};
 
             var some1 = list.LastOrNone();
 
@@ -109,7 +109,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void LastOrNone_WithPredicate_ReturnsSome()
         {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+            var list = new List<int> {0, 1, 2, 3, 4};
 
             var some2 = list.LastOrNone(x => x > 2);
 
@@ -120,7 +120,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void LastOrNon_PredicateMatchesNon_ReturnsNone()
         {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+            var list = new List<int> {0, 1, 2, 3, 4};
 
             var none = list.FirstOrNone(x => x == 10);
 
@@ -130,7 +130,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void SingleOrNone_SingleMatchingElement_ReturnsSome()
         {
-            var list1 = new List<int> { 0, 1, 2, 3, 4 };
+            var list1 = new List<int> {0, 1, 2, 3, 4};
 
             var some1 = list1.SingleOrNone(x => x == 2);
 
@@ -141,7 +141,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void SingleOrNone_SingleElementInCollection_ReturnsSome()
         {
-            var list3 = new List<int> { 0 };
+            var list3 = new List<int> {0};
 
             var some2 = list3.SingleOrNone();
 
@@ -152,7 +152,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void SingleOrNone_MultipleMatchingElements_ThrowsException()
         {
-            var list2 = new List<int> { 0, 1, 2, 2, 3, 4 };
+            var list2 = new List<int> {0, 1, 2, 2, 3, 4};
 
             Assert.Throws<InvalidOperationException>(() => list2.SingleOrNone(x => x == 2));
         }
@@ -160,7 +160,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void SingleOrNone_MultipleElements_ThrowsException()
         {
-            var list2 = new List<int> { 0, 1, 2, 2, 3, 4 };
+            var list2 = new List<int> {0, 1, 2, 2, 3, 4};
 
             Assert.Throws<InvalidOperationException>(() => list2.SingleOrNone());
         }

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/OptionLinqExtensionsTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/OptionLinqExtensionsTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Galaxus.Functional.Linq;
+using Galaxus.Functional.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Galaxus.Functional.Tests.OptionExtensions
@@ -11,8 +13,8 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void ElementAtOrNone_IndexIsZero_ReturnsSome()
         {
-            var list = new List<int> {0, 1, 2, 3, 4};
-            
+            var list = new List<int> { 0, 1, 2, 3, 4 };
+
             var some = list.ElementAtOrNone(0);
 
             Assert.IsTrue(some.IsSome);
@@ -22,7 +24,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void ElementAtOrNone_IndexIsCount_ReturnsNone()
         {
-            var list = new List<int> {0, 1, 2, 3, 4};
+            var list = new List<int> { 0, 1, 2, 3, 4 };
 
             var none = list.ElementAtOrNone(5);
 
@@ -32,7 +34,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void ElementAtOrNone_IndexIsNegativeOne_ReturnsNone()
         {
-            var list = new List<int> {0, 1, 2, 3, 4};
+            var list = new List<int> { 0, 1, 2, 3, 4 };
 
             var none = list.ElementAtOrNone(-1);
 
@@ -40,9 +42,21 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         }
 
         [Test]
+        public void ElementAtOrNone_AppliedToFailingEnumerator_DoesNotThrow()
+        {
+            var index = 5;
+            var sequence = new YieldElementsThenFail<string>("Hello world", index + 1);
+
+            var composition = sequence.ElementAtOrNone(index);
+
+            Assert.IsTrue(composition.IsSome);
+            Assert.Throws<AssertionException>(() => sequence.ToList());
+        }
+
+        [Test]
         public void FirstOrNone_NoPredicate_ReturnsSome()
         {
-            var list = new List<int> {0, 1, 2, 3, 4};
+            var list = new List<int> { 0, 1, 2, 3, 4 };
 
             var some = list.FirstOrNone();
 
@@ -53,7 +67,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void FirstOrNone_WithPredicate_ReturnsSome()
         {
-            var list = new List<int> {0, 1, 2, 3, 4};
+            var list = new List<int> { 0, 1, 2, 3, 4 };
             var some = list.FirstOrNone(x => x > 2);
 
             Assert.IsTrue(some.IsSome);
@@ -63,7 +77,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void FirstOrNone_PredicateMatchesNone_ReturnsNone()
         {
-            var list = new List<int> {0, 1, 2, 3, 4};
+            var list = new List<int> { 0, 1, 2, 3, 4 };
 
             var none = list.FirstOrNone(x => x == 10);
 
@@ -71,9 +85,20 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         }
 
         [Test]
+        public void FirstOrNone_AppliedToFailingEnumerator_DoesNotThrow()
+        {
+            var sequence = new YieldElementsThenFail<string>("Hello world", 1);
+
+            var composition = sequence.FirstOrNone();
+
+            Assert.IsTrue(composition.IsSome);
+            Assert.Throws<AssertionException>(() => sequence.ToList());
+        }
+
+        [Test]
         public void LastOrNone_GetLast_ReturnsSome()
         {
-            var list = new List<int> {0, 1, 2, 3, 4};
+            var list = new List<int> { 0, 1, 2, 3, 4 };
 
             var some1 = list.LastOrNone();
 
@@ -84,7 +109,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void LastOrNone_WithPredicate_ReturnsSome()
         {
-            var list = new List<int> {0, 1, 2, 3, 4};
+            var list = new List<int> { 0, 1, 2, 3, 4 };
 
             var some2 = list.LastOrNone(x => x > 2);
 
@@ -95,7 +120,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void LastOrNon_PredicateMatchesNon_ReturnsNone()
         {
-            var list = new List<int> {0, 1, 2, 3, 4};
+            var list = new List<int> { 0, 1, 2, 3, 4 };
 
             var none = list.FirstOrNone(x => x == 10);
 
@@ -105,7 +130,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void SingleOrNone_SingleMatchingElement_ReturnsSome()
         {
-            var list1 = new List<int> {0, 1, 2, 3, 4};
+            var list1 = new List<int> { 0, 1, 2, 3, 4 };
 
             var some1 = list1.SingleOrNone(x => x == 2);
 
@@ -116,7 +141,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void SingleOrNone_SingleElementInCollection_ReturnsSome()
         {
-            var list3 = new List<int> {0};
+            var list3 = new List<int> { 0 };
 
             var some2 = list3.SingleOrNone();
 
@@ -127,7 +152,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void SingleOrNone_MultipleMatchingElements_ThrowsException()
         {
-            var list2 = new List<int> {0, 1, 2, 2, 3, 4};
+            var list2 = new List<int> { 0, 1, 2, 2, 3, 4 };
 
             Assert.Throws<InvalidOperationException>(() => list2.SingleOrNone(x => x == 2));
         }
@@ -135,7 +160,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void SingleOrNone_MultipleElements_ThrowsException()
         {
-            var list2 = new List<int> {0, 1, 2, 2, 3, 4};
+            var list2 = new List<int> { 0, 1, 2, 2, 3, 4 };
 
             Assert.Throws<InvalidOperationException>(() => list2.SingleOrNone());
         }
@@ -150,6 +175,15 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var none = list4.SingleOrNone();
 
             Assert.IsTrue(none.IsNone);
+        }
+
+        [Test]
+        public void SingleOrNone_AppliedToFailingEnumerator_DoesNotThrow()
+        {
+            var sequence = new YieldElementsThenFail<string>("Hello world", 2);
+
+            Assert.Throws<InvalidOperationException>(() => sequence.SingleOrNone());
+            Assert.Throws<AssertionException>(() => sequence.ToList());
         }
     }
 }

--- a/Galaxus.Functional.Tests/Helpers/FailOnNthElement.cs
+++ b/Galaxus.Functional.Tests/Helpers/FailOnNthElement.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Galaxus.Functional.Tests.Helpers
+{
+    internal class YieldElementsThenFail<T> : IEnumerable<T>
+    {
+        private readonly T _elementToYield;
+        private readonly int _numberOfElements;
+
+        public YieldElementsThenFail(T elementToYield, int numberOfElements)
+        {
+            _elementToYield = elementToYield;
+            _numberOfElements = numberOfElements;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            foreach (var _ in Enumerable.Range(0, _numberOfElements))
+            {
+                yield return _elementToYield;
+            }
+
+            Assert.Fail("Sequence was unexpectedly enumerated.");
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+            => GetEnumerator();
+    }
+}

--- a/Galaxus.Functional/Linq/OptionLinqExtensions.cs
+++ b/Galaxus.Functional/Linq/OptionLinqExtensions.cs
@@ -36,7 +36,7 @@ namespace Galaxus.Functional.Linq
         ///     <c><see cref="Option{T}" />.None</c> if <c>source</c> is empty; otherwise, the first element in <c>source</c>.
         /// </returns>
         public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source)
-            => source.FirstOrNone(_ => true);
+            => source.FirstOrNone(True);
 
         /// <summary>
         ///     Returns the first element of the sequence that satisfies a condition or <see cref="Option{T}.None" /> if the
@@ -67,7 +67,7 @@ namespace Galaxus.Functional.Linq
         /// </returns>
         /// <exception cref="ArgumentNullException"><c>source</c> is <c>null</c>.</exception>
         public static Option<TSource> LastOrNone<TSource>(this IEnumerable<TSource> source)
-            => source.LastOrNone(_ => true);
+            => source.LastOrNone(True);
 
         /// <summary>
         ///     Returns the last element of a sequence that satisfies a condition or <see cref="Option{T}.None" /> if no such
@@ -104,7 +104,7 @@ namespace Galaxus.Functional.Linq
         /// <exception cref="ArgumentNullException"><c>source</c> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException">The input sequence contains more than one element.</exception>
         public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source)
-            => source.SingleOrNone(_ => true);
+            => source.SingleOrNone(True);
 
         /// <summary>
         ///     Returns the only element of a sequence that satisfies a specified condition or <see cref="Option{T}.None" /> if no
@@ -122,5 +122,9 @@ namespace Galaxus.Functional.Linq
                 .Where(predicate)
                 .Select(Option<TSource>.Some)
                 .SingleOrDefault();
+
+        // This probably should be defined publicly together with False and Identity
+        private static bool True<TSource>(TSource _)
+            => true;
     }
 }

--- a/Galaxus.Functional/Linq/OptionLinqExtensions.cs
+++ b/Galaxus.Functional/Linq/OptionLinqExtensions.cs
@@ -22,10 +22,9 @@ namespace Galaxus.Functional.Linq
         /// </returns>
         /// <exception cref="ArgumentNullException"><c>source</c> is <c>null</c>.</exception>
         public static Option<TSource> ElementAtOrNone<TSource>(this IEnumerable<TSource> source, int index)
-        {
-            var value = source.ToList();
-            return index >= value.Count || index < 0 ? Option<TSource>.None : Option<TSource>.Some(value[index]);
-        }
+            => source
+                .Select(Option<TSource>.Some)
+                .ElementAtOrDefault(index);
 
         /// <summary>
         ///     Returns the first element of the sequence that satisfies a condition or <see cref="Option{T}.None" /> if the
@@ -37,10 +36,7 @@ namespace Galaxus.Functional.Linq
         ///     <c><see cref="Option{T}" />.None</c> if <c>source</c> is empty; otherwise, the first element in <c>source</c>.
         /// </returns>
         public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source)
-        {
-            var value = source.ToList();
-            return value.Count == 0 ? Option<TSource>.None : Option<TSource>.Some(value[0]);
-        }
+            => source.FirstOrNone(_ => true);
 
         /// <summary>
         ///     Returns the first element of the sequence that satisfies a condition or <see cref="Option{T}.None" /> if the
@@ -56,8 +52,15 @@ namespace Galaxus.Functional.Linq
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
         public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            var value = source.Where(predicate).ToList();
-            return value.Count == 0 ? Option<TSource>.None : Option<TSource>.Some(value[0]);
+            foreach (var element in source)
+            {
+                if (predicate(element))
+                {
+                    return Option<TSource>.Some(element);
+                }
+            }
+
+            return Option<TSource>.None;
         }
 
         /// <summary>
@@ -71,10 +74,7 @@ namespace Galaxus.Functional.Linq
         /// </returns>
         /// <exception cref="ArgumentNullException"><c>source</c> is <c>null</c>.</exception>
         public static Option<TSource> LastOrNone<TSource>(this IEnumerable<TSource> source)
-        {
-            var value = source.ToList();
-            return value.Count == 0 ? Option<TSource>.None : Option<TSource>.Some(value[value.Count - 1]);
-        }
+            => source.LastOrNone(_ => true);
 
         /// <summary>
         ///     Returns the last element of a sequence that satisfies a condition or <see cref="Option{T}.None" /> if no such
@@ -88,11 +88,12 @@ namespace Galaxus.Functional.Linq
         ///     function; otherwise, the last element that passes the test in the predicate function.
         /// </returns>
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
-        public static Option<TSource> LastOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
-        {
-            var value = source.Where(predicate).ToList();
-            return value.Count == 0 ? Option<TSource>.None : Option<TSource>.Some(value[value.Count - 1]);
-        }
+        public static Option<TSource> LastOrNone<TSource>(this IEnumerable<TSource> source,
+            Func<TSource, bool> predicate)
+            => source
+                .Where(predicate)
+                .Select(Option<TSource>.Some)
+                .LastOrDefault();
 
         /// <summary>
         ///     Returns the only element of a sequence, or <see cref="Option{T}.None" /> if the sequence is empty; this method
@@ -110,16 +111,7 @@ namespace Galaxus.Functional.Linq
         /// <exception cref="ArgumentNullException"><c>source</c> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException">The input sequence contains more than one element.</exception>
         public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source)
-        {
-            var value = source.ToList();
-            if (value.Count == 0)
-                return Option<TSource>.None;
-
-            if (value.Count > 1)
-                throw new InvalidOperationException("Sequence contains more than one element");
-
-            return Option<TSource>.Some(value[0]);
-        }
+            => source.SingleOrNone(_ => true);
 
         /// <summary>
         ///     Returns the only element of a sequence that satisfies a specified condition or <see cref="Option{T}.None" /> if no
@@ -131,16 +123,11 @@ namespace Galaxus.Functional.Linq
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException">More than one element satisfies the condition in <c>source</c>.</exception>
-        public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
-        {
-            var value = source.Where(predicate).ToList();
-            if (value.Count == 0)
-                return Option<TSource>.None;
-
-            if (value.Count > 1)
-                throw new InvalidOperationException("Sequence contains more than one element");
-
-            return Option<TSource>.Some(value[0]);
-        }
+        public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source,
+            Func<TSource, bool> predicate)
+            => source
+                .Where(predicate)
+                .Select(Option<TSource>.Some)
+                .SingleOrDefault();
     }
 }

--- a/Galaxus.Functional/Linq/OptionLinqExtensions.cs
+++ b/Galaxus.Functional/Linq/OptionLinqExtensions.cs
@@ -51,17 +51,10 @@ namespace Galaxus.Functional.Linq
         /// </returns>
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
         public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
-        {
-            foreach (var element in source)
-            {
-                if (predicate(element))
-                {
-                    return Option<TSource>.Some(element);
-                }
-            }
-
-            return Option<TSource>.None;
-        }
+            => source
+                .Where(predicate)
+                .Select(Option<TSource>.Some)
+                .FirstOrDefault();
 
         /// <summary>
         ///     Returns the last element of a sequence, or <see cref="Option{T}.None" /> if the sequence contains no elements.


### PR DESCRIPTION
`FirstOrNone` is an optimized version, otherwise we use the underlying Linq implementations