### PR TITLE
.editorconfig for Code Style and no more XMLDoc warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ insert_final_newline = true
 [*.cs]
 max_line_length = 150
 
-# New line preferences
+# Whitespace rules; newline, space and indents
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
@@ -20,97 +20,6 @@ csharp_new_line_before_members_in_object_initializers = false
 csharp_new_line_before_members_in_anonymous_types = false
 csharp_new_line_between_query_expression_clauses = true
 
-# Indentation preferences
-csharp_indent_block_contents = true
-csharp_indent_braces = false
-csharp_indent_case_contents = true
-csharp_indent_case_contents_when_block = true
-csharp_indent_switch_labels = true
-csharp_indent_labels = one_less_than_current
-
-# Modifier preferences
-csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async:suggestion
-
-# avoid this. unless absolutely necessary
-dotnet_style_qualification_for_field = false:suggestion
-dotnet_style_qualification_for_property = false:suggestion
-dotnet_style_qualification_for_method = false:suggestion
-dotnet_style_qualification_for_event = false:suggestion
-
-# Types: use keywords instead of BCL types, and permit var only when the type is clear
-csharp_style_var_for_built_in_types = true:suggestion
-csharp_style_var_when_type_is_apparent = true:none
-csharp_style_var_elsewhere = true:suggestion
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = true:suggestion
-
-# name all constant fields using PascalCase
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
-dotnet_naming_symbols.constant_fields.applicable_kinds = field
-dotnet_naming_symbols.constant_fields.required_modifiers = const
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
-
-# internal and private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
-dotnet_naming_rule.camel_case_for_private_internal_fields.symbols = private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
-dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
-dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
-dotnet_naming_style.camel_case_underscore_style.required_prefix = _
-dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
-
-# Code style defaults
-csharp_using_directive_placement = outside_namespace:suggestion
-dotnet_sort_system_directives_first = true
-csharp_prefer_braces = true:silent
-csharp_preserve_single_line_blocks = true:none
-csharp_preserve_single_line_statements = false:none
-csharp_prefer_static_local_function = true:suggestion
-csharp_prefer_simple_using_statement = false:none
-csharp_style_prefer_switch_expression = true:suggestion
-dotnet_style_readonly_field = true:suggestion
-
-# Expression-level preferences
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_style_prefer_conditional_expression_over_return = true:silent
-csharp_prefer_simple_default_expression = true:suggestion
-
-# Expression-bodied members
-csharp_style_expression_bodied_methods = false:silent
-csharp_style_expression_bodied_constructors = false:silent
-csharp_style_expression_bodied_operators = true:silent
-csharp_style_expression_bodied_properties = true:silent
-csharp_style_expression_bodied_indexers = true:silent
-csharp_style_expression_bodied_accessors = true:silent
-csharp_style_expression_bodied_lambdas = true:silent
-csharp_style_expression_bodied_local_functions = true:silent
-
-# Pattern matching
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-
-# Null checking preferences
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
-
-# Other features
-csharp_style_prefer_index_operator = false:none
-csharp_style_prefer_range_operator = false:none
-csharp_style_pattern_local_over_anonymous_function = false:none
-
-# Space preferences
 csharp_space_after_cast = false
 csharp_space_after_colon_in_inheritance_clause = true
 csharp_space_after_comma = true
@@ -118,7 +27,7 @@ csharp_space_after_dot = false
 csharp_space_after_keywords_in_control_flow_statements = true
 csharp_space_after_semicolon_in_for_statement = true
 csharp_space_around_binary_operators = before_and_after
-csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_around_declaration_statements = false
 csharp_space_before_colon_in_inheritance_clause = true
 csharp_space_before_comma = false
 csharp_space_before_dot = false
@@ -133,3 +42,107 @@ csharp_space_between_method_declaration_name_and_open_parenthesis = false
 csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
+
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# Use var where possible, use keywords instead of types (e.g. string instead of String)
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:none
+csharp_style_var_elsewhere = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Other styling rules
+csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async:suggestion
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:suggestion
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:suggestion
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
+dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary:suggestion
+
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = true:silent
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+csharp_style_prefer_switch_expression = true:suggestion
+dotnet_style_readonly_field = true:suggestion
+
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+csharp_prefer_simple_default_expression = true:suggestion
+
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = true:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = true:silent
+
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# Naming Style - Constant fields should be PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# Naming Style - Private / Internal fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+
+# Naming Style - Interfaces must be IPascalCase
+dotnet_naming_rule.interface_types_must_be_prefixed_with_i.severity = warning
+dotnet_naming_rule.interface_types_must_be_prefixed_with_i.style = prefix_interface_interface_with_i
+dotnet_naming_rule.interface_types_must_be_prefixed_with_i.symbols = interface_types
+dotnet_naming_rule.interfaces_rule.severity = warning
+dotnet_naming_rule.interfaces_rule.style = i_upper_camel_case_style
+dotnet_naming_rule.interfaces_rule.symbols = interfaces_symbols
+dotnet_naming_style.prefix_interface_interface_with_i.capitalization = pascal_case
+dotnet_naming_style.prefix_interface_interface_with_i.required_prefix = I
+dotnet_naming_style.i_upper_camel_case_style.capitalization = pascal_case
+dotnet_naming_style.i_upper_camel_case_style.required_prefix = I
+dotnet_naming_symbols.interface_types.applicable_kinds = interface
+dotnet_naming_symbols.interfaces_symbols.applicable_accessibilities = *
+dotnet_naming_symbols.interfaces_symbols.applicable_kinds = interface

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
+max_line_length = 120

--- a/.editorconfig
+++ b/.editorconfig
@@ -57,6 +57,13 @@ csharp_style_var_elsewhere = true:suggestion
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
 
+# Argument style
+csharp_arguments_literal = positional
+csharp_arguments_string_literal = positional
+csharp_arguments_named = positional
+csharp_arguments_anonymous_function = positional
+csharp_arguments_other = positional
+
 # Other styling rules
 csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async:suggestion
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,4 +9,127 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.cs]
-max_line_length = 120
+max_line_length = 150
+
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = false
+csharp_new_line_before_members_in_anonymous_types = false
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# Modifier preferences
+csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async:suggestion
+
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Types: use keywords instead of BCL types, and permit var only when the type is clear
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:none
+csharp_style_var_elsewhere = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+
+# Code style defaults
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = true:silent
+csharp_preserve_single_line_blocks = true:none
+csharp_preserve_single_line_statements = false:none
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+csharp_style_prefer_switch_expression = true:suggestion
+dotnet_style_readonly_field = true:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+csharp_prefer_simple_default_expression = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = true:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = true:silent
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,4 +1,4 @@
-name: Run Tests 
+name: Run Tests
 
 on:
   push:
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.*
+        dotnet-version: 6.0.*
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/Galaxus.Functional.Tests/(Either)/EitherExtensionTests.cs
+++ b/Galaxus.Functional.Tests/(Either)/EitherExtensionTests.cs
@@ -2,76 +2,75 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests
+namespace Galaxus.Functional.Tests;
+
+[TestFixture]
+public class EitherExtensionTests
 {
-    [TestFixture]
-    public class EitherExtensionTests
+    [Test]
+    public void SelectASelectBAreEvaluatedCorrectly()
     {
-        [Test]
-        public void SelectASelectBAreEvaluatedCorrectly()
+        var eithers = new List<Either<string, int>>
         {
-            var eithers = new List<Either<string, int>>
-            {
-                new Either<string, int>(1),
-                new Either<string, int>("Hello"),
-                new Either<string, int>(2),
-                new Either<string, int>("World")
-            };
+            new Either<string, int>(1),
+            new Either<string, int>("Hello"),
+            new Either<string, int>(2),
+            new Either<string, int>("World")
+        };
 
-            var aEntries = eithers.SelectA().ToList();
-            var bEntries = eithers.SelectB().ToList();
+        var aEntries = eithers.SelectA().ToList();
+        var bEntries = eithers.SelectB().ToList();
 
-            CollectionAssert.AreEqual(new List<string> { "Hello", "World" }, actual: aEntries);
-            CollectionAssert.AreEqual(new List<int> { 1, 2 }, actual: bEntries);
-        }
+        CollectionAssert.AreEqual(new List<string> { "Hello", "World" }, aEntries);
+        CollectionAssert.AreEqual(new List<int> { 1, 2 }, bEntries);
+    }
 
-        [Test]
-        public void SelectASelectBSelectCAreEvaluatedCorrectly()
+    [Test]
+    public void SelectASelectBSelectCAreEvaluatedCorrectly()
+    {
+        var eithers = new List<Either<string, int, bool>>
         {
-            var eithers = new List<Either<string, int, bool>>
-            {
-                new Either<string, int, bool>(1),
-                new Either<string, int, bool>("Hello"),
-                new Either<string, int, bool>(true),
-                new Either<string, int, bool>(2),
-                new Either<string, int, bool>("World")
-            };
+            new Either<string, int, bool>(1),
+            new Either<string, int, bool>("Hello"),
+            new Either<string, int, bool>(true),
+            new Either<string, int, bool>(2),
+            new Either<string, int, bool>("World")
+        };
 
-            var aEntries = eithers.SelectA().ToList();
-            var bEntries = eithers.SelectB().ToList();
-            var cEntries = eithers.SelectC().ToList();
+        var aEntries = eithers.SelectA().ToList();
+        var bEntries = eithers.SelectB().ToList();
+        var cEntries = eithers.SelectC().ToList();
 
-            CollectionAssert.AreEqual(new List<string> { "Hello", "World" }, actual: aEntries);
-            CollectionAssert.AreEqual(new List<int> { 1, 2 }, actual: bEntries);
-            CollectionAssert.AreEqual(new List<bool> { true }, actual: cEntries);
-        }
+        CollectionAssert.AreEqual(new List<string> { "Hello", "World" }, aEntries);
+        CollectionAssert.AreEqual(new List<int> { 1, 2 }, bEntries);
+        CollectionAssert.AreEqual(new List<bool> { true }, cEntries);
+    }
 
-        [Test]
-        public void ToEither_Some_ReturnsOptionValue()
-        {
-            // Arrange
-            var expectedResult = 1;
-            var option = expectedResult.ToOption();
+    [Test]
+    public void ToEither_Some_ReturnsOptionValue()
+    {
+        // Arrange
+        var expectedResult = 1;
+        var option = expectedResult.ToOption();
 
-            // Act
-            var result = option.ToEither("default");
+        // Act
+        var result = option.ToEither("default");
 
-            // Assert
-            Assert.That(result.Equals(other: expectedResult));
-        }
+        // Assert
+        Assert.That(result.Equals(expectedResult));
+    }
 
-        [Test]
-        public void ToEither_None_ReturnsFallback()
-        {
-            // Arrange
-            var expectedResult = "default";
-            var option = Option<int>.None;
+    [Test]
+    public void ToEither_None_ReturnsFallback()
+    {
+        // Arrange
+        var expectedResult = "default";
+        var option = Option<int>.None;
 
-            // Act
-            var result = option.ToEither(fallback: expectedResult);
+        // Act
+        var result = option.ToEither(expectedResult);
 
-            // Assert
-            Assert.That(result.Equals(other: expectedResult));
-        }
+        // Assert
+        Assert.That(result.Equals(expectedResult));
     }
 }

--- a/Galaxus.Functional.Tests/(Either)/EitherExtensionTests.cs
+++ b/Galaxus.Functional.Tests/(Either)/EitherExtensionTests.cs
@@ -21,8 +21,8 @@ namespace Galaxus.Functional.Tests
             var aEntries = eithers.SelectA().ToList();
             var bEntries = eithers.SelectB().ToList();
 
-            CollectionAssert.AreEqual(new List<string> { "Hello", "World" }, aEntries);
-            CollectionAssert.AreEqual(new List<int> { 1, 2 }, bEntries);
+            CollectionAssert.AreEqual(new List<string> { "Hello", "World" }, actual: aEntries);
+            CollectionAssert.AreEqual(new List<int> { 1, 2 }, actual: bEntries);
         }
 
         [Test]
@@ -41,9 +41,9 @@ namespace Galaxus.Functional.Tests
             var bEntries = eithers.SelectB().ToList();
             var cEntries = eithers.SelectC().ToList();
 
-            CollectionAssert.AreEqual(new List<string> { "Hello", "World" }, aEntries);
-            CollectionAssert.AreEqual(new List<int> { 1, 2 }, bEntries);
-            CollectionAssert.AreEqual(new List<bool> { true }, cEntries);
+            CollectionAssert.AreEqual(new List<string> { "Hello", "World" }, actual: aEntries);
+            CollectionAssert.AreEqual(new List<int> { 1, 2 }, actual: bEntries);
+            CollectionAssert.AreEqual(new List<bool> { true }, actual: cEntries);
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace Galaxus.Functional.Tests
             var result = option.ToEither("default");
 
             // Assert
-            Assert.That(result.Equals(expectedResult));
+            Assert.That(result.Equals(other: expectedResult));
         }
 
         [Test]
@@ -68,10 +68,10 @@ namespace Galaxus.Functional.Tests
             var option = Option<int>.None;
 
             // Act
-            var result = option.ToEither(expectedResult);
+            var result = option.ToEither(fallback: expectedResult);
 
             // Assert
-            Assert.That(result.Equals(expectedResult));
+            Assert.That(result.Equals(other: expectedResult));
         }
     }
 }

--- a/Galaxus.Functional.Tests/(Either)/EitherTests.cs
+++ b/Galaxus.Functional.Tests/(Either)/EitherTests.cs
@@ -1,9 +1,9 @@
-using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
+using NUnit.Framework;
 
 namespace Galaxus.Functional.Tests
 {
@@ -11,10 +11,11 @@ namespace Galaxus.Functional.Tests
     public class EitherTests
     {
         [Test]
-        [SuppressMessage("ReSharper", "ObjectCreationAsStatement", Justification = "The 'new' throws anyways - at least it should")]
+        [SuppressMessage("ReSharper", "ObjectCreationAsStatement",
+            Justification = "The 'new' throws anyways - at least it should")]
         public void CtorThrowsWhenNull()
         {
-            Assert.Throws<ArgumentNullException>(() => new Either<string, object>(default(string)));
+            Assert.Throws<ArgumentNullException>(() => new Either<string, object>(default));
             Assert.Throws<ArgumentNullException>(() => new Either<string, object>(default(object)));
         }
 
@@ -24,8 +25,8 @@ namespace Galaxus.Functional.Tests
             var union1 = new Either<string, int>(117);
             var union2 = new Either<string, int>(666);
             var union3 = new Either<string, int>(117);
-            Assert.AreNotEqual(union1, union2);
-            Assert.AreEqual(union1, union3);
+            Assert.AreNotEqual(expected: union1, actual: union2);
+            Assert.AreEqual(expected: union1, actual: union3);
             Assert.AreNotEqual(union1.GetHashCode(), union2.GetHashCode());
             Assert.AreEqual(union1.GetHashCode(), union3.GetHashCode());
         }
@@ -36,8 +37,8 @@ namespace Galaxus.Functional.Tests
             var union1 = new Either<string, int>("hello");
             var union2 = new Either<string, int>("bye");
             var union3 = new Either<string, int>("hello");
-            Assert.AreNotEqual(union1, union2);
-            Assert.AreEqual(union1, union3);
+            Assert.AreNotEqual(expected: union1, actual: union2);
+            Assert.AreEqual(expected: union1, actual: union3);
             Assert.AreNotEqual(union1.GetHashCode(), union2.GetHashCode());
             Assert.AreEqual(union1.GetHashCode(), union3.GetHashCode());
         }
@@ -47,30 +48,30 @@ namespace Galaxus.Functional.Tests
         {
             var union1 = new Either<string, int>(117);
             var union2 = new Either<string, int>("hello");
-            Assert.AreNotEqual(union1, union2);
+            Assert.AreNotEqual(expected: union1, actual: union2);
             Assert.AreNotEqual(union1.GetHashCode(), union2.GetHashCode());
         }
 
         [Test]
         public void UnionEqualityWithMixedValueTypeVariantsBothZero()
         {
-            var union1 = new Either<byte, int>(default(byte));
+            var union1 = new Either<byte, int>(default);
             var union2 = new Either<byte, int>(default(int));
-            Assert.AreNotEqual(union1, union2);
+            Assert.AreNotEqual(expected: union1, actual: union2);
         }
-        
+
         [Test]
         public void IsAIsBAreEvaluatedCorrectly()
         {
             var someA = new Either<string, int>("hello");
             var someB = new Either<string, int>(117);
 
-            Assert.IsTrue(someA.IsA);
-            Assert.IsFalse(someA.IsB);
-            Assert.IsFalse(someB.IsA);
-            Assert.IsTrue(someB.IsB);
+            Assert.IsTrue(condition: someA.IsA);
+            Assert.IsFalse(condition: someA.IsB);
+            Assert.IsFalse(condition: someB.IsA);
+            Assert.IsTrue(condition: someB.IsB);
         }
-        
+
         [Test]
         public void IsAIsBIsCAreEvaluatedCorrectly()
         {
@@ -78,103 +79,103 @@ namespace Galaxus.Functional.Tests
             var someB = new Either<string, int, bool>(117);
             var someC = new Either<string, int, bool>(true);
 
-            Assert.IsTrue(someA.IsA);
-            Assert.IsFalse(someA.IsB);
-            Assert.IsFalse(someA.IsC);
-            Assert.IsFalse(someB.IsA);
-            Assert.IsTrue(someB.IsB);
-            Assert.IsFalse(someB.IsC);
-            Assert.IsFalse(someC.IsA);
-            Assert.IsFalse(someC.IsB);
-            Assert.IsTrue(someC.IsC);
+            Assert.IsTrue(condition: someA.IsA);
+            Assert.IsFalse(condition: someA.IsB);
+            Assert.IsFalse(condition: someA.IsC);
+            Assert.IsFalse(condition: someB.IsA);
+            Assert.IsTrue(condition: someB.IsB);
+            Assert.IsFalse(condition: someB.IsC);
+            Assert.IsFalse(condition: someC.IsA);
+            Assert.IsFalse(condition: someC.IsB);
+            Assert.IsTrue(condition: someC.IsC);
         }
 
         [Test]
         public async Task Either2MatchAsyncForAReturnsA()
         {
-            Func<string, Task<string>> continuationA = async s => await Task.FromResult(s);
-            Func<bool, Task<string>> continuationB = async _ =>  await Task.FromResult("B");
+            Func<string, Task<string>> continuationA = async s => await Task.FromResult(result: s);
+            Func<bool, Task<string>> continuationB = async _ => await Task.FromResult("B");
 
             var someA = new Either<string, bool>("A");
 
             var result = await someA.MatchAsync(
-                async a => await continuationA(a),
-                async b => await continuationB(b));
+                async a => await continuationA(arg: a),
+                async b => await continuationB(arg: b));
 
-            Assert.That(result, Is.EqualTo("A"));
+            Assert.That(actual: result, Is.EqualTo("A"));
         }
 
         [Test]
         public async Task Either2MatchAsyncForBReturnsB()
         {
             Func<bool, Task<string>> continuationA = async _ => await Task.FromResult("A");
-            Func<string, Task<string>> continuationB = async s =>  await Task.FromResult(s);
+            Func<string, Task<string>> continuationB = async s => await Task.FromResult(result: s);
 
             var someB = new Either<bool, string>("B");
 
             var result = await someB.MatchAsync(
-                async a => await continuationA(a),
-                async b => await continuationB(b));
+                async a => await continuationA(arg: a),
+                async b => await continuationB(arg: b));
 
-            Assert.That(result, Is.EqualTo("B"));
+            Assert.That(actual: result, Is.EqualTo("B"));
         }
 
         [Test]
         public async Task Either3MatchAsyncForAReturnsA()
         {
-            Func<string, Task<string>> continuationA = async s => await Task.FromResult(s);
-            Func<bool, Task<string>> continuationB = async _ =>  await Task.FromResult("B");
-            Func<int, Task<string>> continuationC = async _ =>  await Task.FromResult("C");
+            Func<string, Task<string>> continuationA = async s => await Task.FromResult(result: s);
+            Func<bool, Task<string>> continuationB = async _ => await Task.FromResult("B");
+            Func<int, Task<string>> continuationC = async _ => await Task.FromResult("C");
 
             var someA = new Either<string, bool, int>("A");
 
             var result = await someA.MatchAsync(
-                async a => await continuationA(a),
-                async b => await continuationB(b),
-                async c => await continuationC(c));
+                async a => await continuationA(arg: a),
+                async b => await continuationB(arg: b),
+                async c => await continuationC(arg: c));
 
-            Assert.That(result, Is.EqualTo("A"));
+            Assert.That(actual: result, Is.EqualTo("A"));
         }
 
         [Test]
         public async Task Either3MatchAsyncForBReturnsB()
         {
             Func<bool, Task<string>> continuationA = async _ => await Task.FromResult("A");
-            Func<string, Task<string>> continuationB = async s =>  await Task.FromResult(s);
-            Func<int, Task<string>> continuationC = async _ =>  await Task.FromResult("C");
+            Func<string, Task<string>> continuationB = async s => await Task.FromResult(result: s);
+            Func<int, Task<string>> continuationC = async _ => await Task.FromResult("C");
 
             var someB = new Either<bool, string, int>("B");
 
             var result = await someB.MatchAsync(
-                async a => await continuationA(a),
-                async b => await continuationB(b),
-                async c => await continuationC(c));
+                async a => await continuationA(arg: a),
+                async b => await continuationB(arg: b),
+                async c => await continuationC(arg: c));
 
-            Assert.That(result, Is.EqualTo("B"));
+            Assert.That(actual: result, Is.EqualTo("B"));
         }
 
         [Test]
         public async Task Either3MatchAsyncForCReturnsC()
         {
             Func<bool, Task<string>> continuationA = async _ => await Task.FromResult("A");
-            Func<int, Task<string>> continuationB = async _ =>  await Task.FromResult("B");
-            Func<string, Task<string>> continuationC = async s =>  await Task.FromResult(s);
+            Func<int, Task<string>> continuationB = async _ => await Task.FromResult("B");
+            Func<string, Task<string>> continuationC = async s => await Task.FromResult(result: s);
 
             var someC = new Either<bool, int, string>("C");
 
             var result = await someC.MatchAsync(
-                async a => await continuationA(a),
-                async b => await continuationB(b),
-                async c => await continuationC(c));
+                async a => await continuationA(arg: a),
+                async b => await continuationB(arg: b),
+                async c => await continuationC(arg: c));
 
-            Assert.That(result, Is.EqualTo("C"));
+            Assert.That(actual: result, Is.EqualTo("C"));
         }
 
         [Test]
         [TestCaseSource(nameof(IEitherReturnsCorrectTypeTestCases))]
         public void IEitherReturnsCorrectType(IEither givenInterface, Type expectedType)
         {
-            Assert.AreEqual(expectedType, givenInterface.ToObject().GetType());
+            Assert.AreEqual(expected: expectedType, givenInterface.ToObject().GetType());
         }
 
         [Test]
@@ -183,21 +184,21 @@ namespace Galaxus.Functional.Tests
         [TestCase(default(byte))]
         public void ToStringDelegates<T>(T arg)
         {
-            var eitherLeft = new Either<T, Unit>(arg);
+            var eitherLeft = new Either<T, Unit>(a: arg);
             var toStringLeftResult = eitherLeft.ToString();
-            Assert.IsNotNull(toStringLeftResult);
-            Assert.AreEqual(arg.ToString(), toStringLeftResult);
+            Assert.IsNotNull(anObject: toStringLeftResult);
+            Assert.AreEqual(arg.ToString(), actual: toStringLeftResult);
 
-            var eitherRight = new Either<Unit, T>(arg);
+            var eitherRight = new Either<Unit, T>(b: arg);
             var toStringRightResult = eitherRight.ToString();
-            Assert.IsNotNull(toStringRightResult);
-            Assert.AreEqual(arg.ToString(), toStringRightResult);
+            Assert.IsNotNull(anObject: toStringRightResult);
+            Assert.AreEqual(arg.ToString(), actual: toStringRightResult);
         }
 
         private static IEnumerable<object[]> IEitherReturnsCorrectTypeTestCases()
         {
             return IEitherReturnsCorrectTypeTestCasesExplicit()
-                .Select(testObj => new object[] {testObj.GivenInterface, testObj.ExpectedType});
+                .Select(testObj => new object[] { testObj.GivenInterface, testObj.ExpectedType });
         }
 
         private static IEnumerable<(IEither GivenInterface, Type ExpectedType)>
@@ -214,13 +215,13 @@ namespace Galaxus.Functional.Tests
         [TestCaseSource(nameof(IEitherReturnsCorrectObjectTestCases))]
         public void IEitherReturnsCorrectObject(IEither givenInterface, object expectedObject)
         {
-            Assert.AreEqual(expectedObject, givenInterface.ToObject());
+            Assert.AreEqual(expected: expectedObject, givenInterface.ToObject());
         }
 
         private static IEnumerable<object[]> IEitherReturnsCorrectObjectTestCases()
         {
             return IEitherReturnsCorrectObjectTestCasesExplicit()
-                .Select(testObj => new [] {testObj.GivenInterface, testObj.ExpectedObject});
+                .Select(testObj => new[] { testObj.GivenInterface, testObj.ExpectedObject });
         }
 
         private static IEnumerable<(IEither GivenInterface, object ExpectedObject)>

--- a/Galaxus.Functional.Tests/(Either)/EitherTests.cs
+++ b/Galaxus.Functional.Tests/(Either)/EitherTests.cs
@@ -5,232 +5,231 @@ using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests
+namespace Galaxus.Functional.Tests;
+
+[TestFixture]
+public class EitherTests
 {
-    [TestFixture]
-    public class EitherTests
+    [Test]
+    [SuppressMessage("ReSharper", "ObjectCreationAsStatement", Justification = "The 'new' throws anyways - at least it should")]
+    public void CtorThrowsWhenNull()
     {
-        [Test]
-        [SuppressMessage("ReSharper", "ObjectCreationAsStatement", Justification = "The 'new' throws anyways - at least it should")]
-        public void CtorThrowsWhenNull()
-        {
-            Assert.Throws<ArgumentNullException>(() => new Either<string, object>(default));
-            Assert.Throws<ArgumentNullException>(() => new Either<string, object>(default(object)));
-        }
+        Assert.Throws<ArgumentNullException>(() => new Either<string, object>(default));
+        Assert.Throws<ArgumentNullException>(() => new Either<string, object>(default(object)));
+    }
 
-        [Test]
-        public void UnionEqualityAndHashCodeWithValueTypeVariant()
-        {
-            var union1 = new Either<string, int>(117);
-            var union2 = new Either<string, int>(666);
-            var union3 = new Either<string, int>(117);
-            Assert.AreNotEqual(expected: union1, actual: union2);
-            Assert.AreEqual(expected: union1, actual: union3);
-            Assert.AreNotEqual(union1.GetHashCode(), union2.GetHashCode());
-            Assert.AreEqual(union1.GetHashCode(), union3.GetHashCode());
-        }
+    [Test]
+    public void UnionEqualityAndHashCodeWithValueTypeVariant()
+    {
+        var union1 = new Either<string, int>(117);
+        var union2 = new Either<string, int>(666);
+        var union3 = new Either<string, int>(117);
+        Assert.AreNotEqual(union1, union2);
+        Assert.AreEqual(union1, union3);
+        Assert.AreNotEqual(union1.GetHashCode(), union2.GetHashCode());
+        Assert.AreEqual(union1.GetHashCode(), union3.GetHashCode());
+    }
 
-        [Test]
-        public void UnionEqualityAndHashCodeWithReferenceTypeVariant()
-        {
-            var union1 = new Either<string, int>("hello");
-            var union2 = new Either<string, int>("bye");
-            var union3 = new Either<string, int>("hello");
-            Assert.AreNotEqual(expected: union1, actual: union2);
-            Assert.AreEqual(expected: union1, actual: union3);
-            Assert.AreNotEqual(union1.GetHashCode(), union2.GetHashCode());
-            Assert.AreEqual(union1.GetHashCode(), union3.GetHashCode());
-        }
+    [Test]
+    public void UnionEqualityAndHashCodeWithReferenceTypeVariant()
+    {
+        var union1 = new Either<string, int>("hello");
+        var union2 = new Either<string, int>("bye");
+        var union3 = new Either<string, int>("hello");
+        Assert.AreNotEqual(union1, union2);
+        Assert.AreEqual(union1, union3);
+        Assert.AreNotEqual(union1.GetHashCode(), union2.GetHashCode());
+        Assert.AreEqual(union1.GetHashCode(), union3.GetHashCode());
+    }
 
-        [Test]
-        public void UnionEqualityAndHashCodeWithMixedTypeVariants()
-        {
-            var union1 = new Either<string, int>(117);
-            var union2 = new Either<string, int>("hello");
-            Assert.AreNotEqual(expected: union1, actual: union2);
-            Assert.AreNotEqual(union1.GetHashCode(), union2.GetHashCode());
-        }
+    [Test]
+    public void UnionEqualityAndHashCodeWithMixedTypeVariants()
+    {
+        var union1 = new Either<string, int>(117);
+        var union2 = new Either<string, int>("hello");
+        Assert.AreNotEqual(union1, union2);
+        Assert.AreNotEqual(union1.GetHashCode(), union2.GetHashCode());
+    }
 
-        [Test]
-        public void UnionEqualityWithMixedValueTypeVariantsBothZero()
-        {
-            var union1 = new Either<byte, int>(default);
-            var union2 = new Either<byte, int>(default(int));
-            Assert.AreNotEqual(expected: union1, actual: union2);
-        }
+    [Test]
+    public void UnionEqualityWithMixedValueTypeVariantsBothZero()
+    {
+        var union1 = new Either<byte, int>(default);
+        var union2 = new Either<byte, int>(default(int));
+        Assert.AreNotEqual(union1, union2);
+    }
 
-        [Test]
-        public void IsAIsBAreEvaluatedCorrectly()
-        {
-            var someA = new Either<string, int>("hello");
-            var someB = new Either<string, int>(117);
+    [Test]
+    public void IsAIsBAreEvaluatedCorrectly()
+    {
+        var someA = new Either<string, int>("hello");
+        var someB = new Either<string, int>(117);
 
-            Assert.IsTrue(condition: someA.IsA);
-            Assert.IsFalse(condition: someA.IsB);
-            Assert.IsFalse(condition: someB.IsA);
-            Assert.IsTrue(condition: someB.IsB);
-        }
+        Assert.IsTrue(someA.IsA);
+        Assert.IsFalse(someA.IsB);
+        Assert.IsFalse(someB.IsA);
+        Assert.IsTrue(someB.IsB);
+    }
 
-        [Test]
-        public void IsAIsBIsCAreEvaluatedCorrectly()
-        {
-            var someA = new Either<string, int, bool>("hello");
-            var someB = new Either<string, int, bool>(117);
-            var someC = new Either<string, int, bool>(true);
+    [Test]
+    public void IsAIsBIsCAreEvaluatedCorrectly()
+    {
+        var someA = new Either<string, int, bool>("hello");
+        var someB = new Either<string, int, bool>(117);
+        var someC = new Either<string, int, bool>(true);
 
-            Assert.IsTrue(condition: someA.IsA);
-            Assert.IsFalse(condition: someA.IsB);
-            Assert.IsFalse(condition: someA.IsC);
-            Assert.IsFalse(condition: someB.IsA);
-            Assert.IsTrue(condition: someB.IsB);
-            Assert.IsFalse(condition: someB.IsC);
-            Assert.IsFalse(condition: someC.IsA);
-            Assert.IsFalse(condition: someC.IsB);
-            Assert.IsTrue(condition: someC.IsC);
-        }
+        Assert.IsTrue(someA.IsA);
+        Assert.IsFalse(someA.IsB);
+        Assert.IsFalse(someA.IsC);
+        Assert.IsFalse(someB.IsA);
+        Assert.IsTrue(someB.IsB);
+        Assert.IsFalse(someB.IsC);
+        Assert.IsFalse(someC.IsA);
+        Assert.IsFalse(someC.IsB);
+        Assert.IsTrue(someC.IsC);
+    }
 
-        [Test]
-        public async Task Either2MatchAsyncForAReturnsA()
-        {
-            Func<string, Task<string>> continuationA = async s => await Task.FromResult(result: s);
-            Func<bool, Task<string>> continuationB = async _ => await Task.FromResult("B");
+    [Test]
+    public async Task Either2MatchAsyncForAReturnsA()
+    {
+        Func<string, Task<string>> continuationA = async s => await Task.FromResult(s);
+        Func<bool, Task<string>> continuationB = async _ => await Task.FromResult("B");
 
-            var someA = new Either<string, bool>("A");
+        var someA = new Either<string, bool>("A");
 
-            var result = await someA.MatchAsync(
-                async a => await continuationA(arg: a),
-                async b => await continuationB(arg: b));
+        var result = await someA.MatchAsync(
+            async a => await continuationA(a),
+            async b => await continuationB(b));
 
-            Assert.That(actual: result, Is.EqualTo("A"));
-        }
+        Assert.That(result, Is.EqualTo("A"));
+    }
 
-        [Test]
-        public async Task Either2MatchAsyncForBReturnsB()
-        {
-            Func<bool, Task<string>> continuationA = async _ => await Task.FromResult("A");
-            Func<string, Task<string>> continuationB = async s => await Task.FromResult(result: s);
+    [Test]
+    public async Task Either2MatchAsyncForBReturnsB()
+    {
+        Func<bool, Task<string>> continuationA = async _ => await Task.FromResult("A");
+        Func<string, Task<string>> continuationB = async s => await Task.FromResult(s);
 
-            var someB = new Either<bool, string>("B");
+        var someB = new Either<bool, string>("B");
 
-            var result = await someB.MatchAsync(
-                async a => await continuationA(arg: a),
-                async b => await continuationB(arg: b));
+        var result = await someB.MatchAsync(
+            async a => await continuationA(a),
+            async b => await continuationB(b));
 
-            Assert.That(actual: result, Is.EqualTo("B"));
-        }
+        Assert.That(result, Is.EqualTo("B"));
+    }
 
-        [Test]
-        public async Task Either3MatchAsyncForAReturnsA()
-        {
-            Func<string, Task<string>> continuationA = async s => await Task.FromResult(result: s);
-            Func<bool, Task<string>> continuationB = async _ => await Task.FromResult("B");
-            Func<int, Task<string>> continuationC = async _ => await Task.FromResult("C");
+    [Test]
+    public async Task Either3MatchAsyncForAReturnsA()
+    {
+        Func<string, Task<string>> continuationA = async s => await Task.FromResult(s);
+        Func<bool, Task<string>> continuationB = async _ => await Task.FromResult("B");
+        Func<int, Task<string>> continuationC = async _ => await Task.FromResult("C");
 
-            var someA = new Either<string, bool, int>("A");
+        var someA = new Either<string, bool, int>("A");
 
-            var result = await someA.MatchAsync(
-                async a => await continuationA(arg: a),
-                async b => await continuationB(arg: b),
-                async c => await continuationC(arg: c));
+        var result = await someA.MatchAsync(
+            async a => await continuationA(a),
+            async b => await continuationB(b),
+            async c => await continuationC(c));
 
-            Assert.That(actual: result, Is.EqualTo("A"));
-        }
+        Assert.That(result, Is.EqualTo("A"));
+    }
 
-        [Test]
-        public async Task Either3MatchAsyncForBReturnsB()
-        {
-            Func<bool, Task<string>> continuationA = async _ => await Task.FromResult("A");
-            Func<string, Task<string>> continuationB = async s => await Task.FromResult(result: s);
-            Func<int, Task<string>> continuationC = async _ => await Task.FromResult("C");
+    [Test]
+    public async Task Either3MatchAsyncForBReturnsB()
+    {
+        Func<bool, Task<string>> continuationA = async _ => await Task.FromResult("A");
+        Func<string, Task<string>> continuationB = async s => await Task.FromResult(s);
+        Func<int, Task<string>> continuationC = async _ => await Task.FromResult("C");
 
-            var someB = new Either<bool, string, int>("B");
+        var someB = new Either<bool, string, int>("B");
 
-            var result = await someB.MatchAsync(
-                async a => await continuationA(arg: a),
-                async b => await continuationB(arg: b),
-                async c => await continuationC(arg: c));
+        var result = await someB.MatchAsync(
+            async a => await continuationA(a),
+            async b => await continuationB(b),
+            async c => await continuationC(c));
 
-            Assert.That(actual: result, Is.EqualTo("B"));
-        }
+        Assert.That(result, Is.EqualTo("B"));
+    }
 
-        [Test]
-        public async Task Either3MatchAsyncForCReturnsC()
-        {
-            Func<bool, Task<string>> continuationA = async _ => await Task.FromResult("A");
-            Func<int, Task<string>> continuationB = async _ => await Task.FromResult("B");
-            Func<string, Task<string>> continuationC = async s => await Task.FromResult(result: s);
+    [Test]
+    public async Task Either3MatchAsyncForCReturnsC()
+    {
+        Func<bool, Task<string>> continuationA = async _ => await Task.FromResult("A");
+        Func<int, Task<string>> continuationB = async _ => await Task.FromResult("B");
+        Func<string, Task<string>> continuationC = async s => await Task.FromResult(s);
 
-            var someC = new Either<bool, int, string>("C");
+        var someC = new Either<bool, int, string>("C");
 
-            var result = await someC.MatchAsync(
-                async a => await continuationA(arg: a),
-                async b => await continuationB(arg: b),
-                async c => await continuationC(arg: c));
+        var result = await someC.MatchAsync(
+            async a => await continuationA(a),
+            async b => await continuationB(b),
+            async c => await continuationC(c));
 
-            Assert.That(actual: result, Is.EqualTo("C"));
-        }
+        Assert.That(result, Is.EqualTo("C"));
+    }
 
-        [Test]
-        [TestCaseSource(nameof(IEitherReturnsCorrectTypeTestCases))]
-        public void IEitherReturnsCorrectType(IEither givenInterface, Type expectedType)
-        {
-            Assert.AreEqual(expected: expectedType, givenInterface.ToObject().GetType());
-        }
+    [Test]
+    [TestCaseSource(nameof(IEitherReturnsCorrectTypeTestCases))]
+    public void IEitherReturnsCorrectType(IEither givenInterface, Type expectedType)
+    {
+        Assert.AreEqual(expectedType, givenInterface.ToObject().GetType());
+    }
 
-        [Test]
-        [TestCase(3)]
-        [TestCase("Foo")]
-        [TestCase(default(byte))]
-        public void ToStringDelegates<T>(T arg)
-        {
-            var eitherLeft = new Either<T, Unit>(a: arg);
-            var toStringLeftResult = eitherLeft.ToString();
-            Assert.IsNotNull(anObject: toStringLeftResult);
-            Assert.AreEqual(arg.ToString(), actual: toStringLeftResult);
+    [Test]
+    [TestCase(3)]
+    [TestCase("Foo")]
+    [TestCase(default(byte))]
+    public void ToStringDelegates<T>(T arg)
+    {
+        var eitherLeft = new Either<T, Unit>(arg);
+        var toStringLeftResult = eitherLeft.ToString();
+        Assert.IsNotNull(toStringLeftResult);
+        Assert.AreEqual(arg.ToString(), toStringLeftResult);
 
-            var eitherRight = new Either<Unit, T>(b: arg);
-            var toStringRightResult = eitherRight.ToString();
-            Assert.IsNotNull(anObject: toStringRightResult);
-            Assert.AreEqual(arg.ToString(), actual: toStringRightResult);
-        }
+        var eitherRight = new Either<Unit, T>(arg);
+        var toStringRightResult = eitherRight.ToString();
+        Assert.IsNotNull(toStringRightResult);
+        Assert.AreEqual(arg.ToString(), toStringRightResult);
+    }
 
-        private static IEnumerable<object[]> IEitherReturnsCorrectTypeTestCases()
-        {
-            return IEitherReturnsCorrectTypeTestCasesExplicit()
-                .Select(testObj => new object[] { testObj.GivenInterface, testObj.ExpectedType });
-        }
+    private static IEnumerable<object[]> IEitherReturnsCorrectTypeTestCases()
+    {
+        return IEitherReturnsCorrectTypeTestCasesExplicit()
+            .Select(testObj => new object[] { testObj.GivenInterface, testObj.ExpectedType });
+    }
 
-        private static IEnumerable<(IEither GivenInterface, Type ExpectedType)>
-            IEitherReturnsCorrectTypeTestCasesExplicit()
-        {
-            yield return (new Either<string, char>("hello"), typeof(string));
-            yield return (new Either<string, char>('B'), typeof(char));
-            yield return (new Either<string, char, bool>("World"), typeof(string));
-            yield return (new Either<string, char, bool>('B'), typeof(char));
-            yield return (new Either<string, char, bool>(false), typeof(bool));
-        }
+    private static IEnumerable<(IEither GivenInterface, Type ExpectedType)>
+        IEitherReturnsCorrectTypeTestCasesExplicit()
+    {
+        yield return (new Either<string, char>("hello"), typeof(string));
+        yield return (new Either<string, char>('B'), typeof(char));
+        yield return (new Either<string, char, bool>("World"), typeof(string));
+        yield return (new Either<string, char, bool>('B'), typeof(char));
+        yield return (new Either<string, char, bool>(false), typeof(bool));
+    }
 
-        [Test]
-        [TestCaseSource(nameof(IEitherReturnsCorrectObjectTestCases))]
-        public void IEitherReturnsCorrectObject(IEither givenInterface, object expectedObject)
-        {
-            Assert.AreEqual(expected: expectedObject, givenInterface.ToObject());
-        }
+    [Test]
+    [TestCaseSource(nameof(IEitherReturnsCorrectObjectTestCases))]
+    public void IEitherReturnsCorrectObject(IEither givenInterface, object expectedObject)
+    {
+        Assert.AreEqual(expectedObject, givenInterface.ToObject());
+    }
 
-        private static IEnumerable<object[]> IEitherReturnsCorrectObjectTestCases()
-        {
-            return IEitherReturnsCorrectObjectTestCasesExplicit()
-                .Select(testObj => new[] { testObj.GivenInterface, testObj.ExpectedObject });
-        }
+    private static IEnumerable<object[]> IEitherReturnsCorrectObjectTestCases()
+    {
+        return IEitherReturnsCorrectObjectTestCasesExplicit()
+            .Select(testObj => new[] { testObj.GivenInterface, testObj.ExpectedObject });
+    }
 
-        private static IEnumerable<(IEither GivenInterface, object ExpectedObject)>
-            IEitherReturnsCorrectObjectTestCasesExplicit()
-        {
-            yield return (new Either<string, char>("Digitec"), "Digitec");
-            yield return (new Either<string, char>('X'), 'X');
-            yield return (new Either<string, char, bool>("Galaxus"), "Galaxus");
-            yield return (new Either<string, char, bool>('Y'), 'Y');
-            yield return (new Either<string, char, bool>(true), true);
-        }
+    private static IEnumerable<(IEither GivenInterface, object ExpectedObject)>
+        IEitherReturnsCorrectObjectTestCasesExplicit()
+    {
+        yield return (new Either<string, char>("Digitec"), "Digitec");
+        yield return (new Either<string, char>('X'), 'X');
+        yield return (new Either<string, char, bool>("Galaxus"), "Galaxus");
+        yield return (new Either<string, char, bool>('Y'), 'Y');
+        yield return (new Either<string, char, bool>(true), true);
     }
 }

--- a/Galaxus.Functional.Tests/(Either)/EitherTests.cs
+++ b/Galaxus.Functional.Tests/(Either)/EitherTests.cs
@@ -11,8 +11,7 @@ namespace Galaxus.Functional.Tests
     public class EitherTests
     {
         [Test]
-        [SuppressMessage("ReSharper", "ObjectCreationAsStatement",
-            Justification = "The 'new' throws anyways - at least it should")]
+        [SuppressMessage("ReSharper", "ObjectCreationAsStatement", Justification = "The 'new' throws anyways - at least it should")]
         public void CtorThrowsWhenNull()
         {
             Assert.Throws<ArgumentNullException>(() => new Either<string, object>(default));

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/AutoMapTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/AutoMapTests.cs
@@ -16,7 +16,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public void Map_None_RemainsNone()
         {
-            Assert.IsTrue(Option<string>.None.Map<string, object>().IsNone);
+            Assert.IsTrue(condition: Option<string>.None.Map<string, object>().IsNone);
         }
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/AutoMapTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/AutoMapTests.cs
@@ -1,22 +1,21 @@
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests.OptionExtensions
-{
-    [TestFixture]
-    public class AutoMapTests
-    {
-        [Test]
-        public void Map_Some_InnerValueRemains()
-        {
-            Assert.AreEqual(true, true.ToOption().Map<bool, object>().Unwrap());
-            Assert.AreEqual(false, false.ToOption().Map<bool, object>().Unwrap());
-            Assert.AreEqual("hello", "hello".ToOption().Map<string, object>().Unwrap());
-        }
+namespace Galaxus.Functional.Tests.OptionExtensions;
 
-        [Test]
-        public void Map_None_RemainsNone()
-        {
-            Assert.IsTrue(condition: Option<string>.None.Map<string, object>().IsNone);
-        }
+[TestFixture]
+public class AutoMapTests
+{
+    [Test]
+    public void Map_Some_InnerValueRemains()
+    {
+        Assert.AreEqual(true, true.ToOption().Map<bool, object>().Unwrap());
+        Assert.AreEqual(false, false.ToOption().Map<bool, object>().Unwrap());
+        Assert.AreEqual("hello", "hello".ToOption().Map<string, object>().Unwrap());
+    }
+
+    [Test]
+    public void Map_None_RemainsNone()
+    {
+        Assert.IsTrue(Option<string>.None.Map<string, object>().IsNone);
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/FlattenTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/FlattenTests.cs
@@ -1,84 +1,83 @@
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests.OptionExtensions
+namespace Galaxus.Functional.Tests.OptionExtensions;
+
+[TestFixture]
+public class FlattenTests
 {
-    [TestFixture]
-    public class FlattenTests
+    [Test]
+    public void Flatten_StringWithDepth2()
     {
-        [Test]
-        public void Flatten_StringWithDepth2()
-        {
-            var option2 = "test".ToOption().ToOption();
-            var singleOption = option2.Flatten();
+        var option2 = "test".ToOption().ToOption();
+        var singleOption = option2.Flatten();
 
-            Assert.IsTrue(condition: option2.IsSome);
-            Assert.AreEqual(typeof(Option<Option<string>>), option2.GetType());
-            Assert.AreEqual(typeof(Option<string>), singleOption.GetType());
-            Assert.IsTrue(condition: singleOption.IsSome);
-            Assert.AreEqual("test", singleOption.Unwrap());
-        }
+        Assert.IsTrue(option2.IsSome);
+        Assert.AreEqual(typeof(Option<Option<string>>), option2.GetType());
+        Assert.AreEqual(typeof(Option<string>), singleOption.GetType());
+        Assert.IsTrue(singleOption.IsSome);
+        Assert.AreEqual("test", singleOption.Unwrap());
+    }
 
-        [Test]
-        public void Flatten_IntWithDepth2()
-        {
-            var option2 = 1.ToOption().ToOption();
-            var singleOption = option2.Flatten();
+    [Test]
+    public void Flatten_IntWithDepth2()
+    {
+        var option2 = 1.ToOption().ToOption();
+        var singleOption = option2.Flatten();
 
-            Assert.IsTrue(condition: option2.IsSome);
-            Assert.AreEqual(typeof(Option<Option<int>>), option2.GetType());
-            Assert.AreEqual(typeof(Option<int>), singleOption.GetType());
-            Assert.IsTrue(condition: singleOption.IsSome);
-            Assert.AreEqual(1, singleOption.Unwrap());
-        }
+        Assert.IsTrue(option2.IsSome);
+        Assert.AreEqual(typeof(Option<Option<int>>), option2.GetType());
+        Assert.AreEqual(typeof(Option<int>), singleOption.GetType());
+        Assert.IsTrue(singleOption.IsSome);
+        Assert.AreEqual(1, singleOption.Unwrap());
+    }
 
-        [Test]
-        public void Flatten_NoneWithDepth2()
-        {
-            var option2 = Option<int>.None.ToOption();
-            var singleOption = option2.Flatten();
+    [Test]
+    public void Flatten_NoneWithDepth2()
+    {
+        var option2 = Option<int>.None.ToOption();
+        var singleOption = option2.Flatten();
 
-            Assert.IsTrue(condition: option2.IsSome);
-            Assert.AreEqual(typeof(Option<Option<int>>), option2.GetType());
-            Assert.AreEqual(typeof(Option<int>), singleOption.GetType());
-            Assert.IsTrue(condition: singleOption.IsNone);
-        }
+        Assert.IsTrue(option2.IsSome);
+        Assert.AreEqual(typeof(Option<Option<int>>), option2.GetType());
+        Assert.AreEqual(typeof(Option<int>), singleOption.GetType());
+        Assert.IsTrue(singleOption.IsNone);
+    }
 
-        [Test]
-        public void Flatten_StringWithDepth3()
-        {
-            var option3 = "test".ToOption().ToOption().ToOption();
-            var singleOption = option3.Flatten();
+    [Test]
+    public void Flatten_StringWithDepth3()
+    {
+        var option3 = "test".ToOption().ToOption().ToOption();
+        var singleOption = option3.Flatten();
 
-            Assert.IsTrue(condition: option3.IsSome);
-            Assert.AreEqual(typeof(Option<Option<Option<string>>>), option3.GetType());
-            Assert.AreEqual(typeof(Option<string>), singleOption.GetType());
-            Assert.IsTrue(condition: singleOption.IsSome);
-            Assert.AreEqual("test", singleOption.Unwrap());
-        }
+        Assert.IsTrue(option3.IsSome);
+        Assert.AreEqual(typeof(Option<Option<Option<string>>>), option3.GetType());
+        Assert.AreEqual(typeof(Option<string>), singleOption.GetType());
+        Assert.IsTrue(singleOption.IsSome);
+        Assert.AreEqual("test", singleOption.Unwrap());
+    }
 
-        [Test]
-        public void Flatten_IntWithDepth3()
-        {
-            var option3 = 1.ToOption().ToOption().ToOption();
-            var singleOption = option3.Flatten();
+    [Test]
+    public void Flatten_IntWithDepth3()
+    {
+        var option3 = 1.ToOption().ToOption().ToOption();
+        var singleOption = option3.Flatten();
 
-            Assert.IsTrue(condition: option3.IsSome);
-            Assert.AreEqual(typeof(Option<Option<Option<int>>>), option3.GetType());
-            Assert.AreEqual(typeof(Option<int>), singleOption.GetType());
-            Assert.IsTrue(condition: singleOption.IsSome);
-            Assert.AreEqual(1, singleOption.Unwrap());
-        }
+        Assert.IsTrue(option3.IsSome);
+        Assert.AreEqual(typeof(Option<Option<Option<int>>>), option3.GetType());
+        Assert.AreEqual(typeof(Option<int>), singleOption.GetType());
+        Assert.IsTrue(singleOption.IsSome);
+        Assert.AreEqual(1, singleOption.Unwrap());
+    }
 
-        [Test]
-        public void Flatten_NoneWithDepth3()
-        {
-            var option3 = Option<int>.None.ToOption().ToOption();
-            var singleOption = option3.Flatten();
+    [Test]
+    public void Flatten_NoneWithDepth3()
+    {
+        var option3 = Option<int>.None.ToOption().ToOption();
+        var singleOption = option3.Flatten();
 
-            Assert.IsTrue(condition: option3.IsSome);
-            Assert.AreEqual(typeof(Option<Option<Option<int>>>), option3.GetType());
-            Assert.AreEqual(typeof(Option<int>), singleOption.GetType());
-            Assert.IsTrue(condition: singleOption.IsNone);
-        }
+        Assert.IsTrue(option3.IsSome);
+        Assert.AreEqual(typeof(Option<Option<Option<int>>>), option3.GetType());
+        Assert.AreEqual(typeof(Option<int>), singleOption.GetType());
+        Assert.IsTrue(singleOption.IsNone);
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/FlattenTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/FlattenTests.cs
@@ -11,24 +11,24 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var option2 = "test".ToOption().ToOption();
             var singleOption = option2.Flatten();
 
-            Assert.IsTrue(option2.IsSome);
+            Assert.IsTrue(condition: option2.IsSome);
             Assert.AreEqual(typeof(Option<Option<string>>), option2.GetType());
             Assert.AreEqual(typeof(Option<string>), singleOption.GetType());
-            Assert.IsTrue(singleOption.IsSome);
+            Assert.IsTrue(condition: singleOption.IsSome);
             Assert.AreEqual("test", singleOption.Unwrap());
         }
 
         [Test]
         public void Flatten_IntWithDepth2()
         {
-                var option2 = 1.ToOption().ToOption();
-                var singleOption = option2.Flatten();
+            var option2 = 1.ToOption().ToOption();
+            var singleOption = option2.Flatten();
 
-                Assert.IsTrue(option2.IsSome);
-                Assert.AreEqual(typeof(Option<Option<int>>), option2.GetType());
-                Assert.AreEqual(typeof(Option<int>), singleOption.GetType());
-                Assert.IsTrue(singleOption.IsSome);
-                Assert.AreEqual(1, singleOption.Unwrap());
+            Assert.IsTrue(condition: option2.IsSome);
+            Assert.AreEqual(typeof(Option<Option<int>>), option2.GetType());
+            Assert.AreEqual(typeof(Option<int>), singleOption.GetType());
+            Assert.IsTrue(condition: singleOption.IsSome);
+            Assert.AreEqual(1, singleOption.Unwrap());
         }
 
         [Test]
@@ -37,10 +37,10 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var option2 = Option<int>.None.ToOption();
             var singleOption = option2.Flatten();
 
-            Assert.IsTrue(option2.IsSome);
+            Assert.IsTrue(condition: option2.IsSome);
             Assert.AreEqual(typeof(Option<Option<int>>), option2.GetType());
             Assert.AreEqual(typeof(Option<int>), singleOption.GetType());
-            Assert.IsTrue(singleOption.IsNone);
+            Assert.IsTrue(condition: singleOption.IsNone);
         }
 
         [Test]
@@ -49,10 +49,10 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var option3 = "test".ToOption().ToOption().ToOption();
             var singleOption = option3.Flatten();
 
-            Assert.IsTrue(option3.IsSome);
+            Assert.IsTrue(condition: option3.IsSome);
             Assert.AreEqual(typeof(Option<Option<Option<string>>>), option3.GetType());
             Assert.AreEqual(typeof(Option<string>), singleOption.GetType());
-            Assert.IsTrue(singleOption.IsSome);
+            Assert.IsTrue(condition: singleOption.IsSome);
             Assert.AreEqual("test", singleOption.Unwrap());
         }
 
@@ -62,10 +62,10 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var option3 = 1.ToOption().ToOption().ToOption();
             var singleOption = option3.Flatten();
 
-            Assert.IsTrue(option3.IsSome);
+            Assert.IsTrue(condition: option3.IsSome);
             Assert.AreEqual(typeof(Option<Option<Option<int>>>), option3.GetType());
             Assert.AreEqual(typeof(Option<int>), singleOption.GetType());
-            Assert.IsTrue(singleOption.IsSome);
+            Assert.IsTrue(condition: singleOption.IsSome);
             Assert.AreEqual(1, singleOption.Unwrap());
         }
 
@@ -75,10 +75,10 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var option3 = Option<int>.None.ToOption().ToOption();
             var singleOption = option3.Flatten();
 
-            Assert.IsTrue(option3.IsSome);
+            Assert.IsTrue(condition: option3.IsSome);
             Assert.AreEqual(typeof(Option<Option<Option<int>>>), option3.GetType());
             Assert.AreEqual(typeof(Option<int>), singleOption.GetType());
-            Assert.IsTrue(singleOption.IsNone);
+            Assert.IsTrue(condition: singleOption.IsNone);
         }
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/OptionLinqExtensionsTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/OptionLinqExtensionsTests.cs
@@ -6,244 +6,243 @@ using Galaxus.Functional.Linq;
 using Galaxus.Functional.Tests.Helpers;
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests.OptionExtensions
+namespace Galaxus.Functional.Tests.OptionExtensions;
+
+[TestFixture]
+public class OptionLinqExtensionsTests
 {
-    [TestFixture]
-    public class OptionLinqExtensionsTests
+    [Test]
+    public void ElementAtOrNone_IndexIsZero_ReturnsSome()
     {
-        [Test]
-        public void ElementAtOrNone_IndexIsZero_ReturnsSome()
-        {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+        var list = new List<int> { 0, 1, 2, 3, 4 };
 
-            var some = list.ElementAtOrNone(0);
+        var some = list.ElementAtOrNone(0);
 
-            Assert.IsTrue(condition: some.IsSome);
-            Assert.AreEqual(0, some.Unwrap());
-        }
+        Assert.IsTrue(some.IsSome);
+        Assert.AreEqual(0, some.Unwrap());
+    }
 
-        [Test]
-        public void ElementAtOrNone_IndexIsCount_ReturnsNone()
-        {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+    [Test]
+    public void ElementAtOrNone_IndexIsCount_ReturnsNone()
+    {
+        var list = new List<int> { 0, 1, 2, 3, 4 };
 
-            var none = list.ElementAtOrNone(5);
+        var none = list.ElementAtOrNone(5);
 
-            Assert.IsTrue(condition: none.IsNone);
-        }
+        Assert.IsTrue(none.IsNone);
+    }
 
-        [Test]
-        public void ElementAtOrNone_IndexIsNegativeOne_ReturnsNone()
-        {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+    [Test]
+    public void ElementAtOrNone_IndexIsNegativeOne_ReturnsNone()
+    {
+        var list = new List<int> { 0, 1, 2, 3, 4 };
 
-            var none = list.ElementAtOrNone(-1);
+        var none = list.ElementAtOrNone(-1);
 
-            Assert.IsTrue(condition: none.IsNone);
-        }
+        Assert.IsTrue(none.IsNone);
+    }
 
-        [Test]
-        public void ElementAtOrNone_AppliedToFailingEnumerator_DoesNotThrow()
-        {
-            var index = 5;
-            var sequence = new YieldElementsThenFail<string>("Hello world", index + 1);
+    [Test]
+    public void ElementAtOrNone_AppliedToFailingEnumerator_DoesNotThrow()
+    {
+        var index = 5;
+        var sequence = new YieldElementsThenFail<string>("Hello world", index + 1);
 
-            var composition = sequence.ElementAtOrNone(index: index);
+        var composition = sequence.ElementAtOrNone(index);
 
-            Assert.IsTrue(condition: composition.IsSome);
-            Assert.Throws<AssertionException>(() => sequence.ToList());
-        }
+        Assert.IsTrue(composition.IsSome);
+        Assert.Throws<AssertionException>(() => sequence.ToList());
+    }
 
-        [Test]
-        public void FirstOrNone_NoPredicate_ReturnsSome()
-        {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+    [Test]
+    public void FirstOrNone_NoPredicate_ReturnsSome()
+    {
+        var list = new List<int> { 0, 1, 2, 3, 4 };
 
-            var some = list.FirstOrNone();
+        var some = list.FirstOrNone();
 
-            Assert.IsTrue(condition: some.IsSome);
-            Assert.AreEqual(0, some.Unwrap());
-        }
+        Assert.IsTrue(some.IsSome);
+        Assert.AreEqual(0, some.Unwrap());
+    }
 
-        [Test]
-        public void FirstOrNone_WithPredicate_ReturnsSome()
-        {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
-            var some = list.FirstOrNone(x => x > 2);
+    [Test]
+    public void FirstOrNone_WithPredicate_ReturnsSome()
+    {
+        var list = new List<int> { 0, 1, 2, 3, 4 };
+        var some = list.FirstOrNone(x => x > 2);
 
-            Assert.IsTrue(condition: some.IsSome);
-            Assert.AreEqual(3, some.Unwrap());
-        }
+        Assert.IsTrue(some.IsSome);
+        Assert.AreEqual(3, some.Unwrap());
+    }
 
-        [Test]
-        public void FirstOrNone_PredicateMatchesNone_ReturnsNone()
-        {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+    [Test]
+    public void FirstOrNone_PredicateMatchesNone_ReturnsNone()
+    {
+        var list = new List<int> { 0, 1, 2, 3, 4 };
 
-            var none = list.FirstOrNone(x => x == 10);
+        var none = list.FirstOrNone(x => x == 10);
 
-            Assert.IsTrue(condition: none.IsNone);
-        }
+        Assert.IsTrue(none.IsNone);
+    }
 
-        [Test]
-        public void FirstOrNone_AppliedToFailingEnumerator_DoesNotThrow()
-        {
-            var sequence = new YieldElementsThenFail<string>("Hello world", 1);
+    [Test]
+    public void FirstOrNone_AppliedToFailingEnumerator_DoesNotThrow()
+    {
+        var sequence = new YieldElementsThenFail<string>("Hello world", 1);
 
-            var composition = sequence.FirstOrNone();
+        var composition = sequence.FirstOrNone();
 
-            Assert.IsTrue(condition: composition.IsSome);
-            Assert.Throws<AssertionException>(() => sequence.ToList());
-        }
+        Assert.IsTrue(composition.IsSome);
+        Assert.Throws<AssertionException>(() => sequence.ToList());
+    }
 
-        [Test]
-        public void LastOrNone_GetLast_ReturnsSome()
-        {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+    [Test]
+    public void LastOrNone_GetLast_ReturnsSome()
+    {
+        var list = new List<int> { 0, 1, 2, 3, 4 };
 
-            var some1 = list.LastOrNone();
+        var some1 = list.LastOrNone();
 
-            Assert.IsTrue(condition: some1.IsSome);
-            Assert.AreEqual(4, some1.Unwrap());
-        }
+        Assert.IsTrue(some1.IsSome);
+        Assert.AreEqual(4, some1.Unwrap());
+    }
 
-        [Test]
-        public void LastOrNone_WithPredicate_ReturnsSome()
-        {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+    [Test]
+    public void LastOrNone_WithPredicate_ReturnsSome()
+    {
+        var list = new List<int> { 0, 1, 2, 3, 4 };
 
-            var some2 = list.LastOrNone(x => x > 2);
+        var some2 = list.LastOrNone(x => x > 2);
 
-            Assert.IsTrue(condition: some2.IsSome);
-            Assert.AreEqual(4, some2.Unwrap());
-        }
+        Assert.IsTrue(some2.IsSome);
+        Assert.AreEqual(4, some2.Unwrap());
+    }
 
-        [Test]
-        public void LastOrNon_PredicateMatchesNon_ReturnsNone()
-        {
-            var list = new List<int> { 0, 1, 2, 3, 4 };
+    [Test]
+    public void LastOrNon_PredicateMatchesNon_ReturnsNone()
+    {
+        var list = new List<int> { 0, 1, 2, 3, 4 };
 
-            var none = list.FirstOrNone(x => x == 10);
+        var none = list.FirstOrNone(x => x == 10);
 
-            Assert.IsTrue(condition: none.IsNone);
-        }
+        Assert.IsTrue(none.IsNone);
+    }
 
-        [Test]
-        public void SingleOrNone_SingleMatchingElement_ReturnsSome()
-        {
-            var list1 = new List<int> { 0, 1, 2, 3, 4 };
+    [Test]
+    public void SingleOrNone_SingleMatchingElement_ReturnsSome()
+    {
+        var list1 = new List<int> { 0, 1, 2, 3, 4 };
 
-            var some1 = list1.SingleOrNone(x => x == 2);
+        var some1 = list1.SingleOrNone(x => x == 2);
 
-            Assert.IsTrue(condition: some1.IsSome);
-            Assert.AreEqual(2, some1.Unwrap());
-        }
+        Assert.IsTrue(some1.IsSome);
+        Assert.AreEqual(2, some1.Unwrap());
+    }
 
-        [Test]
-        public void SingleOrNone_SingleElementInCollection_ReturnsSome()
-        {
-            var list3 = new List<int> { 0 };
+    [Test]
+    public void SingleOrNone_SingleElementInCollection_ReturnsSome()
+    {
+        var list3 = new List<int> { 0 };
 
-            var some2 = list3.SingleOrNone();
+        var some2 = list3.SingleOrNone();
 
-            Assert.IsTrue(condition: some2.IsSome);
-            Assert.AreEqual(0, some2.Unwrap());
-        }
+        Assert.IsTrue(some2.IsSome);
+        Assert.AreEqual(0, some2.Unwrap());
+    }
 
-        [Test]
-        public void SingleOrNone_MultipleMatchingElements_ThrowsException()
-        {
-            var list2 = new List<int> { 0, 1, 2, 2, 3, 4 };
+    [Test]
+    public void SingleOrNone_MultipleMatchingElements_ThrowsException()
+    {
+        var list2 = new List<int> { 0, 1, 2, 2, 3, 4 };
 
-            Assert.Throws<InvalidOperationException>(() => list2.SingleOrNone(x => x == 2));
-        }
+        Assert.Throws<InvalidOperationException>(() => list2.SingleOrNone(x => x == 2));
+    }
 
-        [Test]
-        public void SingleOrNone_MultipleElements_ThrowsException()
-        {
-            var list2 = new List<int> { 0, 1, 2, 2, 3, 4 };
+    [Test]
+    public void SingleOrNone_MultipleElements_ThrowsException()
+    {
+        var list2 = new List<int> { 0, 1, 2, 2, 3, 4 };
 
-            Assert.Throws<InvalidOperationException>(() => list2.SingleOrNone());
-        }
+        Assert.Throws<InvalidOperationException>(() => list2.SingleOrNone());
+    }
 
-        [Test]
-        public void SingleOrNone_EmptyList_ReturnsNone()
-        {
-            // ReSharper disable once CollectionNeverUpdated.Local
-            // This is intentional
-            var list4 = new List<int>();
+    [Test]
+    public void SingleOrNone_EmptyList_ReturnsNone()
+    {
+        // ReSharper disable once CollectionNeverUpdated.Local
+        // This is intentional
+        var list4 = new List<int>();
 
-            var none = list4.SingleOrNone();
+        var none = list4.SingleOrNone();
 
-            Assert.IsTrue(condition: none.IsNone);
-        }
+        Assert.IsTrue(none.IsNone);
+    }
 
-        [Test]
-        public void SingleOrNone_AppliedToFailingEnumerator_DoesNotThrow()
-        {
-            var sequence = new YieldElementsThenFail<string>("Hello world", 2);
+    [Test]
+    public void SingleOrNone_AppliedToFailingEnumerator_DoesNotThrow()
+    {
+        var sequence = new YieldElementsThenFail<string>("Hello world", 2);
 
-            Assert.Throws<InvalidOperationException>(() => sequence.SingleOrNone());
-            Assert.Throws<AssertionException>(() => sequence.ToList());
-        }
+        Assert.Throws<InvalidOperationException>(() => sequence.SingleOrNone());
+        Assert.Throws<AssertionException>(() => sequence.ToList());
+    }
 
-        [Test]
-        public void GetValueOrNone_WithValue_ReturnsValue()
-        {
-            // Arrange
-            const string key = "Asterix";
-            const string expectedValue = "Obelix";
-            var bestFriends = new Dictionary<string, string> { { key, expectedValue } };
+    [Test]
+    public void GetValueOrNone_WithValue_ReturnsValue()
+    {
+        // Arrange
+        const string key = "Asterix";
+        const string expectedValue = "Obelix";
+        var bestFriends = new Dictionary<string, string> { { key, expectedValue } };
 
-            // Act
-            var bestFriendOrNone = bestFriends.GetValueOrNone(key: key);
+        // Act
+        var bestFriendOrNone = bestFriends.GetValueOrNone(key);
 
-            // Assert
-            Assert.That(bestFriendOrNone.Unwrap(), Is.EqualTo(expected: expectedValue));
-        }
+        // Assert
+        Assert.That(bestFriendOrNone.Unwrap(), Is.EqualTo(expectedValue));
+    }
 
-        [Test]
-        public void GetValueOrNone_WithoutValue_ReturnsNone()
-        {
-            // Arrange
-            var bestFriends = new Dictionary<string, string>();
+    [Test]
+    public void GetValueOrNone_WithoutValue_ReturnsNone()
+    {
+        // Arrange
+        var bestFriends = new Dictionary<string, string>();
 
-            // Act
-            var bestFriendOrNone = bestFriends.GetValueOrNone("The Grinch");
+        // Act
+        var bestFriendOrNone = bestFriends.GetValueOrNone("The Grinch");
 
-            // Assert
-            Assert.That(actual: bestFriendOrNone, Is.EqualTo(expected: Option<string>.None));
-        }
+        // Assert
+        Assert.That(bestFriendOrNone, Is.EqualTo(Option<string>.None));
+    }
 
-        [Test]
-        public void GetValueOrNone_WorksForReadOnlyDictionary()
-        {
-            // Arrange
-            const string key = "Asterix";
-            const string expectedValue = "Obelix";
-            var bestFriends =
-                new ReadOnlyDictionary<string, string>(new Dictionary<string, string> { { key, expectedValue } });
+    [Test]
+    public void GetValueOrNone_WorksForReadOnlyDictionary()
+    {
+        // Arrange
+        const string key = "Asterix";
+        const string expectedValue = "Obelix";
+        var bestFriends =
+            new ReadOnlyDictionary<string, string>(new Dictionary<string, string> { { key, expectedValue } });
 
-            // Act
-            var bestFriendOrNone = bestFriends.GetValueOrNone(key: key);
+        // Act
+        var bestFriendOrNone = bestFriends.GetValueOrNone(key);
 
-            // Assert
-            Assert.That(bestFriendOrNone.Unwrap(), Is.EqualTo(expected: expectedValue));
-        }
+        // Assert
+        Assert.That(bestFriendOrNone.Unwrap(), Is.EqualTo(expectedValue));
+    }
 
-        [Test]
-        public void GetValueOrNone_WorksForList()
-        {
-            // Arrange
-            const string key = "Asterix";
-            const string expectedValue = "Obelix";
-            var bestFriends = new[] { new KeyValuePair<string, string>(key: key, value: expectedValue) };
+    [Test]
+    public void GetValueOrNone_WorksForList()
+    {
+        // Arrange
+        const string key = "Asterix";
+        const string expectedValue = "Obelix";
+        var bestFriends = new[] { new KeyValuePair<string, string>(key, expectedValue) };
 
-            // Act
-            var bestFriendOrNone = bestFriends.GetValueOrNone(key: key);
+        // Act
+        var bestFriendOrNone = bestFriends.GetValueOrNone(key);
 
-            // Assert
-            Assert.That(bestFriendOrNone.Unwrap(), Is.EqualTo(expected: expectedValue));
-        }
+        // Assert
+        Assert.That(bestFriendOrNone.Unwrap(), Is.EqualTo(expectedValue));
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/OptionLinqExtensionsTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/OptionLinqExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
 
             var some = list.ElementAtOrNone(0);
 
-            Assert.IsTrue(some.IsSome);
+            Assert.IsTrue(condition: some.IsSome);
             Assert.AreEqual(0, some.Unwrap());
         }
 
@@ -29,7 +29,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
 
             var none = list.ElementAtOrNone(5);
 
-            Assert.IsTrue(none.IsNone);
+            Assert.IsTrue(condition: none.IsNone);
         }
 
         [Test]
@@ -39,7 +39,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
 
             var none = list.ElementAtOrNone(-1);
 
-            Assert.IsTrue(none.IsNone);
+            Assert.IsTrue(condition: none.IsNone);
         }
 
         [Test]
@@ -48,9 +48,9 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var index = 5;
             var sequence = new YieldElementsThenFail<string>("Hello world", index + 1);
 
-            var composition = sequence.ElementAtOrNone(index);
+            var composition = sequence.ElementAtOrNone(index: index);
 
-            Assert.IsTrue(composition.IsSome);
+            Assert.IsTrue(condition: composition.IsSome);
             Assert.Throws<AssertionException>(() => sequence.ToList());
         }
 
@@ -61,7 +61,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
 
             var some = list.FirstOrNone();
 
-            Assert.IsTrue(some.IsSome);
+            Assert.IsTrue(condition: some.IsSome);
             Assert.AreEqual(0, some.Unwrap());
         }
 
@@ -71,7 +71,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var list = new List<int> { 0, 1, 2, 3, 4 };
             var some = list.FirstOrNone(x => x > 2);
 
-            Assert.IsTrue(some.IsSome);
+            Assert.IsTrue(condition: some.IsSome);
             Assert.AreEqual(3, some.Unwrap());
         }
 
@@ -82,7 +82,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
 
             var none = list.FirstOrNone(x => x == 10);
 
-            Assert.IsTrue(none.IsNone);
+            Assert.IsTrue(condition: none.IsNone);
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
 
             var composition = sequence.FirstOrNone();
 
-            Assert.IsTrue(composition.IsSome);
+            Assert.IsTrue(condition: composition.IsSome);
             Assert.Throws<AssertionException>(() => sequence.ToList());
         }
 
@@ -103,7 +103,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
 
             var some1 = list.LastOrNone();
 
-            Assert.IsTrue(some1.IsSome);
+            Assert.IsTrue(condition: some1.IsSome);
             Assert.AreEqual(4, some1.Unwrap());
         }
 
@@ -114,7 +114,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
 
             var some2 = list.LastOrNone(x => x > 2);
 
-            Assert.IsTrue(some2.IsSome);
+            Assert.IsTrue(condition: some2.IsSome);
             Assert.AreEqual(4, some2.Unwrap());
         }
 
@@ -125,7 +125,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
 
             var none = list.FirstOrNone(x => x == 10);
 
-            Assert.IsTrue(none.IsNone);
+            Assert.IsTrue(condition: none.IsNone);
         }
 
         [Test]
@@ -135,7 +135,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
 
             var some1 = list1.SingleOrNone(x => x == 2);
 
-            Assert.IsTrue(some1.IsSome);
+            Assert.IsTrue(condition: some1.IsSome);
             Assert.AreEqual(2, some1.Unwrap());
         }
 
@@ -146,7 +146,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
 
             var some2 = list3.SingleOrNone();
 
-            Assert.IsTrue(some2.IsSome);
+            Assert.IsTrue(condition: some2.IsSome);
             Assert.AreEqual(0, some2.Unwrap());
         }
 
@@ -175,7 +175,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
 
             var none = list4.SingleOrNone();
 
-            Assert.IsTrue(none.IsNone);
+            Assert.IsTrue(condition: none.IsNone);
         }
 
         [Test]
@@ -193,13 +193,13 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             // Arrange
             const string key = "Asterix";
             const string expectedValue = "Obelix";
-            var bestFriends = new Dictionary<string, string> { { key, expectedValue }, };
+            var bestFriends = new Dictionary<string, string> { { key, expectedValue } };
 
             // Act
-            var bestFriendOrNone = bestFriends.GetValueOrNone(key);
+            var bestFriendOrNone = bestFriends.GetValueOrNone(key: key);
 
             // Assert
-            Assert.That(bestFriendOrNone.Unwrap(), Is.EqualTo(expectedValue));
+            Assert.That(bestFriendOrNone.Unwrap(), Is.EqualTo(expected: expectedValue));
         }
 
         [Test]
@@ -212,23 +212,24 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var bestFriendOrNone = bestFriends.GetValueOrNone("The Grinch");
 
             // Assert
-            Assert.That(bestFriendOrNone, Is.EqualTo(Option<string>.None));
+            Assert.That(actual: bestFriendOrNone, Is.EqualTo(expected: Option<string>.None));
         }
-        
+
         [Test]
         public void GetValueOrNone_WorksForReadOnlyDictionary()
         {
             // Arrange
             const string key = "Asterix";
             const string expectedValue = "Obelix";
-            var bestFriends = new ReadOnlyDictionary<string, string>(new Dictionary<string, string> { { key, expectedValue }, });
+            var bestFriends =
+                new ReadOnlyDictionary<string, string>(new Dictionary<string, string> { { key, expectedValue } });
 
             // Act
-            var bestFriendOrNone = bestFriends.GetValueOrNone(key);
+            var bestFriendOrNone = bestFriends.GetValueOrNone(key: key);
 
             // Assert
-            Assert.That(bestFriendOrNone.Unwrap(), Is.EqualTo(expectedValue));
-        }         
+            Assert.That(bestFriendOrNone.Unwrap(), Is.EqualTo(expected: expectedValue));
+        }
 
         [Test]
         public void GetValueOrNone_WorksForList()
@@ -236,13 +237,13 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             // Arrange
             const string key = "Asterix";
             const string expectedValue = "Obelix";
-            var bestFriends = new[] { new KeyValuePair<string, string>(key, expectedValue) };
+            var bestFriends = new[] { new KeyValuePair<string, string>(key: key, value: expectedValue) };
 
             // Act
-            var bestFriendOrNone = bestFriends.GetValueOrNone(key);
+            var bestFriendOrNone = bestFriends.GetValueOrNone(key: key);
 
             // Assert
-            Assert.That(bestFriendOrNone.Unwrap(), Is.EqualTo(expectedValue));
-        } 
+            Assert.That(bestFriendOrNone.Unwrap(), Is.EqualTo(expected: expectedValue));
+        }
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/SelectSomeTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/SelectSomeTests.cs
@@ -20,7 +20,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
                 999.ToOption()
             }.SelectSome().ToList();
 
-            Assert.AreEqual(4, some.Count);
+            Assert.AreEqual(4, actual: some.Count);
             Assert.AreEqual(0, some[0]);
             Assert.AreEqual(99, some[1]);
             Assert.AreEqual(666, some[2]);
@@ -40,7 +40,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
                 new Option<string>()
             }.SelectSome(str => str[0]).ToList();
 
-            Assert.AreEqual("hw!", string.Join("", some));
+            Assert.AreEqual("hw!", string.Join("", values: some));
         }
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/SelectSomeTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/SelectSomeTests.cs
@@ -1,37 +1,36 @@
 using System.Linq;
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests.OptionExtensions
+namespace Galaxus.Functional.Tests.OptionExtensions;
+
+[TestFixture]
+public class SelectSomeTests
 {
-    [TestFixture]
-    public class SelectSomeTests
+    [Test]
+    public void SelectSome_AllSomeValuesRemainInOriginalOrder()
     {
-        [Test]
-        public void SelectSome_AllSomeValuesRemainInOriginalOrder()
+        var some = new[]
         {
-            var some = new[]
-            {
-                0.ToOption(), 99.ToOption(), new Option<int>(), new Option<int>(), 666.ToOption(),
-                new Option<int>(), 999.ToOption()
-            }.SelectSome().ToList();
+            0.ToOption(), 99.ToOption(), new Option<int>(), new Option<int>(), 666.ToOption(),
+            new Option<int>(), 999.ToOption()
+        }.SelectSome().ToList();
 
-            Assert.AreEqual(4, actual: some.Count);
-            Assert.AreEqual(0, some[0]);
-            Assert.AreEqual(99, some[1]);
-            Assert.AreEqual(666, some[2]);
-            Assert.AreEqual(999, some[3]);
-        }
+        Assert.AreEqual(4, some.Count);
+        Assert.AreEqual(0, some[0]);
+        Assert.AreEqual(99, some[1]);
+        Assert.AreEqual(666, some[2]);
+        Assert.AreEqual(999, some[3]);
+    }
 
-        [Test]
-        public void SelectSome_WithSelector_CorrectValueMapping()
+    [Test]
+    public void SelectSome_WithSelector_CorrectValueMapping()
+    {
+        var some = new[]
         {
-            var some = new[]
-            {
-                "hello".ToOption(), "world".ToOption(), new Option<string>(), new Option<string>(), "!".ToOption(),
-                new Option<string>()
-            }.SelectSome(str => str[0]).ToList();
+            "hello".ToOption(), "world".ToOption(), new Option<string>(), new Option<string>(), "!".ToOption(),
+            new Option<string>()
+        }.SelectSome(str => str[0]).ToList();
 
-            Assert.AreEqual("hw!", string.Join("", values: some));
-        }
+        Assert.AreEqual("hw!", string.Join("", some));
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/SelectSomeTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/SelectSomeTests.cs
@@ -11,13 +11,8 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         {
             var some = new[]
             {
-                0.ToOption(),
-                99.ToOption(),
-                new Option<int>(),
-                new Option<int>(),
-                666.ToOption(),
-                new Option<int>(),
-                999.ToOption()
+                0.ToOption(), 99.ToOption(), new Option<int>(), new Option<int>(), 666.ToOption(),
+                new Option<int>(), 999.ToOption()
             }.SelectSome().ToList();
 
             Assert.AreEqual(4, actual: some.Count);
@@ -32,11 +27,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         {
             var some = new[]
             {
-                "hello".ToOption(),
-                "world".ToOption(),
-                new Option<string>(),
-                new Option<string>(),
-                "!".ToOption(),
+                "hello".ToOption(), "world".ToOption(), new Option<string>(), new Option<string>(), "!".ToOption(),
                 new Option<string>()
             }.SelectSome(str => str[0]).ToList();
 

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/ToNullableTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/ToNullableTests.cs
@@ -1,21 +1,20 @@
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests.OptionExtensions
-{
-    [TestFixture]
-    public class ToNullableTests
-    {
-        [Test]
-        public void ToNullable_NonNull_ReturnsOriginalValue()
-        {
-            Assert.AreEqual(true, true.ToOption().ToNullable());
-            Assert.AreEqual(false, false.ToOption().ToNullable());
-        }
+namespace Galaxus.Functional.Tests.OptionExtensions;
 
-        [Test]
-        public void ToNullable_Null_ReturnsDefaultValue()
-        {
-            Assert.AreEqual(default(bool?), Option<bool>.None.ToNullable());
-        }
+[TestFixture]
+public class ToNullableTests
+{
+    [Test]
+    public void ToNullable_NonNull_ReturnsOriginalValue()
+    {
+        Assert.AreEqual(true, true.ToOption().ToNullable());
+        Assert.AreEqual(false, false.ToOption().ToNullable());
+    }
+
+    [Test]
+    public void ToNullable_Null_ReturnsDefaultValue()
+    {
+        Assert.AreEqual(default(bool?), Option<bool>.None.ToNullable());
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/ToOptionTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/ToOptionTests.cs
@@ -15,31 +15,31 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             Assert.AreEqual("hello", "hello".ToOption<object>().Unwrap());
 
             var instance = new DummyReferenceType();
-            Assert.AreSame(instance, instance.ToOption().Unwrap());
+            Assert.AreSame(expected: instance, instance.ToOption().Unwrap());
         }
 
         [Test]
         public void ToOption_ValueType_ReturnsSome()
         {
-            Assert.IsTrue(1.ToOption().IsSome);
+            Assert.IsTrue(condition: 1.ToOption().IsSome);
         }
 
         [Test]
         public void ToOption_ReferenceType_ReturnsSome()
         {
-            Assert.IsTrue(new DummyReferenceType().ToOption().IsSome);
+            Assert.IsTrue(condition: new DummyReferenceType().ToOption().IsSome);
         }
 
         [Test]
         public void ToOption_NullValueType_ReturnsNone()
         {
-            Assert.IsTrue(((int?)null).ToOption().IsNone);
+            Assert.IsTrue(condition: ((int?)null).ToOption().IsNone);
         }
 
         [Test]
         public void ToOption_NullReferenceType_ReturnsNone()
         {
-            Assert.IsTrue(((DummyReferenceType)null).ToOption().IsNone);
+            Assert.IsTrue(condition: ((DummyReferenceType)null).ToOption().IsNone);
         }
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/ToOptionTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/ToOptionTests.cs
@@ -1,45 +1,44 @@
 using Galaxus.Functional.Tests.Helpers;
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests.OptionExtensions
+namespace Galaxus.Functional.Tests.OptionExtensions;
+
+[TestFixture]
+public class ToOptionTests
 {
-    [TestFixture]
-    public class ToOptionTests
+    [Test]
+    public void ToOption_ContainsOriginalValue()
     {
-        [Test]
-        public void ToOption_ContainsOriginalValue()
-        {
-            Assert.AreEqual(true, true.ToOption().Unwrap());
-            Assert.AreEqual(false, false.ToOption().Unwrap());
-            Assert.AreEqual("hello", "hello".ToOption().Unwrap());
-            Assert.AreEqual("hello", "hello".ToOption<object>().Unwrap());
+        Assert.AreEqual(true, true.ToOption().Unwrap());
+        Assert.AreEqual(false, false.ToOption().Unwrap());
+        Assert.AreEqual("hello", "hello".ToOption().Unwrap());
+        Assert.AreEqual("hello", "hello".ToOption<object>().Unwrap());
 
-            var instance = new DummyReferenceType();
-            Assert.AreSame(expected: instance, instance.ToOption().Unwrap());
-        }
+        var instance = new DummyReferenceType();
+        Assert.AreSame(instance, instance.ToOption().Unwrap());
+    }
 
-        [Test]
-        public void ToOption_ValueType_ReturnsSome()
-        {
-            Assert.IsTrue(condition: 1.ToOption().IsSome);
-        }
+    [Test]
+    public void ToOption_ValueType_ReturnsSome()
+    {
+        Assert.IsTrue(1.ToOption().IsSome);
+    }
 
-        [Test]
-        public void ToOption_ReferenceType_ReturnsSome()
-        {
-            Assert.IsTrue(condition: new DummyReferenceType().ToOption().IsSome);
-        }
+    [Test]
+    public void ToOption_ReferenceType_ReturnsSome()
+    {
+        Assert.IsTrue(new DummyReferenceType().ToOption().IsSome);
+    }
 
-        [Test]
-        public void ToOption_NullValueType_ReturnsNone()
-        {
-            Assert.IsTrue(condition: ((int?)null).ToOption().IsNone);
-        }
+    [Test]
+    public void ToOption_NullValueType_ReturnsNone()
+    {
+        Assert.IsTrue(((int?)null).ToOption().IsNone);
+    }
 
-        [Test]
-        public void ToOption_NullReferenceType_ReturnsNone()
-        {
-            Assert.IsTrue(condition: ((DummyReferenceType)null).ToOption().IsNone);
-        }
+    [Test]
+    public void ToOption_NullReferenceType_ReturnsNone()
+    {
+        Assert.IsTrue(((DummyReferenceType)null).ToOption().IsNone);
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/UnwrapAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/UnwrapAsyncTests.cs
@@ -2,749 +2,748 @@
 using System.Threading.Tasks;
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests.OptionExtensions
+namespace Galaxus.Functional.Tests.OptionExtensions;
+
+public class UnwrapAsyncTests
 {
-    public class UnwrapAsyncTests
+    [Test]
+    public async Task UnwrapAsync_WhenOptionIsSome_ThenCorrectValueReturned()
     {
-        [Test]
-        public async Task UnwrapAsync_WhenOptionIsSome_ThenCorrectValueReturned()
+        // arrange
+        var some = Task.FromResult("hello".ToOption());
+
+        // act
+        var hello = await some.UnwrapAsync();
+
+        // assert
+        Assert.AreEqual("hello", hello);
+    }
+
+    [Test]
+    public void UnwrapAsync_WhenOptionIsNone_ThenExceptionIsThrown()
+    {
+        // arrange
+        var none = Task.FromResult(Option<string>.None);
+
+        //act
+        async Task Act()
         {
-            // arrange
-            var some = Task.FromResult("hello".ToOption());
-
-            // act
-            var hello = await some.UnwrapAsync();
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
+            await none.UnwrapAsync();
         }
 
-        [Test]
-        public void UnwrapAsync_WhenOptionIsNone_ThenExceptionIsThrown()
-        {
-            // arrange
-            var none = Task.FromResult(result: Option<string>.None);
+        // assert
+        Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(Act);
+    }
 
-            //act
-            async Task Act()
+    [Test]
+    public async Task UnwrapAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var someTask = Task.FromResult("Ford Prefect".ToOption());
+
+        // act
+        await someTask.UnwrapAsync();
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, someTask.Status);
+    }
+
+    [Test]
+    public void UnwrapAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Option<string>>(new ArgumentException());
+
+        // act
+        async Task Act()
+        {
+            await failingTask.UnwrapAsync();
+        }
+
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapAsyncWithErrorMessage_WhenOptionIsSome_ThenCorrectValueReturned()
+    {
+        // arrange
+        var some = Task.FromResult("hello".ToOption());
+
+        // act
+        var hello = await some.UnwrapAsync("World");
+
+        // assert
+        Assert.AreEqual("hello", hello);
+    }
+
+    [Test]
+    public void UnwrapAsyncWithErrorMessage_WhenOptionIsNone_ThenExceptionIsThrown()
+    {
+        // arrange
+        var none = Task.FromResult(Option<string>.None);
+
+        // act
+        async Task Act()
+        {
+            await none.UnwrapAsync("World");
+        }
+
+        // assert
+        Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapAsyncWithErrorMessage_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var someTask = Task.FromResult("Ford Prefect".ToOption());
+
+        // act
+        await someTask.UnwrapAsync("Arthur Dent");
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, someTask.Status);
+    }
+
+    [Test]
+    public void UnwrapAsyncWithErrorMessage_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Option<string>>(new ArgumentException());
+
+        // act
+        async Task Act()
+        {
+            await failingTask.UnwrapAsync("Arthur Dent");
+        }
+
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public void UnwrapAsync_WhenErrorFunctionIsNull_ThenArgumentException()
+    {
+        // arrange
+        var none = Task.FromResult(Option<string>.None);
+
+        // act
+        async Task Act()
+        {
+            await none.UnwrapAsync((Func<string>)null);
+        }
+
+        // assert
+        Assert.ThrowsAsync<ArgumentNullException>(Act);
+    }
+
+    [Test]
+    public void UnwrapAsync_WhenUnwrapOnNoneWithCustomError_ThenExceptionMessageIsCustomErrorMessage()
+    {
+        // arrange
+        var none = Task.FromResult(Option<string>.None);
+
+        // act
+        async Task Act()
+        {
+            try
             {
-                await none.UnwrapAsync();
+                await none.UnwrapAsync("YOLO");
             }
-
-            // assert
-            Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(code: Act);
-        }
-
-        [Test]
-        public async Task UnwrapAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
-        {
-            // arrange
-            var someTask = Task.FromResult("Ford Prefect".ToOption());
-
-            // act
-            await someTask.UnwrapAsync();
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: someTask.Status);
-        }
-
-        [Test]
-        public void UnwrapAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            var failingTask = Task.FromException<Option<string>>(new ArgumentException());
-
-            // act
-            async Task Act()
+            catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
             {
-                await failingTask.UnwrapAsync();
+                Assert.AreEqual("YOLO", ex.Message);
+                throw;
             }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
-        [Test]
-        public async Task UnwrapAsyncWithErrorMessage_WhenOptionIsSome_ThenCorrectValueReturned()
+        // assert
+        Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapAsyncWithErrorFunction_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var someTask = Task.FromResult("Ford Prefect".ToOption());
+
+        // act
+        await someTask.UnwrapAsync(() => "Arthur Dent");
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, someTask.Status);
+    }
+
+    [Test]
+    public void UnwrapAsyncWithErrorFunction_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Option<string>>(new ArgumentException());
+
+        // act
+        async Task Act()
         {
-            // arrange
-            var some = Task.FromResult("hello".ToOption());
-
-            // act
-            var hello = await some.UnwrapAsync("World");
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
+            await failingTask.UnwrapAsync(() => "Arthur Dent");
         }
 
-        [Test]
-        public void UnwrapAsyncWithErrorMessage_WhenOptionIsNone_ThenExceptionIsThrown()
-        {
-            // arrange
-            var none = Task.FromResult(result: Option<string>.None);
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
 
-            // act
-            async Task Act()
+    [Test]
+    public async Task UnwrapAsyncWhitErrorFunction_WhenUnwrapWithCustomInvokableErrorOnSome_ThenNothingIsInvoked()
+    {
+        // arrange
+        var some = Task.FromResult("hello".ToOption());
+        var invoked = false;
+
+        // act
+        var hello = await some.UnwrapAsync(() =>
+        {
+            invoked = true;
+            return "YOLO";
+        });
+
+        // assert
+        Assert.AreEqual("hello", hello);
+        Assert.IsFalse(invoked);
+    }
+
+    [Test]
+    public void UnwrapAsyncWithErrorFunction_WhenUnwrapWithCustomInvokableErrorOnNone_ThenFunctionIsInvoked()
+    {
+        // arrange
+        var none = Task.FromResult(Option<string>.None);
+        var invoked = false;
+
+        // act
+        async Task Act()
+        {
+            try
             {
-                await none.UnwrapAsync("World");
-            }
-
-            // assert
-            Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(code: Act);
-        }
-
-        [Test]
-        public async Task UnwrapAsyncWithErrorMessage_WhenSynchronousContinuation_ThenReturnsSuccessTask()
-        {
-            // arrange
-            var someTask = Task.FromResult("Ford Prefect".ToOption());
-
-            // act
-            await someTask.UnwrapAsync("Arthur Dent");
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: someTask.Status);
-        }
-
-        [Test]
-        public void UnwrapAsyncWithErrorMessage_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            var failingTask = Task.FromException<Option<string>>(new ArgumentException());
-
-            // act
-            async Task Act()
-            {
-                await failingTask.UnwrapAsync("Arthur Dent");
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
-        }
-
-        [Test]
-        public void UnwrapAsync_WhenErrorFunctionIsNull_ThenArgumentException()
-        {
-            // arrange
-            var none = Task.FromResult(result: Option<string>.None);
-
-            // act
-            async Task Act()
-            {
-                await none.UnwrapAsync((Func<string>)null);
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentNullException>(code: Act);
-        }
-
-        [Test]
-        public void UnwrapAsync_WhenUnwrapOnNoneWithCustomError_ThenExceptionMessageIsCustomErrorMessage()
-        {
-            // arrange
-            var none = Task.FromResult(result: Option<string>.None);
-
-            // act
-            async Task Act()
-            {
-                try
+                await none.UnwrapAsync(() =>
                 {
-                    await none.UnwrapAsync("YOLO");
-                }
-                catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
+                    invoked = true;
+                    return "YOLO";
+                });
+            }
+            catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
+            {
+                Assert.AreEqual("YOLO", ex.Message);
+                throw;
+            }
+        }
+
+        // assert
+        Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(Act);
+        Assert.IsTrue(invoked);
+    }
+
+    [Test]
+    public async Task UnwrapAsyncWithErrorFunctionTask_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var someTask = Task.FromResult("Ford Prefect".ToOption());
+
+        // act
+        await someTask.UnwrapAsync(async () => await Task.FromResult("Arthur Dent"));
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, someTask.Status);
+    }
+
+    [Test]
+    public void UnwrapAsyncWithErrorFunctionTask_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // assert
+        var failingTask = Task.FromException<Option<string>>(new ArgumentException());
+
+        // act
+        async Task Act()
+        {
+            await failingTask.UnwrapAsync(async () => await Task.FromResult("Arthur Dent"));
+        }
+
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapAsyncWhitErrorFunctionTask_WhenUnwrapWithCustomInvokableErrorOnSome_ThenNothingIsInvoked()
+    {
+        // arrange
+        var some = Task.FromResult("hello".ToOption());
+        var invoked = false;
+
+        // act
+        var hello = await some.UnwrapAsync(async () =>
+        {
+            invoked = true;
+            return await Task.FromResult("YOLO");
+        });
+
+        // assert
+        Assert.AreEqual("hello", hello);
+        Assert.IsFalse(invoked);
+    }
+
+    [Test]
+    public void UnwrapAsyncWithErrorFunctionTask_WhenUnwrapWithCustomInvokableErrorOnNone_ThenFunctionIsInvoked()
+    {
+        // arrange
+        var none = Task.FromResult(Option<string>.None);
+        var invoked = false;
+
+        // act
+        async Task Act()
+        {
+            try
+            {
+                await none.UnwrapAsync(async () =>
                 {
-                    Assert.AreEqual("YOLO", actual: ex.Message);
-                    throw;
-                }
+                    invoked = true;
+                    return await Task.FromResult("YOLO");
+                });
             }
-
-            // assert
-            Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(code: Act);
-        }
-
-        [Test]
-        public async Task UnwrapAsyncWithErrorFunction_WhenSynchronousContinuation_ThenReturnsSuccessTask()
-        {
-            // arrange
-            var someTask = Task.FromResult("Ford Prefect".ToOption());
-
-            // act
-            await someTask.UnwrapAsync(() => "Arthur Dent");
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: someTask.Status);
-        }
-
-        [Test]
-        public void UnwrapAsyncWithErrorFunction_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            var failingTask = Task.FromException<Option<string>>(new ArgumentException());
-
-            // act
-            async Task Act()
+            catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
             {
-                await failingTask.UnwrapAsync(() => "Arthur Dent");
+                Assert.AreEqual("YOLO", ex.Message);
+                throw;
             }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
-        [Test]
-        public async Task UnwrapAsyncWhitErrorFunction_WhenUnwrapWithCustomInvokableErrorOnSome_ThenNothingIsInvoked()
+        // assert
+        Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(Act);
+        Assert.IsTrue(invoked);
+    }
+
+    [Test]
+    public async Task UnwrapOrAsync_WhenSome_ThenResultIsSomeValue()
+    {
+        // arrange
+        var some = Task.FromResult("hello".ToOption());
+
+        // act
+        var hello = await some.UnwrapOrAsync("world");
+
+        // assert
+        Assert.AreEqual("hello", hello);
+    }
+
+    [Test]
+    public async Task UnwrapOrAsync_WhenNone_ThenResultIsParameterValue()
+    {
+        // arrange
+        var none = Task.FromResult(Option<string>.None);
+
+        // act
+        var world = await none.UnwrapOrAsync("world");
+
+        // assert
+        Assert.AreEqual("world", world);
+    }
+
+    [Test]
+    public async Task UnwrapOrAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var someTask = Task.FromResult("Ford Prefect".ToOption());
+
+        // act
+        await someTask.UnwrapOrAsync("Arthur Dent");
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, someTask.Status);
+    }
+
+    [Test]
+    public void UnwrapOrAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Option<string>>(new ArgumentException());
+
+        // act
+        async Task Act()
         {
-            // arrange
-            var some = Task.FromResult("hello".ToOption());
-            var invoked = false;
-
-            // act
-            var hello = await some.UnwrapAsync(() =>
-            {
-                invoked = true;
-                return "YOLO";
-            });
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
-            Assert.IsFalse(condition: invoked);
+            await failingTask.UnwrapOrAsync("Arthur Dent");
         }
 
-        [Test]
-        public void UnwrapAsyncWithErrorFunction_WhenUnwrapWithCustomInvokableErrorOnNone_ThenFunctionIsInvoked()
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapOrAsyncWithTaskParam_WhenSome_ThenResultIsSomeValue()
+    {
+        // arrange
+        var some = Task.FromResult("hello".ToOption());
+
+        // act
+        var hello = await some.UnwrapOrAsync(Task.FromResult("world"));
+
+        // assert
+        Assert.AreEqual("hello", hello);
+    }
+
+    [Test]
+    public async Task UnwrapOrAsyncWithTaskParam_WhenNone_ThenResultIsParameterValue()
+    {
+        // arrange
+        var none = Task.FromResult(Option<string>.None);
+
+        // act
+        var world = await none.UnwrapOrAsync(Task.FromResult("world"));
+
+        // assert
+        Assert.AreEqual("world", world);
+    }
+
+    [Test]
+    public async Task UnwrapOrAsyncWithTaskParam_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var someTask = Task.FromResult("Ford Prefect".ToOption());
+
+        // act
+        await someTask.UnwrapOrAsync(Task.FromResult("Arthur Dent"));
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, someTask.Status);
+    }
+
+    [Test]
+    public void UnwrapOrAsyncWithTaskParam_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Option<string>>(new ArgumentException());
+
+        // act
+        async Task Act()
         {
-            // arrange
-            var none = Task.FromResult(result: Option<string>.None);
-            var invoked = false;
-
-            // act
-            async Task Act()
-            {
-                try
-                {
-                    await none.UnwrapAsync(() =>
-                    {
-                        invoked = true;
-                        return "YOLO";
-                    });
-                }
-                catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
-                {
-                    Assert.AreEqual("YOLO", actual: ex.Message);
-                    throw;
-                }
-            }
-
-            // assert
-            Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(code: Act);
-            Assert.IsTrue(condition: invoked);
+            await failingTask.UnwrapOrAsync(Task.FromResult("Arthur Dent"));
         }
 
-        [Test]
-        public async Task UnwrapAsyncWithErrorFunctionTask_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsync_WhenSome_ThenResultIsSomeValue()
+    {
+        // arrange
+        var some = Task.FromResult("hello".ToOption());
+
+        // act
+        var hello = await some.UnwrapOrElseAsync(() => "world");
+
+        // assert
+        Assert.AreEqual("hello", hello);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsync_WhenNone_ThenResultIsParameterValue()
+    {
+        // arrange
+        var none = Task.FromResult(Option<string>.None);
+
+        // act
+        var world = await none.UnwrapOrElseAsync(() => "world");
+
+        // assert
+        Assert.AreEqual("world", world);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var someTask = Task.FromResult("Ford Prefect".ToOption());
+
+        // act
+        await someTask.UnwrapOrElseAsync(() => "Arthur Dent");
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, someTask.Status);
+    }
+
+    [Test]
+    public void UnwrapOrElseAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Option<string>>(new ArgumentException());
+
+        // act
+        async Task Act()
         {
-            // arrange
-            var someTask = Task.FromResult("Ford Prefect".ToOption());
-
-            // act
-            await someTask.UnwrapAsync(async () => await Task.FromResult("Arthur Dent"));
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: someTask.Status);
+            await failingTask.UnwrapOrElseAsync(() => "Arthur Dent");
         }
 
-        [Test]
-        public void UnwrapAsyncWithErrorFunctionTask_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsync_WhenUnwrapSomeWithCallBack_ThenNoCallbackInvoked()
+    {
+        // arrange
+        var some = Task.FromResult(Option<string>.Some("hello"));
+        var invoked = false;
+
+        // act
+        var hello = await some.UnwrapOrElseAsync(() =>
         {
-            // assert
-            var failingTask = Task.FromException<Option<string>>(new ArgumentException());
+            invoked = true;
+            return "world";
+        });
 
-            // act
-            async Task Act()
-            {
-                await failingTask.UnwrapAsync(async () => await Task.FromResult("Arthur Dent"));
-            }
+        // assert
+        Assert.AreEqual("hello", hello);
+        Assert.IsFalse(invoked);
+    }
 
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
+    [Test]
+    public async Task UnwrapOrElseAsync_WhenUnwrapNoneWithCallBack_ThenCallbackInvoked()
+    {
+        // arrange
+        var none = Task.FromResult(Option<string>.None);
+        var invoked = false;
+
+        // act
+        var world = await none.UnwrapOrElseAsync(() =>
+        {
+            invoked = true;
+            return "world";
+        });
+
+        // assert
+        Assert.AreEqual("world", world);
+        Assert.IsTrue(invoked);
+    }
+
+
+    [Test]
+    public void UnwrapOrElseAsync_WhenUnwrapNoneWithFunctionIsNull_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        Func<string> nullFunc = null;
+
+        // act
+        // ReSharper disable once ExpressionIsAlwaysNull
+        async Task Act()
+        {
+            await Task.FromResult(Option<string>.None).UnwrapOrElseAsync(nullFunc);
         }
 
-        [Test]
-        public async Task UnwrapAsyncWhitErrorFunctionTask_WhenUnwrapWithCustomInvokableErrorOnSome_ThenNothingIsInvoked()
+        // assert
+        Assert.ThrowsAsync<ArgumentNullException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsyncWithTaskParam_WhenSome_ThenResultIsSomeValue()
+    {
+        // arrange
+        var some = Task.FromResult("hello".ToOption());
+
+        static async Task<string> Continuation()
         {
-            // arrange
-            var some = Task.FromResult("hello".ToOption());
-            var invoked = false;
-
-            // act
-            var hello = await some.UnwrapAsync(async () =>
-            {
-                invoked = true;
-                return await Task.FromResult("YOLO");
-            });
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
-            Assert.IsFalse(condition: invoked);
+            return await Task.FromResult("world");
         }
 
-        [Test]
-        public void UnwrapAsyncWithErrorFunctionTask_WhenUnwrapWithCustomInvokableErrorOnNone_ThenFunctionIsInvoked()
+        // act
+        var hello = await some.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+
+        // assert
+        Assert.AreEqual("hello", hello);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsyncWithTaskParam_WhenNone_ThenResultIsParameterValue()
+    {
+        // arrange
+        var none = Task.FromResult(Option<string>.None);
+
+        static async Task<string> Continuation()
         {
-            // arrange
-            var none = Task.FromResult(result: Option<string>.None);
-            var invoked = false;
-
-            // act
-            async Task Act()
-            {
-                try
-                {
-                    await none.UnwrapAsync(async () =>
-                    {
-                        invoked = true;
-                        return await Task.FromResult("YOLO");
-                    });
-                }
-                catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
-                {
-                    Assert.AreEqual("YOLO", actual: ex.Message);
-                    throw;
-                }
-            }
-
-            // assert
-            Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(code: Act);
-            Assert.IsTrue(condition: invoked);
+            return await Task.FromResult("world");
         }
 
-        [Test]
-        public async Task UnwrapOrAsync_WhenSome_ThenResultIsSomeValue()
+        // act
+        var world = await none.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+
+        // assert
+        Assert.AreEqual("world", world);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsyncWithTaskParam_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var someTask = Task.FromResult("Ford Prefect".ToOption());
+
+        static async Task<string> Continuation()
         {
-            // arrange
-            var some = Task.FromResult("hello".ToOption());
-
-            // act
-            var hello = await some.UnwrapOrAsync("world");
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
+            return await Task.FromResult("Arthur Dent");
         }
 
-        [Test]
-        public async Task UnwrapOrAsync_WhenNone_ThenResultIsParameterValue()
+        // act
+        await someTask.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, someTask.Status);
+    }
+
+    [Test]
+    public void
+        UnwrapOrElseAsyncWithTaskParam_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        static async Task<string> Continuation()
         {
-            // arrange
-            var none = Task.FromResult(result: Option<string>.None);
-
-            // act
-            var world = await none.UnwrapOrAsync("world");
-
-            // assert
-            Assert.AreEqual("world", actual: world);
+            return await Task.FromResult("Arthur Dent");
         }
 
-        [Test]
-        public async Task UnwrapOrAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+        // act
+        async Task Act()
         {
-            // arrange
-            var someTask = Task.FromResult("Ford Prefect".ToOption());
-
-            // act
-            await someTask.UnwrapOrAsync("Arthur Dent");
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: someTask.Status);
+            await Task.FromException<Option<string>>(new ArgumentException())
+                .UnwrapOrElseAsync((Func<Task<string>>)Continuation);
         }
 
-        [Test]
-        public void UnwrapOrAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsyncWithTaskParam_WhenUnwrapSomeWithCallBack_ThenNoCallbackInvoked()
+    {
+        // arrange
+        var some = Task.FromResult(Option<string>.Some("hello"));
+        var invoked = false;
+
+        async Task<string> Continuation()
         {
-            // arrange
-            var failingTask = Task.FromException<Option<string>>(new ArgumentException());
-
-            // act
-            async Task Act()
-            {
-                await failingTask.UnwrapOrAsync("Arthur Dent");
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
-        }
-
-        [Test]
-        public async Task UnwrapOrAsyncWithTaskParam_WhenSome_ThenResultIsSomeValue()
-        {
-            // arrange
-            var some = Task.FromResult("hello".ToOption());
-
-            // act
-            var hello = await some.UnwrapOrAsync(Task.FromResult("world"));
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
-        }
-
-        [Test]
-        public async Task UnwrapOrAsyncWithTaskParam_WhenNone_ThenResultIsParameterValue()
-        {
-            // arrange
-            var none = Task.FromResult(result: Option<string>.None);
-
-            // act
-            var world = await none.UnwrapOrAsync(Task.FromResult("world"));
-
-            // assert
-            Assert.AreEqual("world", actual: world);
-        }
-
-        [Test]
-        public async Task UnwrapOrAsyncWithTaskParam_WhenSynchronousContinuation_ThenReturnsSuccessTask()
-        {
-            // arrange
-            var someTask = Task.FromResult("Ford Prefect".ToOption());
-
-            // act
-            await someTask.UnwrapOrAsync(Task.FromResult("Arthur Dent"));
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: someTask.Status);
-        }
-
-        [Test]
-        public void UnwrapOrAsyncWithTaskParam_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            var failingTask = Task.FromException<Option<string>>(new ArgumentException());
-
-            // act
-            async Task Act()
-            {
-                await failingTask.UnwrapOrAsync(Task.FromResult("Arthur Dent"));
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
-        }
-
-        [Test]
-        public async Task UnwrapOrElseAsync_WhenSome_ThenResultIsSomeValue()
-        {
-            // arrange
-            var some = Task.FromResult("hello".ToOption());
-
-            // act
-            var hello = await some.UnwrapOrElseAsync(() => "world");
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
-        }
-
-        [Test]
-        public async Task UnwrapOrElseAsync_WhenNone_ThenResultIsParameterValue()
-        {
-            // arrange
-            var none = Task.FromResult(result: Option<string>.None);
-
-            // act
-            var world = await none.UnwrapOrElseAsync(() => "world");
-
-            // assert
-            Assert.AreEqual("world", actual: world);
-        }
-
-        [Test]
-        public async Task UnwrapOrElseAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
-        {
-            // arrange
-            var someTask = Task.FromResult("Ford Prefect".ToOption());
-
-            // act
-            await someTask.UnwrapOrElseAsync(() => "Arthur Dent");
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: someTask.Status);
-        }
-
-        [Test]
-        public void UnwrapOrElseAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            var failingTask = Task.FromException<Option<string>>(new ArgumentException());
-
-            // act
-            async Task Act()
-            {
-                await failingTask.UnwrapOrElseAsync(() => "Arthur Dent");
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
-        }
-
-        [Test]
-        public async Task UnwrapOrElseAsync_WhenUnwrapSomeWithCallBack_ThenNoCallbackInvoked()
-        {
-            // arrange
-            var some = Task.FromResult(Option<string>.Some("hello"));
-            var invoked = false;
-
-            // act
-            var hello = await some.UnwrapOrElseAsync(() =>
+            return await Task.Run(() =>
             {
                 invoked = true;
                 return "world";
             });
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
-            Assert.IsFalse(condition: invoked);
         }
 
-        [Test]
-        public async Task UnwrapOrElseAsync_WhenUnwrapNoneWithCallBack_ThenCallbackInvoked()
-        {
-            // arrange
-            var none = Task.FromResult(result: Option<string>.None);
-            var invoked = false;
+        // act
+        var hello = await some.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
 
-            // act
-            var world = await none.UnwrapOrElseAsync(() =>
+        // assert
+        Assert.AreEqual("hello", hello);
+        Assert.IsFalse(invoked);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsyncWithTaskParam_WhenUnwrapNoneWithCallBack_ThenCallbackInvoked()
+    {
+        // arrange
+        var none = Task.FromResult(Option<string>.None);
+        var invoked = false;
+
+        async Task<string> Continuation()
+        {
+            return await Task.Run(() =>
             {
                 invoked = true;
                 return "world";
             });
-
-            // assert
-            Assert.AreEqual("world", actual: world);
-            Assert.IsTrue(condition: invoked);
         }
 
+        // act
+        var world = await none.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
 
-        [Test]
-        public void UnwrapOrElseAsync_WhenUnwrapNoneWithFunctionIsNull_ThenArgumentExceptionIsThrown()
+        // assert
+        Assert.AreEqual("world", world);
+        Assert.IsTrue(invoked);
+    }
+
+    [Test]
+    public void UnwrapOrElseAsyncWithTaskParam_WhenUnwrapNoneWithFunctionTaskIsNull_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        Func<Task<string>> nullFunc = null;
+
+        // act
+        // ReSharper disable once ExpressionIsAlwaysNull
+        async Task Act()
         {
-            // arrange
-            Func<string> nullFunc = null;
-
-            // act
-            // ReSharper disable once ExpressionIsAlwaysNull
-            async Task Act()
-            {
-                await Task.FromResult(result: Option<string>.None).UnwrapOrElseAsync(fallback: nullFunc);
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentNullException>(code: Act);
+            await Task.FromResult(Option<string>.None).UnwrapOrElseAsync(nullFunc);
         }
 
-        [Test]
-        public async Task UnwrapOrElseAsyncWithTaskParam_WhenSome_ThenResultIsSomeValue()
+        // assert
+        Assert.ThrowsAsync<ArgumentNullException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapOrDefaultAsync_WhenSome_ThenResultIsSomeValue()
+    {
+        // arrange
+        var some = Task.FromResult("hello".ToOption());
+
+        // act
+        var hello = await some.UnwrapOrDefaultAsync();
+
+        // assert
+        Assert.AreEqual("hello", hello);
+    }
+
+    [Test]
+    public async Task UnwrapOrDefaultAsync_WhenNone_ThenResultIsDefaultValue()
+    {
+        // arrange
+        var none = Task.FromResult(Option<string>.None);
+
+        // act
+        var defaultString = await none.UnwrapOrDefaultAsync();
+
+        // assert
+        Assert.AreEqual(null, defaultString);
+    }
+
+    [Test]
+    public async Task UnwrapOrDefaultAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var someTask = Task.FromResult("Ford Prefect".ToOption());
+
+        // act
+        await someTask.UnwrapOrDefaultAsync();
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, someTask.Status);
+    }
+
+    [Test]
+    public async Task UnwrapOrDefaultAsync_WhenSynchronousContinuationForNone_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var someTask = Task.FromResult(Option<string>.None);
+
+        // act
+        await someTask.UnwrapOrDefaultAsync();
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, someTask.Status);
+    }
+
+    [Test]
+    public void UnwrapOrDefaultAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Option<string>>(new ArgumentException());
+
+        // act
+        async Task Act()
         {
-            // arrange
-            var some = Task.FromResult("hello".ToOption());
-
-            static async Task<string> Continuation()
-            {
-                return await Task.FromResult("world");
-            }
-
-            // act
-            var hello = await some.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
+            await failingTask.UnwrapOrDefaultAsync();
         }
 
-        [Test]
-        public async Task UnwrapOrElseAsyncWithTaskParam_WhenNone_ThenResultIsParameterValue()
-        {
-            // arrange
-            var none = Task.FromResult(result: Option<string>.None);
-
-            static async Task<string> Continuation()
-            {
-                return await Task.FromResult("world");
-            }
-
-            // act
-            var world = await none.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
-
-            // assert
-            Assert.AreEqual("world", actual: world);
-        }
-
-        [Test]
-        public async Task UnwrapOrElseAsyncWithTaskParam_WhenSynchronousContinuation_ThenReturnsSuccessTask()
-        {
-            // arrange
-            var someTask = Task.FromResult("Ford Prefect".ToOption());
-
-            static async Task<string> Continuation()
-            {
-                return await Task.FromResult("Arthur Dent");
-            }
-
-            // act
-            await someTask.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: someTask.Status);
-        }
-
-        [Test]
-        public void
-            UnwrapOrElseAsyncWithTaskParam_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            static async Task<string> Continuation()
-            {
-                return await Task.FromResult("Arthur Dent");
-            }
-
-            // act
-            async Task Act()
-            {
-                await Task.FromException<Option<string>>(new ArgumentException())
-                    .UnwrapOrElseAsync((Func<Task<string>>)Continuation);
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
-        }
-
-        [Test]
-        public async Task UnwrapOrElseAsyncWithTaskParam_WhenUnwrapSomeWithCallBack_ThenNoCallbackInvoked()
-        {
-            // arrange
-            var some = Task.FromResult(Option<string>.Some("hello"));
-            var invoked = false;
-
-            async Task<string> Continuation()
-            {
-                return await Task.Run(() =>
-                {
-                    invoked = true;
-                    return "world";
-                });
-            }
-
-            // act
-            var hello = await some.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
-            Assert.IsFalse(condition: invoked);
-        }
-
-        [Test]
-        public async Task UnwrapOrElseAsyncWithTaskParam_WhenUnwrapNoneWithCallBack_ThenCallbackInvoked()
-        {
-            // arrange
-            var none = Task.FromResult(result: Option<string>.None);
-            var invoked = false;
-
-            async Task<string> Continuation()
-            {
-                return await Task.Run(() =>
-                {
-                    invoked = true;
-                    return "world";
-                });
-            }
-
-            // act
-            var world = await none.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
-
-            // assert
-            Assert.AreEqual("world", actual: world);
-            Assert.IsTrue(condition: invoked);
-        }
-
-        [Test]
-        public void UnwrapOrElseAsyncWithTaskParam_WhenUnwrapNoneWithFunctionTaskIsNull_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            Func<Task<string>> nullFunc = null;
-
-            // act
-            // ReSharper disable once ExpressionIsAlwaysNull
-            async Task Act()
-            {
-                await Task.FromResult(result: Option<string>.None).UnwrapOrElseAsync(fallback: nullFunc);
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentNullException>(code: Act);
-        }
-
-        [Test]
-        public async Task UnwrapOrDefaultAsync_WhenSome_ThenResultIsSomeValue()
-        {
-            // arrange
-            var some = Task.FromResult("hello".ToOption());
-
-            // act
-            var hello = await some.UnwrapOrDefaultAsync();
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
-        }
-
-        [Test]
-        public async Task UnwrapOrDefaultAsync_WhenNone_ThenResultIsDefaultValue()
-        {
-            // arrange
-            var none = Task.FromResult(result: Option<string>.None);
-
-            // act
-            var defaultString = await none.UnwrapOrDefaultAsync();
-
-            // assert
-            Assert.AreEqual(null, actual: defaultString);
-        }
-
-        [Test]
-        public async Task UnwrapOrDefaultAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
-        {
-            // arrange
-            var someTask = Task.FromResult("Ford Prefect".ToOption());
-
-            // act
-            await someTask.UnwrapOrDefaultAsync();
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: someTask.Status);
-        }
-
-        [Test]
-        public async Task UnwrapOrDefaultAsync_WhenSynchronousContinuationForNone_ThenReturnsSuccessTask()
-        {
-            // arrange
-            var someTask = Task.FromResult(result: Option<string>.None);
-
-            // act
-            await someTask.UnwrapOrDefaultAsync();
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: someTask.Status);
-        }
-
-        [Test]
-        public void UnwrapOrDefaultAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            var failingTask = Task.FromException<Option<string>>(new ArgumentException());
-
-            // act
-            async Task Act()
-            {
-                await failingTask.UnwrapOrDefaultAsync();
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
-        }
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/UnwrapAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/UnwrapAsyncTests.cs
@@ -486,7 +486,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         [Test]
         public async Task UnwrapOrElseAsync_WhenUnwrapSomeWithCallBack_ThenNoCallbackInvoked()
         {
-            // arrange 
+            // arrange
             var some = Task.FromResult(Option<string>.Some("hello"));
             var invoked = false;
 

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/UnwrapAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/UnwrapAsyncTests.cs
@@ -16,20 +16,23 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var hello = await some.UnwrapAsync();
 
             // assert
-            Assert.AreEqual("hello", hello);
+            Assert.AreEqual("hello", actual: hello);
         }
 
         [Test]
         public void UnwrapAsync_WhenOptionIsNone_ThenExceptionIsThrown()
         {
             // arrange
-            var none = Task.FromResult(Option<string>.None);
+            var none = Task.FromResult(result: Option<string>.None);
 
             //act
-            async Task Act() => await none.UnwrapAsync();
+            async Task Act()
+            {
+                await none.UnwrapAsync();
+            }
 
             // assert
-            Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(Act);
+            Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(code: Act);
         }
 
         [Test]
@@ -52,10 +55,13 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var failingTask = Task.FromException<Option<string>>(new ArgumentException());
 
             // act
-            async Task Act() => await failingTask.UnwrapAsync();
+            async Task Act()
+            {
+                await failingTask.UnwrapAsync();
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
@@ -68,20 +74,23 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var hello = await some.UnwrapAsync("World");
 
             // assert
-            Assert.AreEqual("hello", hello);
+            Assert.AreEqual("hello", actual: hello);
         }
 
         [Test]
         public void UnwrapAsyncWithErrorMessage_WhenOptionIsNone_ThenExceptionIsThrown()
         {
             // arrange
-            var none = Task.FromResult(Option<string>.None);
+            var none = Task.FromResult(result: Option<string>.None);
 
             // act
-            async Task Act() => await none.UnwrapAsync("World");
+            async Task Act()
+            {
+                await none.UnwrapAsync("World");
+            }
 
             // assert
-            Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(Act);
+            Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(code: Act);
         }
 
         [Test]
@@ -104,30 +113,36 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var failingTask = Task.FromException<Option<string>>(new ArgumentException());
 
             // act
-            async Task Act() => await failingTask.UnwrapAsync("Arthur Dent");
+            async Task Act()
+            {
+                await failingTask.UnwrapAsync("Arthur Dent");
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
         public void UnwrapAsync_WhenErrorFunctionIsNull_ThenArgumentException()
         {
             // arrange
-            var none = Task.FromResult(Option<string>.None);
+            var none = Task.FromResult(result: Option<string>.None);
 
             // act
-            async Task Act() => await none.UnwrapAsync((Func<string>) null);
+            async Task Act()
+            {
+                await none.UnwrapAsync((Func<string>)null);
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentNullException>(Act);
+            Assert.ThrowsAsync<ArgumentNullException>(code: Act);
         }
 
         [Test]
         public void UnwrapAsync_WhenUnwrapOnNoneWithCustomError_ThenExceptionMessageIsCustomErrorMessage()
         {
             // arrange
-            var none = Task.FromResult(Option<string>.None);
+            var none = Task.FromResult(result: Option<string>.None);
 
             // act
             async Task Act()
@@ -138,13 +153,13 @@ namespace Galaxus.Functional.Tests.OptionExtensions
                 }
                 catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
                 {
-                    Assert.AreEqual("YOLO", ex.Message);
+                    Assert.AreEqual("YOLO", actual: ex.Message);
                     throw;
                 }
             }
 
             // assert
-            Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(Act);
+            Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(code: Act);
         }
 
         [Test]
@@ -167,10 +182,13 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var failingTask = Task.FromException<Option<string>>(new ArgumentException());
 
             // act
-            async Task Act() => await failingTask.UnwrapAsync(() => "Arthur Dent");
+            async Task Act()
+            {
+                await failingTask.UnwrapAsync(() => "Arthur Dent");
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
@@ -188,15 +206,15 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             });
 
             // assert
-            Assert.AreEqual("hello", hello);
-            Assert.IsFalse(invoked);
+            Assert.AreEqual("hello", actual: hello);
+            Assert.IsFalse(condition: invoked);
         }
 
         [Test]
         public void UnwrapAsyncWithErrorFunction_WhenUnwrapWithCustomInvokableErrorOnNone_ThenFunctionIsInvoked()
         {
             // arrange
-            var none = Task.FromResult(Option<string>.None);
+            var none = Task.FromResult(result: Option<string>.None);
             var invoked = false;
 
             // act
@@ -212,14 +230,14 @@ namespace Galaxus.Functional.Tests.OptionExtensions
                 }
                 catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
                 {
-                    Assert.AreEqual("YOLO", ex.Message);
+                    Assert.AreEqual("YOLO", actual: ex.Message);
                     throw;
                 }
             }
 
             // assert
-            Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(Act);
-            Assert.IsTrue(invoked);
+            Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(code: Act);
+            Assert.IsTrue(condition: invoked);
         }
 
         [Test]
@@ -227,10 +245,10 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         {
             // arrange
             var someTask = Task.FromResult("Ford Prefect".ToOption());
-            
+
             // act
             await someTask.UnwrapAsync(async () => await Task.FromResult("Arthur Dent"));
-            
+
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: someTask.Status);
         }
@@ -240,12 +258,15 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         {
             // assert
             var failingTask = Task.FromException<Option<string>>(new ArgumentException());
-            
+
             // act
-            async Task Act() => await failingTask.UnwrapAsync(async () => await Task.FromResult("Arthur Dent"));
+            async Task Act()
+            {
+                await failingTask.UnwrapAsync(async () => await Task.FromResult("Arthur Dent"));
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
@@ -263,15 +284,15 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             });
 
             // assert
-            Assert.AreEqual("hello", hello);
-            Assert.IsFalse(invoked);
+            Assert.AreEqual("hello", actual: hello);
+            Assert.IsFalse(condition: invoked);
         }
 
         [Test]
         public void UnwrapAsyncWithErrorFunctionTask_WhenUnwrapWithCustomInvokableErrorOnNone_ThenFunctionIsInvoked()
         {
             // arrange
-            var none = Task.FromResult(Option<string>.None);
+            var none = Task.FromResult(result: Option<string>.None);
             var invoked = false;
 
             // act
@@ -287,14 +308,14 @@ namespace Galaxus.Functional.Tests.OptionExtensions
                 }
                 catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
                 {
-                    Assert.AreEqual("YOLO", ex.Message);
+                    Assert.AreEqual("YOLO", actual: ex.Message);
                     throw;
                 }
             }
 
             // assert
-            Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(Act);
-            Assert.IsTrue(invoked);
+            Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(code: Act);
+            Assert.IsTrue(condition: invoked);
         }
 
         [Test]
@@ -307,20 +328,20 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var hello = await some.UnwrapOrAsync("world");
 
             // assert
-            Assert.AreEqual("hello", hello);
+            Assert.AreEqual("hello", actual: hello);
         }
 
         [Test]
         public async Task UnwrapOrAsync_WhenNone_ThenResultIsParameterValue()
         {
             // arrange
-            var none = Task.FromResult(Option<string>.None);
+            var none = Task.FromResult(result: Option<string>.None);
 
             // act
             var world = await none.UnwrapOrAsync("world");
 
             // assert
-            Assert.AreEqual("world", world);
+            Assert.AreEqual("world", actual: world);
         }
 
         [Test]
@@ -343,10 +364,13 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var failingTask = Task.FromException<Option<string>>(new ArgumentException());
 
             // act
-            async Task Act() => await failingTask.UnwrapOrAsync("Arthur Dent");
+            async Task Act()
+            {
+                await failingTask.UnwrapOrAsync("Arthur Dent");
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
@@ -359,20 +383,20 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var hello = await some.UnwrapOrAsync(Task.FromResult("world"));
 
             // assert
-            Assert.AreEqual("hello", hello);
+            Assert.AreEqual("hello", actual: hello);
         }
 
         [Test]
         public async Task UnwrapOrAsyncWithTaskParam_WhenNone_ThenResultIsParameterValue()
         {
             // arrange
-            var none = Task.FromResult(Option<string>.None);
+            var none = Task.FromResult(result: Option<string>.None);
 
             // act
             var world = await none.UnwrapOrAsync(Task.FromResult("world"));
 
             // assert
-            Assert.AreEqual("world", world);
+            Assert.AreEqual("world", actual: world);
         }
 
         [Test]
@@ -395,10 +419,13 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var failingTask = Task.FromException<Option<string>>(new ArgumentException());
 
             // act
-            async Task Act() => await failingTask.UnwrapOrAsync(Task.FromResult("Arthur Dent"));
+            async Task Act()
+            {
+                await failingTask.UnwrapOrAsync(Task.FromResult("Arthur Dent"));
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
@@ -411,20 +438,20 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var hello = await some.UnwrapOrElseAsync(() => "world");
 
             // assert
-            Assert.AreEqual("hello", hello);
+            Assert.AreEqual("hello", actual: hello);
         }
 
         [Test]
         public async Task UnwrapOrElseAsync_WhenNone_ThenResultIsParameterValue()
         {
             // arrange
-            var none = Task.FromResult(Option<string>.None);
+            var none = Task.FromResult(result: Option<string>.None);
 
             // act
             var world = await none.UnwrapOrElseAsync(() => "world");
 
             // assert
-            Assert.AreEqual("world", world);
+            Assert.AreEqual("world", actual: world);
         }
 
         [Test]
@@ -447,10 +474,13 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var failingTask = Task.FromException<Option<string>>(new ArgumentException());
 
             // act
-            async Task Act() => await failingTask.UnwrapOrElseAsync(() => "Arthur Dent");
+            async Task Act()
+            {
+                await failingTask.UnwrapOrElseAsync(() => "Arthur Dent");
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
@@ -468,15 +498,15 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             });
 
             // assert
-            Assert.AreEqual("hello", hello);
-            Assert.IsFalse(invoked);
+            Assert.AreEqual("hello", actual: hello);
+            Assert.IsFalse(condition: invoked);
         }
 
         [Test]
         public async Task UnwrapOrElseAsync_WhenUnwrapNoneWithCallBack_ThenCallbackInvoked()
         {
             // arrange
-            var none = Task.FromResult(Option<string>.None);
+            var none = Task.FromResult(result: Option<string>.None);
             var invoked = false;
 
             // act
@@ -487,8 +517,8 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             });
 
             // assert
-            Assert.AreEqual("world", world);
-            Assert.IsTrue(invoked);
+            Assert.AreEqual("world", actual: world);
+            Assert.IsTrue(condition: invoked);
         }
 
 
@@ -500,10 +530,13 @@ namespace Galaxus.Functional.Tests.OptionExtensions
 
             // act
             // ReSharper disable once ExpressionIsAlwaysNull
-            async Task Act() => await Task.FromResult(Option<string>.None).UnwrapOrElseAsync(nullFunc);
+            async Task Act()
+            {
+                await Task.FromResult(result: Option<string>.None).UnwrapOrElseAsync(fallback: nullFunc);
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentNullException>(Act);
+            Assert.ThrowsAsync<ArgumentNullException>(code: Act);
         }
 
         [Test]
@@ -511,27 +544,35 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         {
             // arrange
             var some = Task.FromResult("hello".ToOption());
-            static async Task<string> Continuation() => await Task.FromResult("world");
+
+            static async Task<string> Continuation()
+            {
+                return await Task.FromResult("world");
+            }
 
             // act
-            var hello = await some.UnwrapOrElseAsync((Func<Task<string>>) Continuation);
+            var hello = await some.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
 
             // assert
-            Assert.AreEqual("hello", hello);
+            Assert.AreEqual("hello", actual: hello);
         }
 
         [Test]
         public async Task UnwrapOrElseAsyncWithTaskParam_WhenNone_ThenResultIsParameterValue()
         {
             // arrange
-            var none = Task.FromResult(Option<string>.None);
-            static async Task<string> Continuation() => await Task.FromResult("world");
+            var none = Task.FromResult(result: Option<string>.None);
+
+            static async Task<string> Continuation()
+            {
+                return await Task.FromResult("world");
+            }
 
             // act
-            var world = await none.UnwrapOrElseAsync((Func<Task<string>>) Continuation);
+            var world = await none.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
 
             // assert
-            Assert.AreEqual("world", world);
+            Assert.AreEqual("world", actual: world);
         }
 
         [Test]
@@ -539,10 +580,14 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         {
             // arrange
             var someTask = Task.FromResult("Ford Prefect".ToOption());
-            static async Task<string> Continuation() => await Task.FromResult("Arthur Dent");
+
+            static async Task<string> Continuation()
+            {
+                return await Task.FromResult("Arthur Dent");
+            }
 
             // act
-            await someTask.UnwrapOrElseAsync((Func<Task<string>>) Continuation);
+            await someTask.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
 
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: someTask.Status);
@@ -553,15 +598,20 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             UnwrapOrElseAsyncWithTaskParam_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
         {
             // arrange
-            static async Task<string> Continuation() => await Task.FromResult("Arthur Dent");
+            static async Task<string> Continuation()
+            {
+                return await Task.FromResult("Arthur Dent");
+            }
 
             // act
-            async Task Act() =>
+            async Task Act()
+            {
                 await Task.FromException<Option<string>>(new ArgumentException())
-                    .UnwrapOrElseAsync((Func<Task<string>>) Continuation);
+                    .UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
@@ -571,41 +621,45 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var some = Task.FromResult(Option<string>.Some("hello"));
             var invoked = false;
 
-            async Task<string> Continuation() =>
-                await Task.Run(() =>
+            async Task<string> Continuation()
+            {
+                return await Task.Run(() =>
                 {
                     invoked = true;
                     return "world";
                 });
+            }
 
             // act
-            var hello = await some.UnwrapOrElseAsync((Func<Task<string>>) Continuation);
+            var hello = await some.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
 
             // assert
-            Assert.AreEqual("hello", hello);
-            Assert.IsFalse(invoked);
+            Assert.AreEqual("hello", actual: hello);
+            Assert.IsFalse(condition: invoked);
         }
 
         [Test]
         public async Task UnwrapOrElseAsyncWithTaskParam_WhenUnwrapNoneWithCallBack_ThenCallbackInvoked()
         {
             // arrange
-            var none = Task.FromResult(Option<string>.None);
+            var none = Task.FromResult(result: Option<string>.None);
             var invoked = false;
 
-            async Task<string> Continuation() =>
-                await Task.Run(() =>
+            async Task<string> Continuation()
+            {
+                return await Task.Run(() =>
                 {
                     invoked = true;
                     return "world";
                 });
+            }
 
             // act
-            var world = await none.UnwrapOrElseAsync((Func<Task<string>>) Continuation);
+            var world = await none.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
 
             // assert
-            Assert.AreEqual("world", world);
-            Assert.IsTrue(invoked);
+            Assert.AreEqual("world", actual: world);
+            Assert.IsTrue(condition: invoked);
         }
 
         [Test]
@@ -616,10 +670,13 @@ namespace Galaxus.Functional.Tests.OptionExtensions
 
             // act
             // ReSharper disable once ExpressionIsAlwaysNull
-            async Task Act() => await Task.FromResult(Option<string>.None).UnwrapOrElseAsync(nullFunc);
+            async Task Act()
+            {
+                await Task.FromResult(result: Option<string>.None).UnwrapOrElseAsync(fallback: nullFunc);
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentNullException>(Act);
+            Assert.ThrowsAsync<ArgumentNullException>(code: Act);
         }
 
         [Test]
@@ -632,20 +689,20 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var hello = await some.UnwrapOrDefaultAsync();
 
             // assert
-            Assert.AreEqual("hello", hello);
+            Assert.AreEqual("hello", actual: hello);
         }
 
         [Test]
         public async Task UnwrapOrDefaultAsync_WhenNone_ThenResultIsDefaultValue()
         {
             // arrange
-            var none = Task.FromResult(Option<string>.None);
+            var none = Task.FromResult(result: Option<string>.None);
 
             // act
             var defaultString = await none.UnwrapOrDefaultAsync();
 
             // assert
-            Assert.AreEqual(null, defaultString);
+            Assert.AreEqual(null, actual: defaultString);
         }
 
         [Test]
@@ -665,7 +722,7 @@ namespace Galaxus.Functional.Tests.OptionExtensions
         public async Task UnwrapOrDefaultAsync_WhenSynchronousContinuationForNone_ThenReturnsSuccessTask()
         {
             // arrange
-            var someTask = Task.FromResult(Option<string>.None);
+            var someTask = Task.FromResult(result: Option<string>.None);
 
             // act
             await someTask.UnwrapOrDefaultAsync();
@@ -681,10 +738,13 @@ namespace Galaxus.Functional.Tests.OptionExtensions
             var failingTask = Task.FromException<Option<string>>(new ArgumentException());
 
             // act
-            async Task Act() => await failingTask.UnwrapOrDefaultAsync();
+            async Task Act()
+            {
+                await failingTask.UnwrapOrDefaultAsync();
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionTests.cs
@@ -1,504 +1,503 @@
 using System;
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests
+namespace Galaxus.Functional.Tests;
+
+public class OptionTests
 {
-    public class OptionTests
+    [Test]
+    public void Option_ConstructSomeFromValue()
     {
-        [Test]
-        public void Option_ConstructSomeFromValue()
         {
-            {
-                var val = Option<int>.Some(666);
-                Assert.IsTrue(condition: val.IsSome);
-                Assert.AreEqual(666, val.Unwrap());
-            }
-
-            {
-                var val = Option<string>.Some("hello");
-                Assert.IsTrue(condition: val.IsSome);
-                Assert.AreEqual("hello", val.Unwrap());
-            }
+            var val = Option<int>.Some(666);
+            Assert.IsTrue(val.IsSome);
+            Assert.AreEqual(666, val.Unwrap());
         }
 
-        [Test]
-        public void Option_ConstructSomeOrNoneFromNull()
         {
-            {
-                var val = Option<int?>.Some(null);
-                Assert.IsTrue(condition: val.IsSome);
-            }
+            var val = Option<string>.Some("hello");
+            Assert.IsTrue(val.IsSome);
+            Assert.AreEqual("hello", val.Unwrap());
+        }
+    }
 
-            {
-                var val = Option<string>.Some(null);
-                Assert.IsTrue(condition: val.IsNone);
-            }
+    [Test]
+    public void Option_ConstructSomeOrNoneFromNull()
+    {
+        {
+            var val = Option<int?>.Some(null);
+            Assert.IsTrue(val.IsSome);
         }
 
-        [Test]
-        public void Option_ConstructNoneWithDefaultConstructor()
         {
-            {
-                var val = new Option<int>();
-                Assert.IsTrue(condition: val.IsNone);
-            }
+            var val = Option<string>.Some(null);
+            Assert.IsTrue(val.IsNone);
+        }
+    }
 
-            {
-                var val = new Option<string>();
-                Assert.IsTrue(condition: val.IsNone);
-            }
+    [Test]
+    public void Option_ConstructNoneWithDefaultConstructor()
+    {
+        {
+            var val = new Option<int>();
+            Assert.IsTrue(val.IsNone);
         }
 
-        [Test]
-        public void Option_StaticNoneIsNone()
         {
-            Assert.IsTrue(condition: Option<int>.None.IsNone);
-            Assert.IsTrue(condition: Option<string>.None.IsNone);
+            var val = new Option<string>();
+            Assert.IsTrue(val.IsNone);
+        }
+    }
+
+    [Test]
+    public void Option_StaticNoneIsNone()
+    {
+        Assert.IsTrue(Option<int>.None.IsNone);
+        Assert.IsTrue(Option<string>.None.IsNone);
+    }
+
+    [Test]
+    public void Option_MatchSome_Works()
+    {
+        var some = "hello".ToOption();
+
+        {
+            var called = false;
+            some.Match(s => called = true, () => Assert.Fail());
+            Assert.IsTrue(called);
         }
 
-        [Test]
-        public void Option_MatchSome_Works()
         {
-            var some = "hello".ToOption();
+            var called = false;
 
-            {
-                var called = false;
-                some.Match(s => called = true, () => Assert.Fail());
-                Assert.IsTrue(condition: called);
-            }
-
-            {
-                var called = false;
-
-                var number = some.Match(s =>
-                    {
-                        called = true;
-                        return 666;
-                    },
-                    () =>
-                    {
-                        Assert.Fail();
-                        throw new InvalidOperationException();
-                    });
-
-                Assert.AreEqual(666, actual: number);
-                Assert.IsTrue(condition: called);
-            }
-
-            {
-                var called = false;
-                some.IfSome(s => called = true);
-                Assert.IsTrue(condition: called);
-            }
-        }
-
-        [Test]
-        public void Option_MatchNone_Works()
-        {
-            var none = Option<string>.None;
-
-            {
-                var called = false;
-                none.Match(s => Assert.Fail(), () => called = true);
-                Assert.IsTrue(condition: called);
-            }
-
-            {
-                var called = false;
-
-                var number = none.Match(s =>
-                    {
-                        Assert.Fail();
-                        throw new InvalidOperationException();
-                    },
-                    () =>
-                    {
-                        called = true;
-                        return 666;
-                    });
-
-                Assert.AreEqual(666, actual: number);
-                Assert.IsTrue(condition: called);
-            }
-
-            {
-                var called = false;
-                none.IfSome(s => called = true);
-                Assert.IsFalse(condition: called);
-            }
-        }
-
-        [Test]
-        public void Option_MatchThrowsIfMatchArmIsNull()
-        {
-            // SOME
-            Assert.Throws<ArgumentNullException>(() => { 0.ToOption().Match(null, () => { }); });
-            Assert.Throws<ArgumentNullException>(() => { 0.ToOption().IfSome(null); });
-
-            // NONE
-            Assert.Throws<ArgumentNullException>(() => { Option<int>.None.Match(v => { }, null); });
-
-            // SOME and NONE with return value
-            Assert.Throws<ArgumentNullException>(() => { _ = 0.ToOption().Match(null, () => 0); });
-            Assert.Throws<ArgumentNullException>(() => { _ = Option<int>.None.Match(v => v, null); });
-        }
-
-        [Test]
-        public void Option_And()
-        {
-            {
-                var some = "hello".ToOption();
-                var none = Option<string>.None;
-
-                Assert.AreEqual(expected: Option<string>.None, some.And(fallback: none));
-                Assert.AreEqual(expected: Option<string>.None, none.And(fallback: some));
-            }
-
-            {
-                var some1 = "hello".ToOption();
-                var some2 = 123.ToOption();
-
-                Assert.AreEqual(123.ToOption(), some1.And(fallback: some2));
-            }
-
-            {
-                var none1 = Option<string>.None;
-                var none2 = Option<string>.None;
-
-                Assert.AreEqual(expected: Option<string>.None, none1.And(fallback: none2));
-            }
-        }
-
-        [Test]
-        public void Option_AndThen()
-        {
-            Option<int> Square(int i)
-            {
-                return Option<int>.Some(i * i);
-            }
-
-            Option<int> Nope(int i)
-            {
-                return Option<int>.None;
-            }
-
-            Assert.AreEqual(Option<int>.Some(16),
-                Option<int>.Some(2).AndThen(continuation: Square).AndThen(continuation: Square));
-            Assert.AreEqual(expected: Option<int>.None,
-                Option<int>.Some(2).AndThen(continuation: Square).AndThen(continuation: Nope));
-            Assert.AreEqual(expected: Option<int>.None,
-                Option<int>.Some(2).AndThen(continuation: Nope).AndThen(continuation: Square));
-            Assert.AreEqual(expected: Option<int>.None,
-                Option<int>.None.AndThen(continuation: Square).AndThen(continuation: Square));
-        }
-
-        [Test]
-        public void Option_AndThenWithAction()
-        {
-            {
-                var some = "hello".ToOption();
-                var none = Option<string>.None;
-
+            var number = some.Match(s =>
                 {
-                    var invoked = false;
-
-                    Assert.AreEqual(Option<string>.Some("hello"), some.AndThen(_ => invoked = true));
-                    Assert.IsTrue(condition: invoked);
-                }
-
+                    called = true;
+                    return 666;
+                },
+                () =>
                 {
-                    var invoked = false;
+                    Assert.Fail();
+                    throw new InvalidOperationException();
+                });
 
-                    Assert.AreEqual(expected: Option<string>.None, none.AndThen(_ => invoked = true));
-                    Assert.IsFalse(condition: invoked);
-                }
-            }
+            Assert.AreEqual(666, number);
+            Assert.IsTrue(called);
         }
 
-        [Test]
-        public void Option_UnwrapOr()
+        {
+            var called = false;
+            some.IfSome(s => called = true);
+            Assert.IsTrue(called);
+        }
+    }
+
+    [Test]
+    public void Option_MatchNone_Works()
+    {
+        var none = Option<string>.None;
+
+        {
+            var called = false;
+            none.Match(s => Assert.Fail(), () => called = true);
+            Assert.IsTrue(called);
+        }
+
+        {
+            var called = false;
+
+            var number = none.Match(s =>
+                {
+                    Assert.Fail();
+                    throw new InvalidOperationException();
+                },
+                () =>
+                {
+                    called = true;
+                    return 666;
+                });
+
+            Assert.AreEqual(666, number);
+            Assert.IsTrue(called);
+        }
+
+        {
+            var called = false;
+            none.IfSome(s => called = true);
+            Assert.IsFalse(called);
+        }
+    }
+
+    [Test]
+    public void Option_MatchThrowsIfMatchArmIsNull()
+    {
+        // SOME
+        Assert.Throws<ArgumentNullException>(() => { 0.ToOption().Match(null, () => { }); });
+        Assert.Throws<ArgumentNullException>(() => { 0.ToOption().IfSome(null); });
+
+        // NONE
+        Assert.Throws<ArgumentNullException>(() => { Option<int>.None.Match(v => { }, null); });
+
+        // SOME and NONE with return value
+        Assert.Throws<ArgumentNullException>(() => { _ = 0.ToOption().Match(null, () => 0); });
+        Assert.Throws<ArgumentNullException>(() => { _ = Option<int>.None.Match(v => v, null); });
+    }
+
+    [Test]
+    public void Option_And()
+    {
         {
             var some = "hello".ToOption();
             var none = Option<string>.None;
 
-            Assert.AreEqual("hello", some.UnwrapOr("world"));
-            Assert.AreEqual("world", none.UnwrapOr("world"));
+            Assert.AreEqual(Option<string>.None, some.And(none));
+            Assert.AreEqual(Option<string>.None, none.And(some));
         }
 
-        [Test]
-        public void Option_UnwrapOrWithCallback()
         {
-            var some = Option<string>.Some("hello");
+            var some1 = "hello".ToOption();
+            var some2 = 123.ToOption();
+
+            Assert.AreEqual(123.ToOption(), some1.And(some2));
+        }
+
+        {
+            var none1 = Option<string>.None;
+            var none2 = Option<string>.None;
+
+            Assert.AreEqual(Option<string>.None, none1.And(none2));
+        }
+    }
+
+    [Test]
+    public void Option_AndThen()
+    {
+        Option<int> Square(int i)
+        {
+            return Option<int>.Some(i * i);
+        }
+
+        Option<int> Nope(int i)
+        {
+            return Option<int>.None;
+        }
+
+        Assert.AreEqual(Option<int>.Some(16),
+            Option<int>.Some(2).AndThen(Square).AndThen(Square));
+        Assert.AreEqual(Option<int>.None,
+            Option<int>.Some(2).AndThen(Square).AndThen(Nope));
+        Assert.AreEqual(Option<int>.None,
+            Option<int>.Some(2).AndThen(Nope).AndThen(Square));
+        Assert.AreEqual(Option<int>.None,
+            Option<int>.None.AndThen(Square).AndThen(Square));
+    }
+
+    [Test]
+    public void Option_AndThenWithAction()
+    {
+        {
+            var some = "hello".ToOption();
             var none = Option<string>.None;
 
             {
                 var invoked = false;
 
-                Assert.AreEqual("hello", some.UnwrapOrElse(() =>
-                {
-                    invoked = true;
-                    return "world";
-                }));
-
-                Assert.IsFalse(condition: invoked);
+                Assert.AreEqual(Option<string>.Some("hello"), some.AndThen(_ => invoked = true));
+                Assert.IsTrue(invoked);
             }
 
             {
                 var invoked = false;
 
-                Assert.AreEqual("world", none.UnwrapOrElse(() =>
-                {
-                    invoked = true;
-                    return "world";
-                }));
-
-                Assert.IsTrue(condition: invoked);
+                Assert.AreEqual(Option<string>.None, none.AndThen(_ => invoked = true));
+                Assert.IsFalse(invoked);
             }
         }
+    }
 
+    [Test]
+    public void Option_UnwrapOr()
+    {
+        var some = "hello".ToOption();
+        var none = Option<string>.None;
 
-        [Test]
-        public void Option_UnwrapOrWithNullFunc()
+        Assert.AreEqual("hello", some.UnwrapOr("world"));
+        Assert.AreEqual("world", none.UnwrapOr("world"));
+    }
+
+    [Test]
+    public void Option_UnwrapOrWithCallback()
+    {
+        var some = Option<string>.Some("hello");
+        var none = Option<string>.None;
+
         {
-            Assert.Throws<ArgumentNullException>(() => Option<string>.None.UnwrapOrElse(null));
-        }
+            var invoked = false;
 
-        [Test]
-        public void Option_OkOr()
-        {
-            var some = "hello".ToOption();
-            var none = Option<string>.None;
-            Assert.AreEqual(Result<string, int>.FromOk("hello"), some.OkOr(0));
-            Assert.AreEqual(Result<string, int>.FromErr(0), none.OkOr(0));
-        }
-
-        [Test]
-        public void Option_OkOrElse()
-        {
-            var some = "hello".ToOption();
-            var none = Option<string>.None;
-            Assert.AreEqual(Result<string, int>.FromOk("hello"), some.OkOrElse(() => 0));
-            Assert.AreEqual(Result<string, int>.FromErr(0), none.OkOrElse(() => 0));
-        }
-
-        [Test]
-        public void Option_Or()
-        {
-            var some = "hello".ToOption();
-            var none = Option<string>.None;
-
-            Assert.AreEqual("hello".ToOption(), some.Or("world".ToOption()));
-            Assert.AreEqual("world".ToOption(), none.Or("world".ToOption()));
-        }
-
-        [Test]
-        public void Option_OrWithCallback()
-        {
-            var some = Option<string>.Some("hello");
-            var none = Option<string>.None;
-
+            Assert.AreEqual("hello", some.UnwrapOrElse(() =>
             {
-                var invoked = false;
+                invoked = true;
+                return "world";
+            }));
 
-                Assert.AreEqual("hello".ToOption(), some.OrElse(() =>
-                {
-                    invoked = true;
-                    return "world".ToOption();
-                }));
-
-                Assert.IsFalse(condition: invoked);
-            }
-
-            {
-                var invoked = false;
-
-                Assert.AreEqual("world".ToOption(), none.OrElse(() =>
-                {
-                    invoked = true;
-                    return "world".ToOption();
-                }));
-
-                Assert.IsTrue(condition: invoked);
-            }
+            Assert.IsFalse(invoked);
         }
 
-        [Test]
-        public void Option_Xor()
         {
+            var invoked = false;
+
+            Assert.AreEqual("world", none.UnwrapOrElse(() =>
             {
-                var some = 2.ToOption();
-                var none = Option<int>.None;
+                invoked = true;
+                return "world";
+            }));
 
-                Assert.AreEqual(2.ToOption(), some.Xor(fallback: none));
-                Assert.AreEqual(2.ToOption(), none.Xor(fallback: some));
-            }
+            Assert.IsTrue(invoked);
+        }
+    }
 
+
+    [Test]
+    public void Option_UnwrapOrWithNullFunc()
+    {
+        Assert.Throws<ArgumentNullException>(() => Option<string>.None.UnwrapOrElse(null));
+    }
+
+    [Test]
+    public void Option_OkOr()
+    {
+        var some = "hello".ToOption();
+        var none = Option<string>.None;
+        Assert.AreEqual(Result<string, int>.FromOk("hello"), some.OkOr(0));
+        Assert.AreEqual(Result<string, int>.FromErr(0), none.OkOr(0));
+    }
+
+    [Test]
+    public void Option_OkOrElse()
+    {
+        var some = "hello".ToOption();
+        var none = Option<string>.None;
+        Assert.AreEqual(Result<string, int>.FromOk("hello"), some.OkOrElse(() => 0));
+        Assert.AreEqual(Result<string, int>.FromErr(0), none.OkOrElse(() => 0));
+    }
+
+    [Test]
+    public void Option_Or()
+    {
+        var some = "hello".ToOption();
+        var none = Option<string>.None;
+
+        Assert.AreEqual("hello".ToOption(), some.Or("world".ToOption()));
+        Assert.AreEqual("world".ToOption(), none.Or("world".ToOption()));
+    }
+
+    [Test]
+    public void Option_OrWithCallback()
+    {
+        var some = Option<string>.Some("hello");
+        var none = Option<string>.None;
+
+        {
+            var invoked = false;
+
+            Assert.AreEqual("hello".ToOption(), some.OrElse(() =>
             {
-                var some1 = 2.ToOption();
-                var some2 = 2.ToOption();
+                invoked = true;
+                return "world".ToOption();
+            }));
 
-                Assert.AreEqual(expected: Option<int>.None, some1.Xor(fallback: some2));
-            }
-
-            {
-                var none1 = Option<int>.None;
-                var none2 = Option<int>.None;
-
-                Assert.AreEqual(expected: Option<int>.None, none1.Xor(fallback: none2));
-            }
+            Assert.IsFalse(invoked);
         }
 
-        [Test]
-        public void Option_Map()
+        {
+            var invoked = false;
+
+            Assert.AreEqual("world".ToOption(), none.OrElse(() =>
+            {
+                invoked = true;
+                return "world".ToOption();
+            }));
+
+            Assert.IsTrue(invoked);
+        }
+    }
+
+    [Test]
+    public void Option_Xor()
+    {
+        {
+            var some = 2.ToOption();
+            var none = Option<int>.None;
+
+            Assert.AreEqual(2.ToOption(), some.Xor(none));
+            Assert.AreEqual(2.ToOption(), none.Xor(some));
+        }
+
+        {
+            var some1 = 2.ToOption();
+            var some2 = 2.ToOption();
+
+            Assert.AreEqual(Option<int>.None, some1.Xor(some2));
+        }
+
+        {
+            var none1 = Option<int>.None;
+            var none2 = Option<int>.None;
+
+            Assert.AreEqual(Option<int>.None, none1.Xor(none2));
+        }
+    }
+
+    [Test]
+    public void Option_Map()
+    {
+        var some = "hello".ToOption();
+
+        Assert.AreEqual(5.ToOption(), some.Map(s => s.Length));
+    }
+
+    [Test]
+    public void Option_MapOr()
+    {
+        var some = "hello".ToOption();
+        var none = Option<string>.None;
+
+        Assert.AreEqual(5.ToOption(), some.MapOr(s => s.Length.ToOption(), 2.ToOption()));
+        Assert.AreEqual(42.ToOption(), none.MapOr(s => s.Length.ToOption(), 42.ToOption()));
+    }
+
+    [Test]
+    public void Option_ToObject()
+    {
+        var some = (IOption)"hello".ToOption();
+        var none = (IOption)Option<string>.None;
+
+        Assert.AreEqual("hello", some.ToObject());
+        Assert.IsNull(none.ToObject());
+    }
+
+    [Test]
+    public void Option_Unwrap()
+    {
+        var some = "hello".ToOption();
+        var none = Option<string>.None;
+
+        Assert.AreEqual("hello", some.Unwrap());
+        Assert.Throws<AttemptToUnwrapNoneWhenOptionContainedSomeException>(() => none.Unwrap());
+    }
+
+    [Test]
+    public void Option_UnwrapNullFunc()
+    {
+        Assert.Throws<ArgumentNullException>(() => Option<string>.None.Unwrap((Func<string>)null));
+    }
+
+    [Test]
+    public void Option_UnwrapWithCustomError()
+    {
+        var some = "hello".ToOption();
+        var none = Option<string>.None;
+
+        Assert.AreEqual("hello", some.Unwrap("YOLO"));
+        Assert.Throws<AttemptToUnwrapNoneWhenOptionContainedSomeException>(() =>
+        {
+            try
+            {
+                none.Unwrap("YOLO");
+            }
+            catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
+            {
+                Assert.AreEqual("YOLO", ex.Message);
+                throw;
+            }
+        });
+    }
+
+    [Test]
+    public void Option_UnwrapWithCustomInvokableError()
+    {
         {
             var some = "hello".ToOption();
-
-            Assert.AreEqual(5.ToOption(), some.Map(s => s.Length));
+            var invoked = false;
+            Assert.AreEqual("hello", some.Unwrap(() =>
+            {
+                invoked = true;
+                return "YOLO";
+            }));
+            Assert.IsFalse(invoked);
         }
 
-        [Test]
-        public void Option_MapOr()
         {
-            var some = "hello".ToOption();
             var none = Option<string>.None;
-
-            Assert.AreEqual(5.ToOption(), some.MapOr(s => s.Length.ToOption(), 2.ToOption()));
-            Assert.AreEqual(42.ToOption(), none.MapOr(s => s.Length.ToOption(), 42.ToOption()));
-        }
-
-        [Test]
-        public void Option_ToObject()
-        {
-            var some = (IOption)"hello".ToOption();
-            var none = (IOption)Option<string>.None;
-
-            Assert.AreEqual("hello", some.ToObject());
-            Assert.IsNull(none.ToObject());
-        }
-
-        [Test]
-        public void Option_Unwrap()
-        {
-            var some = "hello".ToOption();
-            var none = Option<string>.None;
-
-            Assert.AreEqual("hello", some.Unwrap());
-            Assert.Throws<AttemptToUnwrapNoneWhenOptionContainedSomeException>(() => none.Unwrap());
-        }
-
-        [Test]
-        public void Option_UnwrapNullFunc()
-        {
-            Assert.Throws<ArgumentNullException>(() => Option<string>.None.Unwrap((Func<string>)null));
-        }
-
-        [Test]
-        public void Option_UnwrapWithCustomError()
-        {
-            var some = "hello".ToOption();
-            var none = Option<string>.None;
-
-            Assert.AreEqual("hello", some.Unwrap("YOLO"));
+            var invoked = false;
             Assert.Throws<AttemptToUnwrapNoneWhenOptionContainedSomeException>(() =>
             {
                 try
                 {
-                    none.Unwrap("YOLO");
+                    none.Unwrap(() =>
+                    {
+                        invoked = true;
+                        return "YOLO";
+                    });
                 }
                 catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
                 {
-                    Assert.AreEqual("YOLO", actual: ex.Message);
+                    Assert.AreEqual("YOLO", ex.Message);
                     throw;
                 }
             });
+
+            Assert.IsTrue(invoked);
         }
+    }
 
-        [Test]
-        public void Option_UnwrapWithCustomInvokableError()
-        {
-            {
-                var some = "hello".ToOption();
-                var invoked = false;
-                Assert.AreEqual("hello", some.Unwrap(() =>
-                {
-                    invoked = true;
-                    return "YOLO";
-                }));
-                Assert.IsFalse(condition: invoked);
-            }
+    [Test]
+    public void Option_EqualsSameType()
+    {
+        var one = 1.ToOption();
+        var oneClone = 1.ToOption();
+        var two = 2.ToOption();
+        var none = new Option<int>();
 
-            {
-                var none = Option<string>.None;
-                var invoked = false;
-                Assert.Throws<AttemptToUnwrapNoneWhenOptionContainedSomeException>(() =>
-                {
-                    try
-                    {
-                        none.Unwrap(() =>
-                        {
-                            invoked = true;
-                            return "YOLO";
-                        });
-                    }
-                    catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
-                    {
-                        Assert.AreEqual("YOLO", actual: ex.Message);
-                        throw;
-                    }
-                });
+        Assert.AreEqual(one, oneClone);
+        Assert.AreEqual(oneClone, one);
 
-                Assert.IsTrue(condition: invoked);
-            }
-        }
+        Assert.AreNotEqual(one, two);
+        Assert.AreNotEqual(two, one);
 
-        [Test]
-        public void Option_EqualsSameType()
-        {
-            var one = 1.ToOption();
-            var oneClone = 1.ToOption();
-            var two = 2.ToOption();
-            var none = new Option<int>();
+        Assert.AreNotEqual(none, one);
+        Assert.AreNotEqual(one, none);
+    }
 
-            Assert.AreEqual(expected: one, actual: oneClone);
-            Assert.AreEqual(expected: oneClone, actual: one);
+    [Test]
+    public void Option_EqualsOtherType()
+    {
+        var one = 1.ToOption();
+        var oneAsObject = 1.ToOption<object>();
+        var none = new Option<object>();
 
-            Assert.AreNotEqual(expected: one, actual: two);
-            Assert.AreNotEqual(expected: two, actual: one);
+        Assert.AreNotEqual(one, oneAsObject);
+        Assert.AreNotEqual(oneAsObject, one);
 
-            Assert.AreNotEqual(expected: none, actual: one);
-            Assert.AreNotEqual(expected: one, actual: none);
-        }
+        Assert.AreNotEqual(none, one);
+        Assert.AreNotEqual(one, none);
+    }
 
-        [Test]
-        public void Option_EqualsOtherType()
-        {
-            var one = 1.ToOption();
-            var oneAsObject = 1.ToOption<object>();
-            var none = new Option<object>();
+    [Test]
+    public void Option_HashAreEqualIfInstancesAreEqual()
+    {
+        Assert.AreEqual("hello".ToOption().GetHashCode(), "hello".ToOption().GetHashCode());
+        Assert.AreEqual(1.ToOption().GetHashCode(), 1.ToOption().GetHashCode());
+        Assert.AreEqual(new Option<int>().GetHashCode(), new Option<int>().GetHashCode());
+    }
 
-            Assert.AreNotEqual(expected: one, actual: oneAsObject);
-            Assert.AreNotEqual(expected: oneAsObject, actual: one);
+    [Test]
+    public void Option_Map_AutoMap()
+    {
+        Assert.AreEqual(true.ToString(), true.ToOption().Map(b => b.ToString()).Unwrap());
 
-            Assert.AreNotEqual(expected: none, actual: one);
-            Assert.AreNotEqual(expected: one, actual: none);
-        }
+        Assert.AreEqual(Option<string>.None, Option<string>.None.Map(b => "foobar"));
 
-        [Test]
-        public void Option_HashAreEqualIfInstancesAreEqual()
-        {
-            Assert.AreEqual("hello".ToOption().GetHashCode(), "hello".ToOption().GetHashCode());
-            Assert.AreEqual(1.ToOption().GetHashCode(), 1.ToOption().GetHashCode());
-            Assert.AreEqual(new Option<int>().GetHashCode(), new Option<int>().GetHashCode());
-        }
-
-        [Test]
-        public void Option_Map_AutoMap()
-        {
-            Assert.AreEqual(true.ToString(), true.ToOption().Map(b => b.ToString()).Unwrap());
-
-            Assert.AreEqual(expected: Option<string>.None, Option<string>.None.Map(b => "foobar"));
-
-            Assert.Throws<ArgumentNullException>(() => "Foobar".ToOption().Map<string>(null));
-        }
+        Assert.Throws<ArgumentNullException>(() => "Foobar".ToOption().Map<string>(null));
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionTests.cs
@@ -1,5 +1,5 @@
-using NUnit.Framework;
 using System;
+using NUnit.Framework;
 
 namespace Galaxus.Functional.Tests
 {
@@ -10,13 +10,13 @@ namespace Galaxus.Functional.Tests
         {
             {
                 var val = Option<int>.Some(666);
-                Assert.IsTrue(val.IsSome);
+                Assert.IsTrue(condition: val.IsSome);
                 Assert.AreEqual(666, val.Unwrap());
             }
 
             {
                 var val = Option<string>.Some("hello");
-                Assert.IsTrue(val.IsSome);
+                Assert.IsTrue(condition: val.IsSome);
                 Assert.AreEqual("hello", val.Unwrap());
             }
         }
@@ -26,12 +26,12 @@ namespace Galaxus.Functional.Tests
         {
             {
                 var val = Option<int?>.Some(null);
-                Assert.IsTrue(val.IsSome);
+                Assert.IsTrue(condition: val.IsSome);
             }
 
             {
                 var val = Option<string>.Some(null);
-                Assert.IsTrue(val.IsNone);
+                Assert.IsTrue(condition: val.IsNone);
             }
         }
 
@@ -40,20 +40,20 @@ namespace Galaxus.Functional.Tests
         {
             {
                 var val = new Option<int>();
-                Assert.IsTrue(val.IsNone);
+                Assert.IsTrue(condition: val.IsNone);
             }
 
             {
                 var val = new Option<string>();
-                Assert.IsTrue(val.IsNone);
+                Assert.IsTrue(condition: val.IsNone);
             }
         }
 
         [Test]
         public void Option_StaticNoneIsNone()
         {
-            Assert.IsTrue(Option<int>.None.IsNone);
-            Assert.IsTrue(Option<string>.None.IsNone);
+            Assert.IsTrue(condition: Option<int>.None.IsNone);
+            Assert.IsTrue(condition: Option<string>.None.IsNone);
         }
 
         [Test]
@@ -62,32 +62,33 @@ namespace Galaxus.Functional.Tests
             var some = "hello".ToOption();
 
             {
-                bool called = false;
+                var called = false;
                 some.Match(s => called = true, () => Assert.Fail());
-                Assert.IsTrue(called);
+                Assert.IsTrue(condition: called);
             }
 
             {
-                bool called = false;
+                var called = false;
 
                 var number = some.Match(s =>
-                {
-                    called = true;
-                    return 666;
-                },
-                () => {
-                    Assert.Fail();
-                    throw new InvalidOperationException();
-                });
+                    {
+                        called = true;
+                        return 666;
+                    },
+                    () =>
+                    {
+                        Assert.Fail();
+                        throw new InvalidOperationException();
+                    });
 
-                Assert.AreEqual(666, number);
-                Assert.IsTrue(called);
+                Assert.AreEqual(666, actual: number);
+                Assert.IsTrue(condition: called);
             }
 
             {
-                bool called = false;
+                var called = false;
                 some.IfSome(s => called = true);
-                Assert.IsTrue(called);
+                Assert.IsTrue(condition: called);
             }
         }
 
@@ -97,32 +98,33 @@ namespace Galaxus.Functional.Tests
             var none = Option<string>.None;
 
             {
-                bool called = false;
+                var called = false;
                 none.Match(s => Assert.Fail(), () => called = true);
-                Assert.IsTrue(called);
+                Assert.IsTrue(condition: called);
             }
 
             {
-                bool called = false;
+                var called = false;
 
                 var number = none.Match(s =>
-                {
-                    Assert.Fail();
-                    throw new InvalidOperationException();
-                },
-                () => {
-                    called = true;
-                    return 666;
-                });
+                    {
+                        Assert.Fail();
+                        throw new InvalidOperationException();
+                    },
+                    () =>
+                    {
+                        called = true;
+                        return 666;
+                    });
 
-                Assert.AreEqual(666, number);
-                Assert.IsTrue(called);
+                Assert.AreEqual(666, actual: number);
+                Assert.IsTrue(condition: called);
             }
 
             {
-                bool called = false;
+                var called = false;
                 none.IfSome(s => called = true);
-                Assert.IsFalse(called);
+                Assert.IsFalse(condition: called);
             }
         }
 
@@ -148,35 +150,46 @@ namespace Galaxus.Functional.Tests
                 var some = "hello".ToOption();
                 var none = Option<string>.None;
 
-                Assert.AreEqual(Option<string>.None, some.And(none));
-                Assert.AreEqual(Option<string>.None, none.And(some));
+                Assert.AreEqual(expected: Option<string>.None, some.And(fallback: none));
+                Assert.AreEqual(expected: Option<string>.None, none.And(fallback: some));
             }
 
             {
                 var some1 = "hello".ToOption();
                 var some2 = 123.ToOption();
 
-                Assert.AreEqual(123.ToOption(), some1.And(some2));
+                Assert.AreEqual(123.ToOption(), some1.And(fallback: some2));
             }
 
             {
                 var none1 = Option<string>.None;
                 var none2 = Option<string>.None;
 
-                Assert.AreEqual(Option<string>.None, none1.And(none2));
+                Assert.AreEqual(expected: Option<string>.None, none1.And(fallback: none2));
             }
         }
 
         [Test]
         public void Option_AndThen()
         {
-            Option<int> Square(int i) => Option<int>.Some(i * i);
-            Option<int> Nope(int i) => Option<int>.None;
+            Option<int> Square(int i)
+            {
+                return Option<int>.Some(i * i);
+            }
 
-            Assert.AreEqual(Option<int>.Some(16), Option<int>.Some(2).AndThen(Square).AndThen(Square));
-            Assert.AreEqual(Option<int>.None, Option<int>.Some(2).AndThen(Square).AndThen(Nope));
-            Assert.AreEqual(Option<int>.None, Option<int>.Some(2).AndThen(Nope).AndThen(Square));
-            Assert.AreEqual(Option<int>.None, Option<int>.None.AndThen(Square).AndThen(Square));
+            Option<int> Nope(int i)
+            {
+                return Option<int>.None;
+            }
+
+            Assert.AreEqual(Option<int>.Some(16),
+                Option<int>.Some(2).AndThen(continuation: Square).AndThen(continuation: Square));
+            Assert.AreEqual(expected: Option<int>.None,
+                Option<int>.Some(2).AndThen(continuation: Square).AndThen(continuation: Nope));
+            Assert.AreEqual(expected: Option<int>.None,
+                Option<int>.Some(2).AndThen(continuation: Nope).AndThen(continuation: Square));
+            Assert.AreEqual(expected: Option<int>.None,
+                Option<int>.None.AndThen(continuation: Square).AndThen(continuation: Square));
         }
 
         [Test]
@@ -187,17 +200,17 @@ namespace Galaxus.Functional.Tests
                 var none = Option<string>.None;
 
                 {
-                    bool invoked = false;
+                    var invoked = false;
 
                     Assert.AreEqual(Option<string>.Some("hello"), some.AndThen(_ => invoked = true));
-                    Assert.IsTrue(invoked);
+                    Assert.IsTrue(condition: invoked);
                 }
 
                 {
-                    bool invoked = false;
+                    var invoked = false;
 
-                    Assert.AreEqual(Option<string>.None, none.AndThen(_ => invoked = true));
-                    Assert.IsFalse(invoked);
+                    Assert.AreEqual(expected: Option<string>.None, none.AndThen(_ => invoked = true));
+                    Assert.IsFalse(condition: invoked);
                 }
             }
         }
@@ -219,7 +232,7 @@ namespace Galaxus.Functional.Tests
             var none = Option<string>.None;
 
             {
-                bool invoked = false;
+                var invoked = false;
 
                 Assert.AreEqual("hello", some.UnwrapOrElse(() =>
                 {
@@ -227,11 +240,11 @@ namespace Galaxus.Functional.Tests
                     return "world";
                 }));
 
-                Assert.IsFalse(invoked);
+                Assert.IsFalse(condition: invoked);
             }
 
             {
-                bool invoked = false;
+                var invoked = false;
 
                 Assert.AreEqual("world", none.UnwrapOrElse(() =>
                 {
@@ -239,7 +252,7 @@ namespace Galaxus.Functional.Tests
                     return "world";
                 }));
 
-                Assert.IsTrue(invoked);
+                Assert.IsTrue(condition: invoked);
             }
         }
 
@@ -285,7 +298,7 @@ namespace Galaxus.Functional.Tests
             var none = Option<string>.None;
 
             {
-                bool invoked = false;
+                var invoked = false;
 
                 Assert.AreEqual("hello".ToOption(), some.OrElse(() =>
                 {
@@ -293,11 +306,11 @@ namespace Galaxus.Functional.Tests
                     return "world".ToOption();
                 }));
 
-                Assert.IsFalse(invoked);
+                Assert.IsFalse(condition: invoked);
             }
 
             {
-                bool invoked = false;
+                var invoked = false;
 
                 Assert.AreEqual("world".ToOption(), none.OrElse(() =>
                 {
@@ -305,7 +318,7 @@ namespace Galaxus.Functional.Tests
                     return "world".ToOption();
                 }));
 
-                Assert.IsTrue(invoked);
+                Assert.IsTrue(condition: invoked);
             }
         }
 
@@ -316,22 +329,22 @@ namespace Galaxus.Functional.Tests
                 var some = 2.ToOption();
                 var none = Option<int>.None;
 
-                Assert.AreEqual(2.ToOption(), some.Xor(none));
-                Assert.AreEqual(2.ToOption(), none.Xor(some));
+                Assert.AreEqual(2.ToOption(), some.Xor(fallback: none));
+                Assert.AreEqual(2.ToOption(), none.Xor(fallback: some));
             }
 
             {
                 var some1 = 2.ToOption();
                 var some2 = 2.ToOption();
 
-                Assert.AreEqual(Option<int>.None, some1.Xor(some2));
+                Assert.AreEqual(expected: Option<int>.None, some1.Xor(fallback: some2));
             }
 
             {
                 var none1 = Option<int>.None;
                 var none2 = Option<int>.None;
 
-                Assert.AreEqual(Option<int>.None, none1.Xor(none2));
+                Assert.AreEqual(expected: Option<int>.None, none1.Xor(fallback: none2));
             }
         }
 
@@ -376,7 +389,7 @@ namespace Galaxus.Functional.Tests
         [Test]
         public void Option_UnwrapNullFunc()
         {
-            Assert.Throws<ArgumentNullException>(() => Option<string>.None.Unwrap((Func<string>) null));
+            Assert.Throws<ArgumentNullException>(() => Option<string>.None.Unwrap((Func<string>)null));
         }
 
         [Test]
@@ -386,14 +399,15 @@ namespace Galaxus.Functional.Tests
             var none = Option<string>.None;
 
             Assert.AreEqual("hello", some.Unwrap("YOLO"));
-            Assert.Throws<AttemptToUnwrapNoneWhenOptionContainedSomeException>(() => {
+            Assert.Throws<AttemptToUnwrapNoneWhenOptionContainedSomeException>(() =>
+            {
                 try
                 {
                     none.Unwrap("YOLO");
                 }
                 catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
                 {
-                    Assert.AreEqual("YOLO", ex.Message);
+                    Assert.AreEqual("YOLO", actual: ex.Message);
                     throw;
                 }
             });
@@ -404,28 +418,36 @@ namespace Galaxus.Functional.Tests
         {
             {
                 var some = "hello".ToOption();
-                bool invoked = false;
-                Assert.AreEqual("hello", some.Unwrap(() => { invoked = true; return "YOLO"; }));
-                Assert.IsFalse(invoked);
+                var invoked = false;
+                Assert.AreEqual("hello", some.Unwrap(() =>
+                {
+                    invoked = true;
+                    return "YOLO";
+                }));
+                Assert.IsFalse(condition: invoked);
             }
 
             {
                 var none = Option<string>.None;
-                bool invoked = false;
+                var invoked = false;
                 Assert.Throws<AttemptToUnwrapNoneWhenOptionContainedSomeException>(() =>
                 {
                     try
                     {
-                        none.Unwrap(() => { invoked = true; return "YOLO"; });
+                        none.Unwrap(() =>
+                        {
+                            invoked = true;
+                            return "YOLO";
+                        });
                     }
                     catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
                     {
-                        Assert.AreEqual("YOLO", ex.Message);
+                        Assert.AreEqual("YOLO", actual: ex.Message);
                         throw;
                     }
                 });
 
-                Assert.IsTrue(invoked);
+                Assert.IsTrue(condition: invoked);
             }
         }
 
@@ -437,14 +459,14 @@ namespace Galaxus.Functional.Tests
             var two = 2.ToOption();
             var none = new Option<int>();
 
-            Assert.AreEqual(one, oneClone);
-            Assert.AreEqual(oneClone, one);
+            Assert.AreEqual(expected: one, actual: oneClone);
+            Assert.AreEqual(expected: oneClone, actual: one);
 
-            Assert.AreNotEqual(one, two);
-            Assert.AreNotEqual(two, one);
+            Assert.AreNotEqual(expected: one, actual: two);
+            Assert.AreNotEqual(expected: two, actual: one);
 
-            Assert.AreNotEqual(none, one);
-            Assert.AreNotEqual(one, none);
+            Assert.AreNotEqual(expected: none, actual: one);
+            Assert.AreNotEqual(expected: one, actual: none);
         }
 
         [Test]
@@ -454,11 +476,11 @@ namespace Galaxus.Functional.Tests
             var oneAsObject = 1.ToOption<object>();
             var none = new Option<object>();
 
-            Assert.AreNotEqual(one, oneAsObject);
-            Assert.AreNotEqual(oneAsObject, one);
+            Assert.AreNotEqual(expected: one, actual: oneAsObject);
+            Assert.AreNotEqual(expected: oneAsObject, actual: one);
 
-            Assert.AreNotEqual(none, one);
-            Assert.AreNotEqual(one, none);
+            Assert.AreNotEqual(expected: none, actual: one);
+            Assert.AreNotEqual(expected: one, actual: none);
         }
 
         [Test]
@@ -474,7 +496,7 @@ namespace Galaxus.Functional.Tests
         {
             Assert.AreEqual(true.ToString(), true.ToOption().Map(b => b.ToString()).Unwrap());
 
-            Assert.AreEqual(Option<string>.None, Option<string>.None.Map(b => "foobar"));
+            Assert.AreEqual(expected: Option<string>.None, Option<string>.None.Map(b => "foobar"));
 
             Assert.Throws<ArgumentNullException>(() => "Foobar".ToOption().Map<string>(null));
         }

--- a/Galaxus.Functional.Tests/(Option)/OptionTests_Contains.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionTests_Contains.cs
@@ -9,7 +9,7 @@ namespace Galaxus.Functional.Tests
         {
             var option = Option<string>.None;
             var contains = option.Contains("hello");
-            Assert.IsFalse(contains);
+            Assert.IsFalse(condition: contains);
         }
 
         [Test]
@@ -17,7 +17,7 @@ namespace Galaxus.Functional.Tests
         {
             var option = "world".ToOption();
             var contains = option.Contains("hello");
-            Assert.IsFalse(contains);
+            Assert.IsFalse(condition: contains);
         }
 
         [Test]
@@ -25,7 +25,7 @@ namespace Galaxus.Functional.Tests
         {
             var option = "hello".ToOption();
             var contains = option.Contains("hello");
-            Assert.IsTrue(contains);
+            Assert.IsTrue(condition: contains);
         }
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionTests_Contains.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionTests_Contains.cs
@@ -1,31 +1,30 @@
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests
+namespace Galaxus.Functional.Tests;
+
+public class OptionTests_Contains
 {
-    public class OptionTests_Contains
+    [Test]
+    public void Option_NoneContainsValue_ReturnsFalse()
     {
-        [Test]
-        public void Option_NoneContainsValue_ReturnsFalse()
-        {
-            var option = Option<string>.None;
-            var contains = option.Contains("hello");
-            Assert.IsFalse(condition: contains);
-        }
+        var option = Option<string>.None;
+        var contains = option.Contains("hello");
+        Assert.IsFalse(contains);
+    }
 
-        [Test]
-        public void Option_SomeContainsValue_ReturnsFalse()
-        {
-            var option = "world".ToOption();
-            var contains = option.Contains("hello");
-            Assert.IsFalse(condition: contains);
-        }
+    [Test]
+    public void Option_SomeContainsValue_ReturnsFalse()
+    {
+        var option = "world".ToOption();
+        var contains = option.Contains("hello");
+        Assert.IsFalse(contains);
+    }
 
-        [Test]
-        public void Option_SomeContainsValue_ReturnsTrue()
-        {
-            var option = "hello".ToOption();
-            var contains = option.Contains("hello");
-            Assert.IsTrue(condition: contains);
-        }
+    [Test]
+    public void Option_SomeContainsValue_ReturnsTrue()
+    {
+        var option = "hello".ToOption();
+        var contains = option.Contains("hello");
+        Assert.IsTrue(contains);
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionTests_Filter.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionTests_Filter.cs
@@ -9,7 +9,7 @@ namespace Galaxus.Functional.Tests
         {
             var option = Option<string>.None;
             option = option.Filter(val => val == "hello");
-            Assert.IsTrue(option.IsNone);
+            Assert.IsTrue(condition: option.IsNone);
         }
 
         [Test]
@@ -17,7 +17,7 @@ namespace Galaxus.Functional.Tests
         {
             var option = "hello".ToOption();
             option = option.Filter(val => val == "hello");
-            Assert.IsTrue(option.IsSome);
+            Assert.IsTrue(condition: option.IsSome);
         }
 
         [Test]
@@ -25,7 +25,7 @@ namespace Galaxus.Functional.Tests
         {
             var option = "world".ToOption();
             option = option.Filter(val => val == "hello");
-            Assert.IsTrue(option.IsNone);
+            Assert.IsTrue(condition: option.IsNone);
         }
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionTests_Filter.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionTests_Filter.cs
@@ -1,31 +1,30 @@
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests
+namespace Galaxus.Functional.Tests;
+
+public class OptionTests_Filter
 {
-    public class OptionTests_Filter
+    [Test]
+    public void Option_FilterValueOnNone_ReturnsNone()
     {
-        [Test]
-        public void Option_FilterValueOnNone_ReturnsNone()
-        {
-            var option = Option<string>.None;
-            option = option.Filter(val => val == "hello");
-            Assert.IsTrue(condition: option.IsNone);
-        }
+        var option = Option<string>.None;
+        option = option.Filter(val => val == "hello");
+        Assert.IsTrue(option.IsNone);
+    }
 
-        [Test]
-        public void Option_FilterValueOnSome_ReturnsSome()
-        {
-            var option = "hello".ToOption();
-            option = option.Filter(val => val == "hello");
-            Assert.IsTrue(condition: option.IsSome);
-        }
+    [Test]
+    public void Option_FilterValueOnSome_ReturnsSome()
+    {
+        var option = "hello".ToOption();
+        option = option.Filter(val => val == "hello");
+        Assert.IsTrue(option.IsSome);
+    }
 
-        [Test]
-        public void Option_FilterValueOnSome_ReturnsNone()
-        {
-            var option = "world".ToOption();
-            option = option.Filter(val => val == "hello");
-            Assert.IsTrue(condition: option.IsNone);
-        }
+    [Test]
+    public void Option_FilterValueOnSome_ReturnsNone()
+    {
+        var option = "world".ToOption();
+        option = option.Filter(val => val == "hello");
+        Assert.IsTrue(option.IsNone);
     }
 }

--- a/Galaxus.Functional.Tests/(Option)/OptionTests_Transpose.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionTests_Transpose.cs
@@ -10,8 +10,8 @@ namespace Galaxus.Functional.Tests
             var option = Option<Result<int, string>>.None;
             var result = option.Transpose();
 
-            Assert.IsTrue(result.IsOk);
-            Assert.IsTrue(result.Unwrap().IsNone);
+            Assert.IsTrue(condition: result.IsOk);
+            Assert.IsTrue(condition: result.Unwrap().IsNone);
         }
 
         [Test]
@@ -20,7 +20,7 @@ namespace Galaxus.Functional.Tests
             var option = 3.ToOk<int, string>().ToOption();
             var result = option.Transpose();
 
-            Assert.IsTrue(result.IsOk);
+            Assert.IsTrue(condition: result.IsOk);
             Assert.AreEqual(result.Unwrap().Unwrap(), 3);
         }
 
@@ -30,7 +30,7 @@ namespace Galaxus.Functional.Tests
             var option = "error".ToErr<int, string>().ToOption();
             var result = option.Transpose();
 
-            Assert.IsTrue(result.IsErr);
+            Assert.IsTrue(condition: result.IsErr);
             Assert.AreEqual("error", result.Err.Unwrap());
         }
     }

--- a/Galaxus.Functional.Tests/(Option)/OptionTests_Transpose.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionTests_Transpose.cs
@@ -1,37 +1,36 @@
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests
+namespace Galaxus.Functional.Tests;
+
+public class OptionTests_Transpose
 {
-    public class OptionTests_Transpose
+    [Test]
+    public void Option_TransposeNone_ReturnsOkNone()
     {
-        [Test]
-        public void Option_TransposeNone_ReturnsOkNone()
-        {
-            var option = Option<Result<int, string>>.None;
-            var result = option.Transpose();
+        var option = Option<Result<int, string>>.None;
+        var result = option.Transpose();
 
-            Assert.IsTrue(condition: result.IsOk);
-            Assert.IsTrue(condition: result.Unwrap().IsNone);
-        }
+        Assert.IsTrue(result.IsOk);
+        Assert.IsTrue(result.Unwrap().IsNone);
+    }
 
-        [Test]
-        public void Option_TransposeSomeOk_ReturnsOkSome()
-        {
-            var option = 3.ToOk<int, string>().ToOption();
-            var result = option.Transpose();
+    [Test]
+    public void Option_TransposeSomeOk_ReturnsOkSome()
+    {
+        var option = 3.ToOk<int, string>().ToOption();
+        var result = option.Transpose();
 
-            Assert.IsTrue(condition: result.IsOk);
-            Assert.AreEqual(result.Unwrap().Unwrap(), 3);
-        }
+        Assert.IsTrue(result.IsOk);
+        Assert.AreEqual(result.Unwrap().Unwrap(), 3);
+    }
 
-        [Test]
-        public void Option_TransposeSomeErr_ReturnsErr()
-        {
-            var option = "error".ToErr<int, string>().ToOption();
-            var result = option.Transpose();
+    [Test]
+    public void Option_TransposeSomeErr_ReturnsErr()
+    {
+        var option = "error".ToErr<int, string>().ToOption();
+        var result = option.Transpose();
 
-            Assert.IsTrue(condition: result.IsErr);
-            Assert.AreEqual("error", result.Err.Unwrap());
-        }
+        Assert.IsTrue(result.IsErr);
+        Assert.AreEqual("error", result.Err.Unwrap());
     }
 }

--- a/Galaxus.Functional.Tests/(Result)/ResultExtensions/AndThenAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultExtensions/AndThenAsyncTests.cs
@@ -3,78 +3,77 @@ using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests.ResultExtensions
+namespace Galaxus.Functional.Tests.ResultExtensions;
+
+public class AndThenAsyncTests
 {
-    public class AndThenAsyncTests
+    [Test]
+    public void AndThenAsync_PreviousTaskThrewArgumentException_ArgumentExceptionIsThrown()
     {
-        [Test]
-        public void AndThenAsync_PreviousTaskThrewArgumentException_ArgumentExceptionIsThrown()
+        // arrange
+        const string continuationResult = "b";
+
+        async Task<Result<string, string>> Continuation(string s)
         {
-            // arrange
-            const string continuationResult = "b";
-
-            async Task<Result<string, string>> Continuation(string s)
-            {
-                return await Task.FromResult(Result<string, string>.FromOk(ok: continuationResult));
-            }
-
-            // act
-            async Task Act()
-            {
-                await Task.FromException<Result<string, string>>(new ArgumentException())
-                    .AndThenAsync((Func<string, Task<Result<string, string>>>)Continuation);
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
+            return await Task.FromResult(Result<string, string>.FromOk(continuationResult));
         }
 
-        [Test]
-        public void AndThenAsync_PreviousTaskWasCanceled_TaskCanceledExceptionIsThrown()
+        // act
+        async Task Act()
         {
-            // arrange
-            const string continuationResult = "b";
-
-            async Task<Result<string, string>> Continuation(string s)
-            {
-                return await Task.FromResult(Result<string, string>.FromOk(ok: continuationResult));
-            }
-
-            var cancellationTokenSource = new CancellationTokenSource();
-
-            // act
-            cancellationTokenSource.Cancel();
-
-            async Task Act()
-            {
-                await Task.FromCanceled<Result<string, string>>(cancellationToken: cancellationTokenSource.Token)
-                    .AndThenAsync((Func<string, Task<Result<string, string>>>)Continuation);
-            }
-
-            // assert
-            Assert.ThrowsAsync<TaskCanceledException>(code: Act);
+            await Task.FromException<Result<string, string>>(new ArgumentException())
+                .AndThenAsync((Func<string, Task<Result<string, string>>>)Continuation);
         }
 
-        [Test]
-        public async Task AndThenAsync_SynchronousContinuation_ReturnsSuccessTask()
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public void AndThenAsync_PreviousTaskWasCanceled_TaskCanceledExceptionIsThrown()
+    {
+        // arrange
+        const string continuationResult = "b";
+
+        async Task<Result<string, string>> Continuation(string s)
         {
-            // arrange
-            const string initialResult = "a";
-            const string continuationResult = "b";
-
-            Result<string, string> Continuation(string s)
-            {
-                return Result<string, string>.FromOk(ok: continuationResult);
-            }
-
-            var resultTask = Task.FromResult(Result<string, string>.FromOk(ok: initialResult))
-                .AndThenAsync((Func<string, Result<string, string>>)Continuation);
-
-            // act
-            await resultTask;
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: resultTask.Status);
+            return await Task.FromResult(Result<string, string>.FromOk(continuationResult));
         }
+
+        var cancellationTokenSource = new CancellationTokenSource();
+
+        // act
+        cancellationTokenSource.Cancel();
+
+        async Task Act()
+        {
+            await Task.FromCanceled<Result<string, string>>(cancellationTokenSource.Token)
+                .AndThenAsync((Func<string, Task<Result<string, string>>>)Continuation);
+        }
+
+        // assert
+        Assert.ThrowsAsync<TaskCanceledException>(Act);
+    }
+
+    [Test]
+    public async Task AndThenAsync_SynchronousContinuation_ReturnsSuccessTask()
+    {
+        // arrange
+        const string initialResult = "a";
+        const string continuationResult = "b";
+
+        Result<string, string> Continuation(string s)
+        {
+            return Result<string, string>.FromOk(continuationResult);
+        }
+
+        var resultTask = Task.FromResult(Result<string, string>.FromOk(initialResult))
+            .AndThenAsync((Func<string, Result<string, string>>)Continuation);
+
+        // act
+        await resultTask;
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, resultTask.Status);
     }
 }

--- a/Galaxus.Functional.Tests/(Result)/ResultExtensions/AndThenAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultExtensions/AndThenAsyncTests.cs
@@ -12,31 +12,47 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             const string continuationResult = "b";
-            async Task<Result<string, string>> Continuation(string s) => await Task.FromResult(Result<string, string>.FromOk(continuationResult));
-            
+
+            async Task<Result<string, string>> Continuation(string s)
+            {
+                return await Task.FromResult(Result<string, string>.FromOk(ok: continuationResult));
+            }
+
             // act
-            async Task Act() => await Task.FromException<Result<string, string>>(new ArgumentException())
-                    .AndThenAsync((Func<string, Task<Result<string, string>>>) Continuation);
+            async Task Act()
+            {
+                await Task.FromException<Result<string, string>>(new ArgumentException())
+                    .AndThenAsync((Func<string, Task<Result<string, string>>>)Continuation);
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
-        
+
         [Test]
         public void AndThenAsync_PreviousTaskWasCanceled_TaskCanceledExceptionIsThrown()
         {
             // arrange
             const string continuationResult = "b";
-            async Task<Result<string, string>> Continuation(string s) => await Task.FromResult(Result<string, string>.FromOk(continuationResult));
+
+            async Task<Result<string, string>> Continuation(string s)
+            {
+                return await Task.FromResult(Result<string, string>.FromOk(ok: continuationResult));
+            }
+
             var cancellationTokenSource = new CancellationTokenSource();
-            
+
             // act
             cancellationTokenSource.Cancel();
-            async Task Act() => await Task.FromCanceled<Result<string, string>>(cancellationTokenSource.Token)
-                    .AndThenAsync((Func<string, Task<Result<string, string>>>) Continuation);
+
+            async Task Act()
+            {
+                await Task.FromCanceled<Result<string, string>>(cancellationToken: cancellationTokenSource.Token)
+                    .AndThenAsync((Func<string, Task<Result<string, string>>>)Continuation);
+            }
 
             // assert
-            Assert.ThrowsAsync<TaskCanceledException>(Act);
+            Assert.ThrowsAsync<TaskCanceledException>(code: Act);
         }
 
         [Test]
@@ -45,13 +61,18 @@ namespace Galaxus.Functional.Tests.ResultExtensions
             // arrange
             const string initialResult = "a";
             const string continuationResult = "b";
-            Result<string, string> Continuation(string s) => Result<string, string>.FromOk(continuationResult);
-            var resultTask = Task.FromResult(Result<string, string>.FromOk(initialResult))
-                .AndThenAsync((Func<string, Result<string, string>>) Continuation);
-            
+
+            Result<string, string> Continuation(string s)
+            {
+                return Result<string, string>.FromOk(ok: continuationResult);
+            }
+
+            var resultTask = Task.FromResult(Result<string, string>.FromOk(ok: initialResult))
+                .AndThenAsync((Func<string, Result<string, string>>)Continuation);
+
             // act
             await resultTask;
-            
+
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: resultTask.Status);
         }

--- a/Galaxus.Functional.Tests/(Result)/ResultExtensions/MapAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultExtensions/MapAsyncTests.cs
@@ -3,148 +3,147 @@ using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests.ResultExtensions
+namespace Galaxus.Functional.Tests.ResultExtensions;
+
+public class MapAsyncTests
 {
-    public class MapAsyncTests
+    [Test]
+    public async Task MapOkAsync_SynchronousContinuation_ReturnsSuccessTask()
     {
-        [Test]
-        public async Task MapOkAsync_SynchronousContinuation_ReturnsSuccessTask()
+        // arrange
+        const string initialResult = "a";
+        const string continuationResult = "b";
+
+        string Continuation(string s)
         {
-            // arrange
-            const string initialResult = "a";
-            const string continuationResult = "b";
-
-            string Continuation(string s)
-            {
-                return continuationResult;
-            }
-
-            var resultTask = Task.FromResult(Result<string, string>.FromOk(ok: initialResult))
-                .MapAsync((Func<string, string>)Continuation);
-
-            // act
-            await resultTask;
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: resultTask.Status);
+            return continuationResult;
         }
 
-        [Test]
-        public void MapOkAsync_PreviousTaskThrewArgumentException_ArgumentExceptionIsThrown()
+        var resultTask = Task.FromResult(Result<string, string>.FromOk(initialResult))
+            .MapAsync((Func<string, string>)Continuation);
+
+        // act
+        await resultTask;
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, resultTask.Status);
+    }
+
+    [Test]
+    public void MapOkAsync_PreviousTaskThrewArgumentException_ArgumentExceptionIsThrown()
+    {
+        // arrange
+        const string continuationResult = "b";
+
+        async Task<string> Continuation(string s)
         {
-            // arrange
-            const string continuationResult = "b";
-
-            async Task<string> Continuation(string s)
-            {
-                return await Task.FromResult(result: continuationResult);
-            }
-
-            // act
-            async Task Act()
-            {
-                await Task.FromException<Result<string, string>>(new ArgumentException())
-                    .MapAsync((Func<string, Task<string>>)Continuation);
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
+            return await Task.FromResult(continuationResult);
         }
 
-        [Test]
-        public void MapOkAsync_PreviousTaskWasCanceled_TaskCanceledExceptionIsThrown()
+        // act
+        async Task Act()
         {
-            // arrange
-            const string continuationResult = "b";
-
-            async Task<string> Continuation(string s)
-            {
-                return await Task.FromResult(result: continuationResult);
-            }
-
-            var cancellationTokenSource = new CancellationTokenSource();
-
-            // act
-            cancellationTokenSource.Cancel();
-
-            async Task Act()
-            {
-                await Task.FromCanceled<Result<string, string>>(cancellationToken: cancellationTokenSource.Token)
-                    .MapAsync((Func<string, Task<string>>)Continuation);
-            }
-
-            // assert
-            Assert.ThrowsAsync<TaskCanceledException>(code: Act);
+            await Task.FromException<Result<string, string>>(new ArgumentException())
+                .MapAsync((Func<string, Task<string>>)Continuation);
         }
 
-        [Test]
-        public async Task MapErrAsync_SynchronousContinuation_ReturnsSuccessTask()
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public void MapOkAsync_PreviousTaskWasCanceled_TaskCanceledExceptionIsThrown()
+    {
+        // arrange
+        const string continuationResult = "b";
+
+        async Task<string> Continuation(string s)
         {
-            // arrange
-            const string initialResult = "a";
-            const string continuationResult = "b";
-
-            string Continuation(string s)
-            {
-                return continuationResult;
-            }
-
-            var resultTask = Task.FromResult(Result<string, string>.FromErr(err: initialResult))
-                .MapErrAsync((Func<string, string>)Continuation);
-
-            // act
-            await resultTask;
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: resultTask.Status);
+            return await Task.FromResult(continuationResult);
         }
 
-        [Test]
-        public void MapErrAsync_PreviousTaskThrewArgumentException_ArgumentExceptionIsThrown()
+        var cancellationTokenSource = new CancellationTokenSource();
+
+        // act
+        cancellationTokenSource.Cancel();
+
+        async Task Act()
         {
-            // arrange
-            const string continuationResult = "b";
-
-            async Task<string> Continuation(string s)
-            {
-                return await Task.FromResult(result: continuationResult);
-            }
-
-            // act
-            async Task Act()
-            {
-                await Task.FromException<Result<string, string>>(new ArgumentException())
-                    .MapErrAsync((Func<string, Task<string>>)Continuation);
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
+            await Task.FromCanceled<Result<string, string>>(cancellationTokenSource.Token)
+                .MapAsync((Func<string, Task<string>>)Continuation);
         }
 
-        [Test]
-        public void MapErrAsync_PreviousTaskWasCanceled_TaskCanceledExceptionIsThrown()
+        // assert
+        Assert.ThrowsAsync<TaskCanceledException>(Act);
+    }
+
+    [Test]
+    public async Task MapErrAsync_SynchronousContinuation_ReturnsSuccessTask()
+    {
+        // arrange
+        const string initialResult = "a";
+        const string continuationResult = "b";
+
+        string Continuation(string s)
         {
-            // arrange
-            const string continuationResult = "b";
-
-            async Task<string> Continuation(string s)
-            {
-                return await Task.FromResult(result: continuationResult);
-            }
-
-            var cancellationTokenSource = new CancellationTokenSource();
-
-            // act
-            cancellationTokenSource.Cancel();
-
-            async Task Act()
-            {
-                await Task.FromCanceled<Result<string, string>>(cancellationToken: cancellationTokenSource.Token)
-                    .MapErrAsync((Func<string, Task<string>>)Continuation);
-            }
-
-            // assert
-            Assert.ThrowsAsync<TaskCanceledException>(code: Act);
+            return continuationResult;
         }
+
+        var resultTask = Task.FromResult(Result<string, string>.FromErr(initialResult))
+            .MapErrAsync((Func<string, string>)Continuation);
+
+        // act
+        await resultTask;
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, resultTask.Status);
+    }
+
+    [Test]
+    public void MapErrAsync_PreviousTaskThrewArgumentException_ArgumentExceptionIsThrown()
+    {
+        // arrange
+        const string continuationResult = "b";
+
+        async Task<string> Continuation(string s)
+        {
+            return await Task.FromResult(continuationResult);
+        }
+
+        // act
+        async Task Act()
+        {
+            await Task.FromException<Result<string, string>>(new ArgumentException())
+                .MapErrAsync((Func<string, Task<string>>)Continuation);
+        }
+
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public void MapErrAsync_PreviousTaskWasCanceled_TaskCanceledExceptionIsThrown()
+    {
+        // arrange
+        const string continuationResult = "b";
+
+        async Task<string> Continuation(string s)
+        {
+            return await Task.FromResult(continuationResult);
+        }
+
+        var cancellationTokenSource = new CancellationTokenSource();
+
+        // act
+        cancellationTokenSource.Cancel();
+
+        async Task Act()
+        {
+            await Task.FromCanceled<Result<string, string>>(cancellationTokenSource.Token)
+                .MapErrAsync((Func<string, Task<string>>)Continuation);
+        }
+
+        // assert
+        Assert.ThrowsAsync<TaskCanceledException>(Act);
     }
 }

--- a/Galaxus.Functional.Tests/(Result)/ResultExtensions/MapAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultExtensions/MapAsyncTests.cs
@@ -13,13 +13,18 @@ namespace Galaxus.Functional.Tests.ResultExtensions
             // arrange
             const string initialResult = "a";
             const string continuationResult = "b";
-            string Continuation(string s) => continuationResult;
-            var resultTask = Task.FromResult(Result<string, string>.FromOk(initialResult))
-                .MapAsync((Func<string, string>) Continuation);
-            
+
+            string Continuation(string s)
+            {
+                return continuationResult;
+            }
+
+            var resultTask = Task.FromResult(Result<string, string>.FromOk(ok: initialResult))
+                .MapAsync((Func<string, string>)Continuation);
+
             // act
             await resultTask;
-            
+
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: resultTask.Status);
         }
@@ -29,15 +34,21 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             const string continuationResult = "b";
-            async Task<string> Continuation(string s) => await Task.FromResult(continuationResult);
+
+            async Task<string> Continuation(string s)
+            {
+                return await Task.FromResult(result: continuationResult);
+            }
 
             // act
-            async Task Act() =>
+            async Task Act()
+            {
                 await Task.FromException<Result<string, string>>(new ArgumentException())
-                    .MapAsync((Func<string, Task<string>>) Continuation);
+                    .MapAsync((Func<string, Task<string>>)Continuation);
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
@@ -45,16 +56,25 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             const string continuationResult = "b";
-            async Task<string> Continuation(string s) => await Task.FromResult(continuationResult);
+
+            async Task<string> Continuation(string s)
+            {
+                return await Task.FromResult(result: continuationResult);
+            }
+
             var cancellationTokenSource = new CancellationTokenSource();
-            
+
             // act
             cancellationTokenSource.Cancel();
-            async Task Act() => await Task.FromCanceled<Result<string, string>>(cancellationTokenSource.Token)
-                    .MapAsync((Func<string, Task<string>>) Continuation);
+
+            async Task Act()
+            {
+                await Task.FromCanceled<Result<string, string>>(cancellationToken: cancellationTokenSource.Token)
+                    .MapAsync((Func<string, Task<string>>)Continuation);
+            }
 
             // assert
-            Assert.ThrowsAsync<TaskCanceledException>(Act);
+            Assert.ThrowsAsync<TaskCanceledException>(code: Act);
         }
 
         [Test]
@@ -63,13 +83,18 @@ namespace Galaxus.Functional.Tests.ResultExtensions
             // arrange
             const string initialResult = "a";
             const string continuationResult = "b";
-            string Continuation(string s) => continuationResult;
-            var resultTask = Task.FromResult(Result<string, string>.FromErr(initialResult))
-                .MapErrAsync((Func<string, string>) Continuation);
-            
+
+            string Continuation(string s)
+            {
+                return continuationResult;
+            }
+
+            var resultTask = Task.FromResult(Result<string, string>.FromErr(err: initialResult))
+                .MapErrAsync((Func<string, string>)Continuation);
+
             // act
             await resultTask;
-            
+
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: resultTask.Status);
         }
@@ -79,15 +104,21 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             const string continuationResult = "b";
-            async Task<string> Continuation(string s) => await Task.FromResult(continuationResult);
-            
+
+            async Task<string> Continuation(string s)
+            {
+                return await Task.FromResult(result: continuationResult);
+            }
+
             // act
-            async Task Act() =>
+            async Task Act()
+            {
                 await Task.FromException<Result<string, string>>(new ArgumentException())
-                    .MapErrAsync((Func<string, Task<string>>) Continuation);
+                    .MapErrAsync((Func<string, Task<string>>)Continuation);
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
@@ -95,17 +126,25 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             const string continuationResult = "b";
-            async Task<string> Continuation(string s) => await Task.FromResult(continuationResult);
+
+            async Task<string> Continuation(string s)
+            {
+                return await Task.FromResult(result: continuationResult);
+            }
+
             var cancellationTokenSource = new CancellationTokenSource();
-            
+
             // act
             cancellationTokenSource.Cancel();
-            async Task Act() =>
-                await Task.FromCanceled<Result<string, string>>(cancellationTokenSource.Token)
-                    .MapErrAsync((Func<string, Task<string>>) Continuation);
+
+            async Task Act()
+            {
+                await Task.FromCanceled<Result<string, string>>(cancellationToken: cancellationTokenSource.Token)
+                    .MapErrAsync((Func<string, Task<string>>)Continuation);
+            }
 
             // assert
-            Assert.ThrowsAsync<TaskCanceledException>(Act);
+            Assert.ThrowsAsync<TaskCanceledException>(code: Act);
         }
     }
 }

--- a/Galaxus.Functional.Tests/(Result)/ResultExtensions/OrElseAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultExtensions/OrElseAsyncTests.cs
@@ -3,78 +3,77 @@ using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests.ResultExtensions
+namespace Galaxus.Functional.Tests.ResultExtensions;
+
+public class OrElseAsyncTests
 {
-    public class OrElseAsyncTests
+    [Test]
+    public void OrElseAsync_PreviousTaskThrewArgumentException_ArgumentExceptionIsThrown()
     {
-        [Test]
-        public void OrElseAsync_PreviousTaskThrewArgumentException_ArgumentExceptionIsThrown()
+        // arrange
+        const string continuationResult = "b";
+
+        async Task<Result<string, string>> Continuation(string s)
         {
-            // arrange
-            const string continuationResult = "b";
-
-            async Task<Result<string, string>> Continuation(string s)
-            {
-                return await Task.FromResult(Result<string, string>.FromOk(ok: continuationResult));
-            }
-
-            // act
-            async Task Act()
-            {
-                await Task.FromException<Result<string, string>>(new ArgumentException())
-                    .OrElseAsync((Func<string, Task<Result<string, string>>>)Continuation);
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
+            return await Task.FromResult(Result<string, string>.FromOk(continuationResult));
         }
 
-        [Test]
-        public void OrElseAsync_PreviousTaskWasCanceled_TaskCanceledExceptionIsThrown()
+        // act
+        async Task Act()
         {
-            // arrange
-            const string continuationResult = "b";
-
-            async Task<Result<string, string>> Continuation(string s)
-            {
-                return await Task.FromResult(Result<string, string>.FromOk(ok: continuationResult));
-            }
-
-            var cancellationTokenSource = new CancellationTokenSource();
-
-            // act
-            cancellationTokenSource.Cancel();
-
-            async Task Act()
-            {
-                await Task.FromCanceled<Result<string, string>>(cancellationToken: cancellationTokenSource.Token)
-                    .OrElseAsync((Func<string, Task<Result<string, string>>>)Continuation);
-            }
-
-            // assert
-            Assert.ThrowsAsync<TaskCanceledException>(code: Act);
+            await Task.FromException<Result<string, string>>(new ArgumentException())
+                .OrElseAsync((Func<string, Task<Result<string, string>>>)Continuation);
         }
 
-        [Test]
-        public async Task OrElseAsync_SynchronousContinuation_ReturnsSuccessTask()
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public void OrElseAsync_PreviousTaskWasCanceled_TaskCanceledExceptionIsThrown()
+    {
+        // arrange
+        const string continuationResult = "b";
+
+        async Task<Result<string, string>> Continuation(string s)
         {
-            // arrange
-            const string initialResult = "a";
-            const string continuationResult = "b";
-
-            Result<string, string> Continuation(string s)
-            {
-                return Result<string, string>.FromErr(err: continuationResult);
-            }
-
-            var resultTask = Task.FromResult(Result<string, string>.FromErr(err: initialResult))
-                .OrElseAsync((Func<string, Result<string, string>>)Continuation);
-
-            // act
-            await resultTask;
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: resultTask.Status);
+            return await Task.FromResult(Result<string, string>.FromOk(continuationResult));
         }
+
+        var cancellationTokenSource = new CancellationTokenSource();
+
+        // act
+        cancellationTokenSource.Cancel();
+
+        async Task Act()
+        {
+            await Task.FromCanceled<Result<string, string>>(cancellationTokenSource.Token)
+                .OrElseAsync((Func<string, Task<Result<string, string>>>)Continuation);
+        }
+
+        // assert
+        Assert.ThrowsAsync<TaskCanceledException>(Act);
+    }
+
+    [Test]
+    public async Task OrElseAsync_SynchronousContinuation_ReturnsSuccessTask()
+    {
+        // arrange
+        const string initialResult = "a";
+        const string continuationResult = "b";
+
+        Result<string, string> Continuation(string s)
+        {
+            return Result<string, string>.FromErr(continuationResult);
+        }
+
+        var resultTask = Task.FromResult(Result<string, string>.FromErr(initialResult))
+            .OrElseAsync((Func<string, Result<string, string>>)Continuation);
+
+        // act
+        await resultTask;
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, resultTask.Status);
     }
 }

--- a/Galaxus.Functional.Tests/(Result)/ResultExtensions/OrElseAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultExtensions/OrElseAsyncTests.cs
@@ -12,15 +12,21 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             const string continuationResult = "b";
-            async Task<Result<string, string>> Continuation(string s) => await Task.FromResult(Result<string, string>.FromOk(continuationResult));
+
+            async Task<Result<string, string>> Continuation(string s)
+            {
+                return await Task.FromResult(Result<string, string>.FromOk(ok: continuationResult));
+            }
 
             // act
-            async Task Act() =>
+            async Task Act()
+            {
                 await Task.FromException<Result<string, string>>(new ArgumentException())
-                    .OrElseAsync((Func<string, Task<Result<string, string>>>) Continuation);
+                    .OrElseAsync((Func<string, Task<Result<string, string>>>)Continuation);
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
@@ -28,17 +34,25 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             const string continuationResult = "b";
-            async Task<Result<string, string>> Continuation(string s) => await Task.FromResult(Result<string, string>.FromOk(continuationResult));
+
+            async Task<Result<string, string>> Continuation(string s)
+            {
+                return await Task.FromResult(Result<string, string>.FromOk(ok: continuationResult));
+            }
+
             var cancellationTokenSource = new CancellationTokenSource();
-            
+
             // act
             cancellationTokenSource.Cancel();
-            async Task Act() =>
-                await Task.FromCanceled<Result<string, string>>(cancellationTokenSource.Token)
-                    .OrElseAsync((Func<string, Task<Result<string, string>>>) Continuation);
+
+            async Task Act()
+            {
+                await Task.FromCanceled<Result<string, string>>(cancellationToken: cancellationTokenSource.Token)
+                    .OrElseAsync((Func<string, Task<Result<string, string>>>)Continuation);
+            }
 
             // assert
-            Assert.ThrowsAsync<TaskCanceledException>(Act);
+            Assert.ThrowsAsync<TaskCanceledException>(code: Act);
         }
 
         [Test]
@@ -47,13 +61,18 @@ namespace Galaxus.Functional.Tests.ResultExtensions
             // arrange
             const string initialResult = "a";
             const string continuationResult = "b";
-            Result<string, string> Continuation(string s) => Result<string, string>.FromErr(continuationResult);
-            var resultTask = Task.FromResult(Result<string, string>.FromErr(initialResult))
-                .OrElseAsync((Func<string, Result<string, string>>) Continuation);
-            
+
+            Result<string, string> Continuation(string s)
+            {
+                return Result<string, string>.FromErr(err: continuationResult);
+            }
+
+            var resultTask = Task.FromResult(Result<string, string>.FromErr(err: initialResult))
+                .OrElseAsync((Func<string, Result<string, string>>)Continuation);
+
             // act
             await resultTask;
-            
+
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: resultTask.Status);
         }

--- a/Galaxus.Functional.Tests/(Result)/ResultExtensions/UnwrapAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultExtensions/UnwrapAsyncTests.cs
@@ -2,716 +2,715 @@ using System;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests.ResultExtensions
+namespace Galaxus.Functional.Tests.ResultExtensions;
+
+public class UnwrapAsyncTests
 {
-    public class UnwrapAsyncTests
+    [Test]
+    public async Task UnwrapAsync_WhenTOk_ThenOkReturned()
     {
-        [Test]
-        public async Task UnwrapAsync_WhenTOk_ThenOkReturned()
+        // arrange
+        var ok = Task.FromResult("hello".ToOk<string, int>());
+
+        // act
+        var hello = await ok.UnwrapAsync();
+
+        // assert
+        Assert.AreEqual("hello", hello);
+    }
+
+    [Test]
+    public void UnwrapAsync_WhenTErr_ThenExceptionThrown()
+    {
+        // arrange
+        var err = Task.FromResult(99.ToErr<string, int>());
+
+        // act
+        async Task Act()
         {
-            // arrange
-            var ok = Task.FromResult("hello".ToOk<string, int>());
-
-            // act
-            var hello = await ok.UnwrapAsync();
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
+            await err.UnwrapAsync();
         }
 
-        [Test]
-        public void UnwrapAsync_WhenTErr_ThenExceptionThrown()
-        {
-            // arrange
-            var err = Task.FromResult(99.ToErr<string, int>());
+        // assert
+        Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(Act);
+    }
 
-            // act
-            async Task Act()
+    [Test]
+    public async Task UnwrapAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
+
+        // act
+        await okTask.UnwrapAsync();
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, okTask.Status);
+    }
+
+    [Test]
+    public void UnwrapAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Result<int, string>>(new ArgumentException());
+
+        // act
+        async Task Act()
+        {
+            await failingTask.UnwrapAsync();
+        }
+
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapAsyncWithErrorMessage_WhenTOk_ThenOkReturned()
+    {
+        // arrange
+        var ok = Task.FromResult("hello".ToOk<string, int>());
+
+        // act
+        var hello = await ok.UnwrapAsync("world");
+
+        // assert
+        Assert.AreEqual("hello", hello);
+    }
+
+    [Test]
+    public void UnwrapAsyncWithErrorMessage_WhenResultIsErr_ThenExceptionWithCorrectMessageIsThrown()
+    {
+        // arrange
+        var err = Task.FromResult(99.ToErr<string, int>());
+
+        // act
+        async Task Act()
+        {
+            try
             {
-                await err.UnwrapAsync();
+                await err.UnwrapAsync("YOLO");
             }
-
-            // assert
-            Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(code: Act);
-        }
-
-        [Test]
-        public async Task UnwrapAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
-        {
-            // arrange
-            var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-
-            // act
-            await okTask.UnwrapAsync();
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
-        }
-
-        [Test]
-        public void UnwrapAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            var failingTask = Task.FromException<Result<int, string>>(new ArgumentException());
-
-            // act
-            async Task Act()
+            catch (AttemptToUnwrapErrWhenResultWasOkException ex)
             {
-                await failingTask.UnwrapAsync();
+                Assert.AreEqual("YOLO", ex.Message);
+                throw;
             }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
-        [Test]
-        public async Task UnwrapAsyncWithErrorMessage_WhenTOk_ThenOkReturned()
+        // assert
+        Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapAsyncWithErrorMessage_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
+
+        // act
+        await okTask.UnwrapAsync("Arthur Dent");
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, okTask.Status);
+    }
+
+    [Test]
+    public void UnwrapAsyncWithErrorMessage_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Result<int, string>>(new ArgumentException());
+
+        // act
+        async Task Act()
         {
-            // arrange
-            var ok = Task.FromResult("hello".ToOk<string, int>());
-
-            // act
-            var hello = await ok.UnwrapAsync("world");
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
+            await failingTask.UnwrapAsync("Arthur Dent");
         }
 
-        [Test]
-        public void UnwrapAsyncWithErrorMessage_WhenResultIsErr_ThenExceptionWithCorrectMessageIsThrown()
-        {
-            // arrange
-            var err = Task.FromResult(99.ToErr<string, int>());
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
 
-            // act
-            async Task Act()
+    [Test]
+    public async Task UnwrapAsyncWithErrorFunction_WhenResultIsOk_ThenFunctionNotInvoked()
+    {
+        // arrange
+        var ok = Task.FromResult("hello".ToOk<string, int>());
+        var invoked = false;
+
+        // act
+        var hello = await ok.UnwrapAsync(err =>
+        {
+            invoked = true;
+            return "YOLO";
+        });
+
+        // assert
+        Assert.AreEqual("hello", hello);
+        Assert.IsFalse(invoked);
+    }
+
+    [Test]
+    public void UnwrapAsyncWithErrorFunction_WhenResultIsErr_ThenFunctionInvoked()
+    {
+        // arrange
+        var err = Task.FromResult(0.ToErr<string, int>());
+        var invoked = false;
+
+        // act
+        async Task Act()
+        {
+            try
             {
-                try
+                await err.UnwrapAsync(e =>
                 {
-                    await err.UnwrapAsync("YOLO");
-                }
-                catch (AttemptToUnwrapErrWhenResultWasOkException ex)
+                    invoked = true;
+                    return "YOLO";
+                });
+            }
+            catch (AttemptToUnwrapErrWhenResultWasOkException ex)
+            {
+                Assert.AreEqual("YOLO", ex.Message);
+                throw;
+            }
+        }
+
+        // assert
+        Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(Act);
+        Assert.IsTrue(invoked);
+    }
+
+    [Test]
+    public async Task UnwrapAsyncWithErrorFunction_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
+
+        // act
+        await okTask.UnwrapAsync(err => "Arthur Dent");
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, okTask.Status);
+    }
+
+    [Test]
+    public void UnwrapAsyncWithErrorFunction_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Result<int, string>>(new ArgumentException());
+
+        // act
+        async Task Act()
+        {
+            await failingTask.UnwrapAsync(err => "Arthur Dent");
+        }
+
+        // arrange
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapAsyncWithErrorFunctionTask_WhenResultIsOk_ThenFunctionNotInvoked()
+    {
+        // arrange
+        var ok = Task.FromResult("hello".ToOk<string, int>());
+        var invoked = false;
+
+        // act
+        var hello = await ok.UnwrapAsync(async err =>
+        {
+            invoked = true;
+            return await Task.FromResult("YOLO");
+        });
+
+        // assert
+        Assert.AreEqual("hello", hello);
+        Assert.IsFalse(invoked);
+    }
+
+    [Test]
+    public void UnwrapAsyncWithErrorFunctionTask_WhenResultIsErr_ThenFunctionInvoked()
+    {
+        // arrange
+        var err = Task.FromResult(0.ToErr<string, int>());
+        var invoked = false;
+
+        // act
+        async Task Act()
+        {
+            try
+            {
+                await err.UnwrapAsync(async e =>
                 {
-                    Assert.AreEqual("YOLO", actual: ex.Message);
-                    throw;
-                }
+                    invoked = true;
+                    return await Task.FromResult("YOLO");
+                });
             }
-
-            // assert
-            Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(code: Act);
-        }
-
-        [Test]
-        public async Task UnwrapAsyncWithErrorMessage_WhenSynchronousContinuation_ThenReturnsSuccessTask()
-        {
-            // arrange
-            var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-
-            // act
-            await okTask.UnwrapAsync("Arthur Dent");
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
-        }
-
-        [Test]
-        public void UnwrapAsyncWithErrorMessage_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            var failingTask = Task.FromException<Result<int, string>>(new ArgumentException());
-
-            // act
-            async Task Act()
+            catch (AttemptToUnwrapErrWhenResultWasOkException ex)
             {
-                await failingTask.UnwrapAsync("Arthur Dent");
+                Assert.AreEqual("YOLO", ex.Message);
+                throw;
             }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
-        [Test]
-        public async Task UnwrapAsyncWithErrorFunction_WhenResultIsOk_ThenFunctionNotInvoked()
+        // arrange
+        Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(Act);
+        Assert.IsTrue(invoked);
+    }
+
+    [Test]
+    public async Task UnwrapAsyncWithErrorFunctionTask_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
+
+        // act
+        await okTask.UnwrapAsync(async err => await Task.FromResult("Arthur Dent"));
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, okTask.Status);
+    }
+
+    [Test]
+    public void UnwrapAsyncWithErrorFunctionTask_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Result<int, string>>(new ArgumentException());
+
+        // act
+        async Task Act()
         {
-            // arrange
-            var ok = Task.FromResult("hello".ToOk<string, int>());
-            var invoked = false;
-
-            // act
-            var hello = await ok.UnwrapAsync(err =>
-            {
-                invoked = true;
-                return "YOLO";
-            });
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
-            Assert.IsFalse(condition: invoked);
+            await failingTask.UnwrapAsync(async err => await Task.FromResult("Arthur Dent"));
         }
 
-        [Test]
-        public void UnwrapAsyncWithErrorFunction_WhenResultIsErr_ThenFunctionInvoked()
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapOrAsync_WhenOk_ThenResultIsOkValue()
+    {
+        // arrange
+        var ok = Task.FromResult("hello".ToOk<string, int>());
+
+        //act
+        var hello = await ok.UnwrapOrAsync("world");
+
+        // assert
+        Assert.AreEqual("hello", hello);
+    }
+
+    [Test]
+    public async Task UnwrapOrAsync_WhenErr_ThenResultIsParameterValue()
+    {
+        // arrange
+        var err = Task.FromResult(33.ToErr<string, int>());
+
+        // act
+        var world = await err.UnwrapOrAsync("world");
+
+        // assert
+        Assert.AreEqual("world", world);
+    }
+
+    [Test]
+    public async Task UnwrapOrAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
+
+        // act
+        await okTask.UnwrapOrAsync("Arthur Dent");
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, okTask.Status);
+    }
+
+    [Test]
+    public void UnwrapOrAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Result<string, int>>(new ArgumentException());
+
+        // act
+        async Task Act()
         {
-            // arrange
-            var err = Task.FromResult(0.ToErr<string, int>());
-            var invoked = false;
-
-            // act
-            async Task Act()
-            {
-                try
-                {
-                    await err.UnwrapAsync(e =>
-                    {
-                        invoked = true;
-                        return "YOLO";
-                    });
-                }
-                catch (AttemptToUnwrapErrWhenResultWasOkException ex)
-                {
-                    Assert.AreEqual("YOLO", actual: ex.Message);
-                    throw;
-                }
-            }
-
-            // assert
-            Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(code: Act);
-            Assert.IsTrue(condition: invoked);
+            await failingTask.UnwrapOrAsync("Arthur Dent");
         }
 
-        [Test]
-        public async Task UnwrapAsyncWithErrorFunction_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapOrAsyncWithTaskParam_WhenOk_ThenResultIsOkValue()
+    {
+        // arrange
+        var ok = Task.FromResult("hello".ToOk<string, int>());
+
+        // act
+        var hello = await ok.UnwrapOrAsync(Task.FromResult("world"));
+
+        // assert
+        Assert.AreEqual("hello", hello);
+    }
+
+    [Test]
+    public async Task UnwrapOrAsyncWithTaskParam_WhenErr_ThenResultIsParameterValue()
+    {
+        // arrange
+        var err = Task.FromResult(99.ToErr<string, int>());
+
+        // act
+        var world = await err.UnwrapOrAsync(Task.FromResult("world"));
+
+        // assert
+        Assert.AreEqual("world", world);
+    }
+
+    [Test]
+    public async Task UnwrapOrAsyncWithTaskParam_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
+
+        // act
+        await okTask.UnwrapOrAsync(Task.FromResult("Arthur Dent"));
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, okTask.Status);
+    }
+
+    [Test]
+    public void UnwrapOrAsyncWithTaskParam_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Result<string, int>>(new ArgumentException());
+
+        // act
+        async Task Act()
         {
-            // arrange
-            var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-
-            // act
-            await okTask.UnwrapAsync(err => "Arthur Dent");
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
+            await failingTask.UnwrapOrAsync(Task.FromResult("Arthur Dent"));
         }
 
-        [Test]
-        public void UnwrapAsyncWithErrorFunction_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsync_WhenOk_ThenResultIsOkValue()
+    {
+        // arrange
+        var ok = Task.FromResult("hello".ToOk<string, int>());
+
+        // act
+        var hello = await ok.UnwrapOrElseAsync(() => "world");
+
+        // arrange
+        Assert.AreEqual("hello", hello);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsync_WhenErr_ThenResultIsParameterValue()
+    {
+        // arrange
+        var err = Task.FromResult(99.ToErr<string, int>());
+
+        // act
+        var world = await err.UnwrapOrElseAsync(() => "world");
+
+        // assert
+        Assert.AreEqual("world", world);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
+
+        // act
+        await okTask.UnwrapOrElseAsync(() => "Arthur Dent");
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, okTask.Status);
+    }
+
+    [Test]
+    public void UnwrapOrElseAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Result<string, int>>(new ArgumentException());
+
+        // act
+        async Task Act()
         {
-            // arrange
-            var failingTask = Task.FromException<Result<int, string>>(new ArgumentException());
-
-            // act
-            async Task Act()
-            {
-                await failingTask.UnwrapAsync(err => "Arthur Dent");
-            }
-
-            // arrange
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
+            await failingTask.UnwrapOrElseAsync(() => "Arthur Dent");
         }
 
-        [Test]
-        public async Task UnwrapAsyncWithErrorFunctionTask_WhenResultIsOk_ThenFunctionNotInvoked()
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsync_WhenUnwrapOkWithCallBack_ThenNoCallbackInvoked()
+    {
+        // arrange
+        var ok = Task.FromResult("hello".ToOk<string, int>());
+        var invoked = false;
+
+        // act
+        var hello = await ok.UnwrapOrElseAsync(() =>
         {
-            // arrange
-            var ok = Task.FromResult("hello".ToOk<string, int>());
-            var invoked = false;
+            invoked = true;
+            return "world";
+        });
 
-            // act
-            var hello = await ok.UnwrapAsync(async err =>
-            {
-                invoked = true;
-                return await Task.FromResult("YOLO");
-            });
+        // assert
+        Assert.AreEqual("hello", hello);
+        Assert.IsFalse(invoked);
+    }
 
-            // assert
-            Assert.AreEqual("hello", actual: hello);
-            Assert.IsFalse(condition: invoked);
+    [Test]
+    public async Task UnwrapOrElseAsync_WhenUnwrapErrWithCallBack_ThenCallbackInvoked()
+    {
+        // arrange
+        var err = Task.FromResult(77.ToErr<string, int>());
+        var invoked = false;
+
+        // act
+        var world = await err.UnwrapOrElseAsync(() =>
+        {
+            invoked = true;
+            return "world";
+        });
+
+        // assert
+        Assert.AreEqual("world", world);
+        Assert.IsTrue(invoked);
+    }
+
+
+    [Test]
+    public void UnwrapOrElse_WhenUnwrapErrWithFunctionIsNull_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        Func<string> nullFunc = null;
+
+        // act
+        // ReSharper disable once ExpressionIsAlwaysNull
+        async Task Act()
+        {
+            await Task.FromResult(88.ToErr<string, int>()).UnwrapOrElseAsync(nullFunc);
         }
 
-        [Test]
-        public void UnwrapAsyncWithErrorFunctionTask_WhenResultIsErr_ThenFunctionInvoked()
+        // assert
+        Assert.ThrowsAsync<ArgumentNullException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsyncWithTaskParam_WhenOk_ThenResultIsOkValue()
+    {
+        // arrange
+        var ok = Task.FromResult("hello".ToOk<string, int>());
+
+        static async Task<string> Continuation()
         {
-            // arrange
-            var err = Task.FromResult(0.ToErr<string, int>());
-            var invoked = false;
-
-            // act
-            async Task Act()
-            {
-                try
-                {
-                    await err.UnwrapAsync(async e =>
-                    {
-                        invoked = true;
-                        return await Task.FromResult("YOLO");
-                    });
-                }
-                catch (AttemptToUnwrapErrWhenResultWasOkException ex)
-                {
-                    Assert.AreEqual("YOLO", actual: ex.Message);
-                    throw;
-                }
-            }
-
-            // arrange
-            Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(code: Act);
-            Assert.IsTrue(condition: invoked);
+            return await Task.FromResult("world");
         }
 
-        [Test]
-        public async Task UnwrapAsyncWithErrorFunctionTask_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+        // act
+        var hello = await ok.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+
+        // assert
+        Assert.AreEqual("hello", hello);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsyncWithTaskParam_WhenErr_ThenResultIsParameterValue()
+    {
+        // arrange
+        var err = Task.FromResult(99.ToErr<string, int>());
+
+        static async Task<string> Continuation()
         {
-            // arrange
-            var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-
-            // act
-            await okTask.UnwrapAsync(async err => await Task.FromResult("Arthur Dent"));
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
+            return await Task.FromResult("world");
         }
 
-        [Test]
-        public void UnwrapAsyncWithErrorFunctionTask_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+        // act
+        var world = await err.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+
+        // assert
+        Assert.AreEqual("world", world);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsyncWithTaskParam_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
+
+        static async Task<string> Continuation()
         {
-            // arrange
-            var failingTask = Task.FromException<Result<int, string>>(new ArgumentException());
-
-            // act
-            async Task Act()
-            {
-                await failingTask.UnwrapAsync(async err => await Task.FromResult("Arthur Dent"));
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
+            return await Task.FromResult("Arthur Dent");
         }
 
-        [Test]
-        public async Task UnwrapOrAsync_WhenOk_ThenResultIsOkValue()
+        // act
+        await okTask.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, okTask.Status);
+    }
+
+    [Test]
+    public void UnwrapOrElseAsyncWithTaskParam_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Result<string, int>>(new ArgumentException());
+
+        static async Task<string> Continuation()
         {
-            // arrange
-            var ok = Task.FromResult("hello".ToOk<string, int>());
-
-            //act
-            var hello = await ok.UnwrapOrAsync("world");
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
+            return await Task.FromResult("Arthur Dent");
         }
 
-        [Test]
-        public async Task UnwrapOrAsync_WhenErr_ThenResultIsParameterValue()
+        // act
+        async Task Act()
         {
-            // arrange
-            var err = Task.FromResult(33.ToErr<string, int>());
-
-            // act
-            var world = await err.UnwrapOrAsync("world");
-
-            // assert
-            Assert.AreEqual("world", actual: world);
+            await failingTask.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
         }
 
-        [Test]
-        public async Task UnwrapOrAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsyncWithTaskParam_WhenUnwrapOkWithCallBack_ThenNoCallbackInvoked()
+    {
+        // arrange
+        var ok = Task.FromResult("hello".ToOk<string, int>());
+        var invoked = false;
+
+        async Task<string> Continuation()
         {
-            // arrange
-            var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-
-            // act
-            await okTask.UnwrapOrAsync("Arthur Dent");
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
-        }
-
-        [Test]
-        public void UnwrapOrAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            var failingTask = Task.FromException<Result<string, int>>(new ArgumentException());
-
-            // act
-            async Task Act()
-            {
-                await failingTask.UnwrapOrAsync("Arthur Dent");
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
-        }
-
-        [Test]
-        public async Task UnwrapOrAsyncWithTaskParam_WhenOk_ThenResultIsOkValue()
-        {
-            // arrange
-            var ok = Task.FromResult("hello".ToOk<string, int>());
-
-            // act
-            var hello = await ok.UnwrapOrAsync(Task.FromResult("world"));
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
-        }
-
-        [Test]
-        public async Task UnwrapOrAsyncWithTaskParam_WhenErr_ThenResultIsParameterValue()
-        {
-            // arrange
-            var err = Task.FromResult(99.ToErr<string, int>());
-
-            // act
-            var world = await err.UnwrapOrAsync(Task.FromResult("world"));
-
-            // assert
-            Assert.AreEqual("world", actual: world);
-        }
-
-        [Test]
-        public async Task UnwrapOrAsyncWithTaskParam_WhenSynchronousContinuation_ThenReturnsSuccessTask()
-        {
-            // arrange
-            var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-
-            // act
-            await okTask.UnwrapOrAsync(Task.FromResult("Arthur Dent"));
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
-        }
-
-        [Test]
-        public void UnwrapOrAsyncWithTaskParam_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            var failingTask = Task.FromException<Result<string, int>>(new ArgumentException());
-
-            // act
-            async Task Act()
-            {
-                await failingTask.UnwrapOrAsync(Task.FromResult("Arthur Dent"));
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
-        }
-
-        [Test]
-        public async Task UnwrapOrElseAsync_WhenOk_ThenResultIsOkValue()
-        {
-            // arrange
-            var ok = Task.FromResult("hello".ToOk<string, int>());
-
-            // act
-            var hello = await ok.UnwrapOrElseAsync(() => "world");
-
-            // arrange
-            Assert.AreEqual("hello", actual: hello);
-        }
-
-        [Test]
-        public async Task UnwrapOrElseAsync_WhenErr_ThenResultIsParameterValue()
-        {
-            // arrange
-            var err = Task.FromResult(99.ToErr<string, int>());
-
-            // act
-            var world = await err.UnwrapOrElseAsync(() => "world");
-
-            // assert
-            Assert.AreEqual("world", actual: world);
-        }
-
-        [Test]
-        public async Task UnwrapOrElseAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
-        {
-            // arrange
-            var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-
-            // act
-            await okTask.UnwrapOrElseAsync(() => "Arthur Dent");
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
-        }
-
-        [Test]
-        public void UnwrapOrElseAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            var failingTask = Task.FromException<Result<string, int>>(new ArgumentException());
-
-            // act
-            async Task Act()
-            {
-                await failingTask.UnwrapOrElseAsync(() => "Arthur Dent");
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
-        }
-
-        [Test]
-        public async Task UnwrapOrElseAsync_WhenUnwrapOkWithCallBack_ThenNoCallbackInvoked()
-        {
-            // arrange
-            var ok = Task.FromResult("hello".ToOk<string, int>());
-            var invoked = false;
-
-            // act
-            var hello = await ok.UnwrapOrElseAsync(() =>
+            return await Task.Run(() =>
             {
                 invoked = true;
                 return "world";
             });
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
-            Assert.IsFalse(condition: invoked);
         }
 
-        [Test]
-        public async Task UnwrapOrElseAsync_WhenUnwrapErrWithCallBack_ThenCallbackInvoked()
-        {
-            // arrange
-            var err = Task.FromResult(77.ToErr<string, int>());
-            var invoked = false;
+        // act
+        var hello = await ok.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
 
-            // act
-            var world = await err.UnwrapOrElseAsync(() =>
+        // assert
+        Assert.AreEqual("hello", hello);
+        Assert.IsFalse(invoked);
+    }
+
+    [Test]
+    public async Task UnwrapOrElseAsyncWithTaskParam_WhenUnwrapErrWithCallBack_ThenCallbackInvoked()
+    {
+        // arrange
+        var err = Task.FromResult(11.ToErr<string, int>());
+        var invoked = false;
+
+        async Task<string> Continuation()
+        {
+            return await Task.Run(() =>
             {
                 invoked = true;
                 return "world";
             });
-
-            // assert
-            Assert.AreEqual("world", actual: world);
-            Assert.IsTrue(condition: invoked);
         }
 
+        // act
+        var world = await err.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
 
-        [Test]
-        public void UnwrapOrElse_WhenUnwrapErrWithFunctionIsNull_ThenArgumentExceptionIsThrown()
+        // assert
+        Assert.AreEqual("world", world);
+        Assert.IsTrue(invoked);
+    }
+
+    [Test]
+    public void UnwrapOrElseAsyncWithTaskParam_WhenUnwrapOkWithFunctionTaskIsNull_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        Func<Task<string>> nullFunc = null;
+
+        // act
+        // ReSharper disable once ExpressionIsAlwaysNull
+        Task Act()
         {
-            // arrange
-            Func<string> nullFunc = null;
-
-            // act
-            // ReSharper disable once ExpressionIsAlwaysNull
-            async Task Act()
-            {
-                await Task.FromResult(88.ToErr<string, int>()).UnwrapOrElseAsync(fallback: nullFunc);
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentNullException>(code: Act);
+            return Task.FromResult(12.ToErr<string, int>()).UnwrapOrElseAsync(nullFunc);
         }
 
-        [Test]
-        public async Task UnwrapOrElseAsyncWithTaskParam_WhenOk_ThenResultIsOkValue()
+        // assert
+        Assert.ThrowsAsync<ArgumentNullException>(Act);
+    }
+
+    [Test]
+    public async Task UnwrapOrDefaultAsync_WhenOk_ThenResultIsOkValue()
+    {
+        // arrange
+        var ok = Task.FromResult("hello".ToOk<string, int>());
+
+        // act
+        var hello = await ok.UnwrapOrDefaultAsync();
+        // assert
+        Assert.AreEqual("hello", hello);
+    }
+
+    [Test]
+    public async Task UnwrapOrDefaultAsync_WhenErr_ThenResultIsDefaultValue()
+    {
+        // arrange
+        var err = Task.FromResult(11.ToErr<string, int>());
+
+        // act
+        var defaultString = await err.UnwrapOrDefaultAsync();
+
+        // assert
+        Assert.AreEqual(null, defaultString);
+    }
+
+    [Test]
+    public async Task UnwrapOrDefaultAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var ok = Task.FromResult("Ford Prefect".ToOk<string, int>());
+
+        // act
+        await ok.UnwrapOrDefaultAsync();
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, ok.Status);
+    }
+
+    [Test]
+    public async Task UnwrapOrDefaultAsync_WhenSynchronousContinuationForErr_ThenReturnsSuccessTask()
+    {
+        // arrange
+        var okTask = Task.FromResult(99.ToErr<string, int>());
+
+        // act
+        await okTask.UnwrapOrDefaultAsync();
+
+        // assert
+        Assert.AreEqual(TaskStatus.RanToCompletion, okTask.Status);
+    }
+
+    [Test]
+    public void UnwrapOrDefaultAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
+    {
+        // arrange
+        var failingTask = Task.FromException<Result<string, int>>(new ArgumentException());
+
+        // act
+        async Task Act()
         {
-            // arrange
-            var ok = Task.FromResult("hello".ToOk<string, int>());
-
-            static async Task<string> Continuation()
-            {
-                return await Task.FromResult("world");
-            }
-
-            // act
-            var hello = await ok.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
+            await failingTask.UnwrapOrDefaultAsync();
         }
 
-        [Test]
-        public async Task UnwrapOrElseAsyncWithTaskParam_WhenErr_ThenResultIsParameterValue()
-        {
-            // arrange
-            var err = Task.FromResult(99.ToErr<string, int>());
-
-            static async Task<string> Continuation()
-            {
-                return await Task.FromResult("world");
-            }
-
-            // act
-            var world = await err.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
-
-            // assert
-            Assert.AreEqual("world", actual: world);
-        }
-
-        [Test]
-        public async Task UnwrapOrElseAsyncWithTaskParam_WhenSynchronousContinuation_ThenReturnsSuccessTask()
-        {
-            // arrange
-            var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-
-            static async Task<string> Continuation()
-            {
-                return await Task.FromResult("Arthur Dent");
-            }
-
-            // act
-            await okTask.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
-        }
-
-        [Test]
-        public void UnwrapOrElseAsyncWithTaskParam_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            var failingTask = Task.FromException<Result<string, int>>(new ArgumentException());
-
-            static async Task<string> Continuation()
-            {
-                return await Task.FromResult("Arthur Dent");
-            }
-
-            // act
-            async Task Act()
-            {
-                await failingTask.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
-        }
-
-        [Test]
-        public async Task UnwrapOrElseAsyncWithTaskParam_WhenUnwrapOkWithCallBack_ThenNoCallbackInvoked()
-        {
-            // arrange
-            var ok = Task.FromResult("hello".ToOk<string, int>());
-            var invoked = false;
-
-            async Task<string> Continuation()
-            {
-                return await Task.Run(() =>
-                {
-                    invoked = true;
-                    return "world";
-                });
-            }
-
-            // act
-            var hello = await ok.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
-
-            // assert
-            Assert.AreEqual("hello", actual: hello);
-            Assert.IsFalse(condition: invoked);
-        }
-
-        [Test]
-        public async Task UnwrapOrElseAsyncWithTaskParam_WhenUnwrapErrWithCallBack_ThenCallbackInvoked()
-        {
-            // arrange
-            var err = Task.FromResult(11.ToErr<string, int>());
-            var invoked = false;
-
-            async Task<string> Continuation()
-            {
-                return await Task.Run(() =>
-                {
-                    invoked = true;
-                    return "world";
-                });
-            }
-
-            // act
-            var world = await err.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
-
-            // assert
-            Assert.AreEqual("world", actual: world);
-            Assert.IsTrue(condition: invoked);
-        }
-
-        [Test]
-        public void UnwrapOrElseAsyncWithTaskParam_WhenUnwrapOkWithFunctionTaskIsNull_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            Func<Task<string>> nullFunc = null;
-
-            // act
-            // ReSharper disable once ExpressionIsAlwaysNull
-            Task Act()
-            {
-                return Task.FromResult(12.ToErr<string, int>()).UnwrapOrElseAsync(fallback: nullFunc);
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentNullException>(code: Act);
-        }
-
-        [Test]
-        public async Task UnwrapOrDefaultAsync_WhenOk_ThenResultIsOkValue()
-        {
-            // arrange
-            var ok = Task.FromResult("hello".ToOk<string, int>());
-
-            // act
-            var hello = await ok.UnwrapOrDefaultAsync();
-            // assert
-            Assert.AreEqual("hello", actual: hello);
-        }
-
-        [Test]
-        public async Task UnwrapOrDefaultAsync_WhenErr_ThenResultIsDefaultValue()
-        {
-            // arrange
-            var err = Task.FromResult(11.ToErr<string, int>());
-
-            // act
-            var defaultString = await err.UnwrapOrDefaultAsync();
-
-            // assert
-            Assert.AreEqual(null, actual: defaultString);
-        }
-
-        [Test]
-        public async Task UnwrapOrDefaultAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
-        {
-            // arrange
-            var ok = Task.FromResult("Ford Prefect".ToOk<string, int>());
-
-            // act
-            await ok.UnwrapOrDefaultAsync();
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: ok.Status);
-        }
-
-        [Test]
-        public async Task UnwrapOrDefaultAsync_WhenSynchronousContinuationForErr_ThenReturnsSuccessTask()
-        {
-            // arrange
-            var okTask = Task.FromResult(99.ToErr<string, int>());
-
-            // act
-            await okTask.UnwrapOrDefaultAsync();
-
-            // assert
-            Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
-        }
-
-        [Test]
-        public void UnwrapOrDefaultAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
-        {
-            // arrange
-            var failingTask = Task.FromException<Result<string, int>>(new ArgumentException());
-
-            // act
-            async Task Act()
-            {
-                await failingTask.UnwrapOrDefaultAsync();
-            }
-
-            // assert
-            Assert.ThrowsAsync<ArgumentException>(code: Act);
-        }
+        // assert
+        Assert.ThrowsAsync<ArgumentException>(Act);
     }
 }

--- a/Galaxus.Functional.Tests/(Result)/ResultExtensions/UnwrapAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultExtensions/UnwrapAsyncTests.cs
@@ -11,12 +11,12 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var ok = Task.FromResult("hello".ToOk<string, int>());
-            
+
             // act
             var hello = await ok.UnwrapAsync();
-            
+
             // assert
-            Assert.AreEqual("hello", hello);
+            Assert.AreEqual("hello", actual: hello);
         }
 
         [Test]
@@ -24,12 +24,15 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var err = Task.FromResult(99.ToErr<string, int>());
-            
+
             // act
-            async Task Act() => await err.UnwrapAsync();
+            async Task Act()
+            {
+                await err.UnwrapAsync();
+            }
 
             // assert
-            Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(Act);
+            Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(code: Act);
         }
 
         [Test]
@@ -37,10 +40,10 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-            
+
             // act
             await okTask.UnwrapAsync();
-            
+
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
         }
@@ -52,10 +55,13 @@ namespace Galaxus.Functional.Tests.ResultExtensions
             var failingTask = Task.FromException<Result<int, string>>(new ArgumentException());
 
             // act
-            async Task Act() => await failingTask.UnwrapAsync();
+            async Task Act()
+            {
+                await failingTask.UnwrapAsync();
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
@@ -63,12 +69,12 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var ok = Task.FromResult("hello".ToOk<string, int>());
-            
+
             // act
             var hello = await ok.UnwrapAsync("world");
-            
+
             // assert
-            Assert.AreEqual("hello", hello);
+            Assert.AreEqual("hello", actual: hello);
         }
 
         [Test]
@@ -76,7 +82,7 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var err = Task.FromResult(99.ToErr<string, int>());
-            
+
             // act
             async Task Act()
             {
@@ -86,13 +92,13 @@ namespace Galaxus.Functional.Tests.ResultExtensions
                 }
                 catch (AttemptToUnwrapErrWhenResultWasOkException ex)
                 {
-                    Assert.AreEqual("YOLO", ex.Message);
+                    Assert.AreEqual("YOLO", actual: ex.Message);
                     throw;
                 }
             }
 
             // assert
-            Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(Act);
+            Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(code: Act);
         }
 
         [Test]
@@ -100,10 +106,10 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-            
+
             // act
             await okTask.UnwrapAsync("Arthur Dent");
-            
+
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
         }
@@ -113,12 +119,15 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var failingTask = Task.FromException<Result<int, string>>(new ArgumentException());
-            
+
             // act
-            async Task Act() => await failingTask.UnwrapAsync("Arthur Dent");
+            async Task Act()
+            {
+                await failingTask.UnwrapAsync("Arthur Dent");
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
@@ -127,17 +136,17 @@ namespace Galaxus.Functional.Tests.ResultExtensions
             // arrange
             var ok = Task.FromResult("hello".ToOk<string, int>());
             var invoked = false;
-            
+
             // act
             var hello = await ok.UnwrapAsync(err =>
             {
                 invoked = true;
                 return "YOLO";
             });
-            
+
             // assert
-            Assert.AreEqual("hello", hello);
-            Assert.IsFalse(invoked);
+            Assert.AreEqual("hello", actual: hello);
+            Assert.IsFalse(condition: invoked);
         }
 
         [Test]
@@ -146,7 +155,7 @@ namespace Galaxus.Functional.Tests.ResultExtensions
             // arrange
             var err = Task.FromResult(0.ToErr<string, int>());
             var invoked = false;
-            
+
             // act
             async Task Act()
             {
@@ -160,14 +169,14 @@ namespace Galaxus.Functional.Tests.ResultExtensions
                 }
                 catch (AttemptToUnwrapErrWhenResultWasOkException ex)
                 {
-                    Assert.AreEqual("YOLO", ex.Message);
+                    Assert.AreEqual("YOLO", actual: ex.Message);
                     throw;
                 }
             }
 
             // assert
-            Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(Act);
-            Assert.IsTrue(invoked);
+            Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(code: Act);
+            Assert.IsTrue(condition: invoked);
         }
 
         [Test]
@@ -175,10 +184,10 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-            
+
             // act
             await okTask.UnwrapAsync(err => "Arthur Dent");
-            
+
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
         }
@@ -190,10 +199,13 @@ namespace Galaxus.Functional.Tests.ResultExtensions
             var failingTask = Task.FromException<Result<int, string>>(new ArgumentException());
 
             // act
-            async Task Act() => await failingTask.UnwrapAsync(err => "Arthur Dent");
-            
+            async Task Act()
+            {
+                await failingTask.UnwrapAsync(err => "Arthur Dent");
+            }
+
             // arrange
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
@@ -202,17 +214,17 @@ namespace Galaxus.Functional.Tests.ResultExtensions
             // arrange
             var ok = Task.FromResult("hello".ToOk<string, int>());
             var invoked = false;
-            
+
             // act
             var hello = await ok.UnwrapAsync(async err =>
             {
                 invoked = true;
                 return await Task.FromResult("YOLO");
             });
-            
+
             // assert
-            Assert.AreEqual("hello", hello);
-            Assert.IsFalse(invoked);
+            Assert.AreEqual("hello", actual: hello);
+            Assert.IsFalse(condition: invoked);
         }
 
         [Test]
@@ -221,7 +233,7 @@ namespace Galaxus.Functional.Tests.ResultExtensions
             // arrange
             var err = Task.FromResult(0.ToErr<string, int>());
             var invoked = false;
-            
+
             // act
             async Task Act()
             {
@@ -235,14 +247,14 @@ namespace Galaxus.Functional.Tests.ResultExtensions
                 }
                 catch (AttemptToUnwrapErrWhenResultWasOkException ex)
                 {
-                    Assert.AreEqual("YOLO", ex.Message);
+                    Assert.AreEqual("YOLO", actual: ex.Message);
                     throw;
                 }
             }
 
             // arrange
-            Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(Act);
-            Assert.IsTrue(invoked);
+            Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(code: Act);
+            Assert.IsTrue(condition: invoked);
         }
 
         [Test]
@@ -250,10 +262,10 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-            
+
             // act
             await okTask.UnwrapAsync(async err => await Task.FromResult("Arthur Dent"));
-            
+
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
         }
@@ -265,10 +277,13 @@ namespace Galaxus.Functional.Tests.ResultExtensions
             var failingTask = Task.FromException<Result<int, string>>(new ArgumentException());
 
             // act
-            async Task Act() => await failingTask.UnwrapAsync(async err => await Task.FromResult("Arthur Dent"));
+            async Task Act()
+            {
+                await failingTask.UnwrapAsync(async err => await Task.FromResult("Arthur Dent"));
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
@@ -276,12 +291,12 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var ok = Task.FromResult("hello".ToOk<string, int>());
-            
+
             //act
             var hello = await ok.UnwrapOrAsync("world");
-            
+
             // assert
-            Assert.AreEqual("hello", hello);
+            Assert.AreEqual("hello", actual: hello);
         }
 
         [Test]
@@ -289,12 +304,12 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var err = Task.FromResult(33.ToErr<string, int>());
-            
+
             // act
             var world = await err.UnwrapOrAsync("world");
-            
+
             // assert
-            Assert.AreEqual("world", world);
+            Assert.AreEqual("world", actual: world);
         }
 
         [Test]
@@ -302,10 +317,10 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-            
+
             // act
             await okTask.UnwrapOrAsync("Arthur Dent");
-            
+
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
         }
@@ -315,12 +330,15 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var failingTask = Task.FromException<Result<string, int>>(new ArgumentException());
-            
+
             // act
-            async Task Act() => await failingTask.UnwrapOrAsync("Arthur Dent");
+            async Task Act()
+            {
+                await failingTask.UnwrapOrAsync("Arthur Dent");
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
 
         [Test]
@@ -328,12 +346,12 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var ok = Task.FromResult("hello".ToOk<string, int>());
-            
+
             // act
             var hello = await ok.UnwrapOrAsync(Task.FromResult("world"));
-            
+
             // assert
-            Assert.AreEqual("hello", hello);
+            Assert.AreEqual("hello", actual: hello);
         }
 
         [Test]
@@ -341,12 +359,12 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var err = Task.FromResult(99.ToErr<string, int>());
-            
+
             // act
             var world = await err.UnwrapOrAsync(Task.FromResult("world"));
-            
+
             // assert
-            Assert.AreEqual("world", world);
+            Assert.AreEqual("world", actual: world);
         }
 
         [Test]
@@ -354,10 +372,10 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-            
+
             // act
             await okTask.UnwrapOrAsync(Task.FromResult("Arthur Dent"));
-            
+
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
         }
@@ -367,25 +385,28 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var failingTask = Task.FromException<Result<string, int>>(new ArgumentException());
-            
+
             // act
-            async Task Act() => await failingTask.UnwrapOrAsync(Task.FromResult("Arthur Dent"));
+            async Task Act()
+            {
+                await failingTask.UnwrapOrAsync(Task.FromResult("Arthur Dent"));
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
-        
+
         [Test]
         public async Task UnwrapOrElseAsync_WhenOk_ThenResultIsOkValue()
         {
             // arrange
             var ok = Task.FromResult("hello".ToOk<string, int>());
-            
+
             // act
             var hello = await ok.UnwrapOrElseAsync(() => "world");
-            
+
             // arrange
-            Assert.AreEqual("hello", hello);
+            Assert.AreEqual("hello", actual: hello);
         }
 
         [Test]
@@ -393,23 +414,23 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var err = Task.FromResult(99.ToErr<string, int>());
-            
+
             // act
             var world = await err.UnwrapOrElseAsync(() => "world");
-            
+
             // assert
-            Assert.AreEqual("world", world);
+            Assert.AreEqual("world", actual: world);
         }
-        
+
         [Test]
         public async Task UnwrapOrElseAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
         {
             // arrange
             var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-            
+
             // act
             await okTask.UnwrapOrElseAsync(() => "Arthur Dent");
-            
+
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
         }
@@ -419,31 +440,34 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var failingTask = Task.FromException<Result<string, int>>(new ArgumentException());
-            
+
             // act
-            async Task Act() => await failingTask.UnwrapOrElseAsync(() => "Arthur Dent");
+            async Task Act()
+            {
+                await failingTask.UnwrapOrElseAsync(() => "Arthur Dent");
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
-        
+
         [Test]
         public async Task UnwrapOrElseAsync_WhenUnwrapOkWithCallBack_ThenNoCallbackInvoked()
         {
             // arrange
             var ok = Task.FromResult("hello".ToOk<string, int>());
             var invoked = false;
-            
+
             // act
             var hello = await ok.UnwrapOrElseAsync(() =>
             {
                 invoked = true;
                 return "world";
             });
-            
+
             // assert
-            Assert.AreEqual("hello", hello);
-            Assert.IsFalse(invoked);
+            Assert.AreEqual("hello", actual: hello);
+            Assert.IsFalse(condition: invoked);
         }
 
         [Test]
@@ -452,17 +476,17 @@ namespace Galaxus.Functional.Tests.ResultExtensions
             // arrange
             var err = Task.FromResult(77.ToErr<string, int>());
             var invoked = false;
-            
+
             // act
             var world = await err.UnwrapOrElseAsync(() =>
             {
                 invoked = true;
                 return "world";
             });
-            
+
             // assert
-            Assert.AreEqual("world", world);
-            Assert.IsTrue(invoked);
+            Assert.AreEqual("world", actual: world);
+            Assert.IsTrue(condition: invoked);
         }
 
 
@@ -474,50 +498,65 @@ namespace Galaxus.Functional.Tests.ResultExtensions
 
             // act
             // ReSharper disable once ExpressionIsAlwaysNull
-            async Task Act() => await Task.FromResult(88.ToErr<string, int>()).UnwrapOrElseAsync(nullFunc);
+            async Task Act()
+            {
+                await Task.FromResult(88.ToErr<string, int>()).UnwrapOrElseAsync(fallback: nullFunc);
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentNullException>(Act);
+            Assert.ThrowsAsync<ArgumentNullException>(code: Act);
         }
-        
+
         [Test]
         public async Task UnwrapOrElseAsyncWithTaskParam_WhenOk_ThenResultIsOkValue()
         {
             // arrange
             var ok = Task.FromResult("hello".ToOk<string, int>());
-            static async Task<string> Continuation() => await Task.FromResult("world");
-            
+
+            static async Task<string> Continuation()
+            {
+                return await Task.FromResult("world");
+            }
+
             // act
-            var hello = await ok.UnwrapOrElseAsync((Func<Task<string>>) Continuation);
-            
+            var hello = await ok.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+
             // assert
-            Assert.AreEqual("hello", hello);
+            Assert.AreEqual("hello", actual: hello);
         }
-        
+
         [Test]
         public async Task UnwrapOrElseAsyncWithTaskParam_WhenErr_ThenResultIsParameterValue()
         {
             // arrange
             var err = Task.FromResult(99.ToErr<string, int>());
-            static async Task<string> Continuation() => await Task.FromResult("world");
-            
+
+            static async Task<string> Continuation()
+            {
+                return await Task.FromResult("world");
+            }
+
             // act
-            var world = await err.UnwrapOrElseAsync((Func<Task<string>>) Continuation);
-            
+            var world = await err.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+
             // assert
-            Assert.AreEqual("world", world);
+            Assert.AreEqual("world", actual: world);
         }
-        
+
         [Test]
         public async Task UnwrapOrElseAsyncWithTaskParam_WhenSynchronousContinuation_ThenReturnsSuccessTask()
         {
             // arrange
             var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
-            static async  Task<string> Continuation() => await Task.FromResult("Arthur Dent");
-            
+
+            static async Task<string> Continuation()
+            {
+                return await Task.FromResult("Arthur Dent");
+            }
+
             // act
-            await okTask.UnwrapOrElseAsync((Func<Task<string>>) Continuation);
-            
+            await okTask.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
         }
@@ -527,34 +566,44 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var failingTask = Task.FromException<Result<string, int>>(new ArgumentException());
-            static async Task<string> Continuation() => await Task.FromResult("Arthur Dent");
-            
+
+            static async Task<string> Continuation()
+            {
+                return await Task.FromResult("Arthur Dent");
+            }
+
             // act
-            async Task Act() => await failingTask.UnwrapOrElseAsync((Func<Task<string>>) Continuation);
+            async Task Act()
+            {
+                await failingTask.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
-        
+
         [Test]
         public async Task UnwrapOrElseAsyncWithTaskParam_WhenUnwrapOkWithCallBack_ThenNoCallbackInvoked()
         {
             // arrange
             var ok = Task.FromResult("hello".ToOk<string, int>());
             var invoked = false;
-            async Task<string> Continuation() =>
-                await Task.Run(() =>
+
+            async Task<string> Continuation()
+            {
+                return await Task.Run(() =>
                 {
                     invoked = true;
                     return "world";
                 });
+            }
 
             // act
-            var hello = await ok.UnwrapOrElseAsync((Func<Task<string>>) Continuation);
-            
+            var hello = await ok.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+
             // assert
-            Assert.AreEqual("hello", hello);
-            Assert.IsFalse(invoked);
+            Assert.AreEqual("hello", actual: hello);
+            Assert.IsFalse(condition: invoked);
         }
 
         [Test]
@@ -563,19 +612,22 @@ namespace Galaxus.Functional.Tests.ResultExtensions
             // arrange
             var err = Task.FromResult(11.ToErr<string, int>());
             var invoked = false;
-            async Task<string> Continuation() =>
-                await Task.Run(() =>
+
+            async Task<string> Continuation()
+            {
+                return await Task.Run(() =>
                 {
                     invoked = true;
                     return "world";
                 });
-            
+            }
+
             // act
-            var world = await err.UnwrapOrElseAsync((Func<Task<string>>) Continuation);
+            var world = await err.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
 
             // assert
-            Assert.AreEqual("world", world);
-            Assert.IsTrue(invoked);
+            Assert.AreEqual("world", actual: world);
+            Assert.IsTrue(condition: invoked);
         }
 
         [Test]
@@ -583,25 +635,28 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             Func<Task<string>> nullFunc = null;
-            
+
             // act
             // ReSharper disable once ExpressionIsAlwaysNull
-            Task Act() => Task.FromResult(12.ToErr<string, int>()).UnwrapOrElseAsync(nullFunc);
+            Task Act()
+            {
+                return Task.FromResult(12.ToErr<string, int>()).UnwrapOrElseAsync(fallback: nullFunc);
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentNullException>(Act);
+            Assert.ThrowsAsync<ArgumentNullException>(code: Act);
         }
-        
+
         [Test]
         public async Task UnwrapOrDefaultAsync_WhenOk_ThenResultIsOkValue()
         {
             // arrange
             var ok = Task.FromResult("hello".ToOk<string, int>());
-            
+
             // act
             var hello = await ok.UnwrapOrDefaultAsync();
             // assert
-            Assert.AreEqual("hello", hello);
+            Assert.AreEqual("hello", actual: hello);
         }
 
         [Test]
@@ -609,51 +664,54 @@ namespace Galaxus.Functional.Tests.ResultExtensions
         {
             // arrange
             var err = Task.FromResult(11.ToErr<string, int>());
-            
+
             // act
             var defaultString = await err.UnwrapOrDefaultAsync();
-            
+
             // assert
-            Assert.AreEqual(null, defaultString);
+            Assert.AreEqual(null, actual: defaultString);
         }
-        
+
         [Test]
         public async Task UnwrapOrDefaultAsync_WhenSynchronousContinuation_ThenReturnsSuccessTask()
         {
             // arrange
             var ok = Task.FromResult("Ford Prefect".ToOk<string, int>());
-            
+
             // act
             await ok.UnwrapOrDefaultAsync();
-            
+
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: ok.Status);
         }
-        
+
         [Test]
         public async Task UnwrapOrDefaultAsync_WhenSynchronousContinuationForErr_ThenReturnsSuccessTask()
         {
             // arrange
             var okTask = Task.FromResult(99.ToErr<string, int>());
-            
+
             // act
             await okTask.UnwrapOrDefaultAsync();
-            
+
             // assert
             Assert.AreEqual(expected: TaskStatus.RanToCompletion, actual: okTask.Status);
         }
-        
+
         [Test]
         public void UnwrapOrDefaultAsync_WhenPreviousTaskThrewArgumentException_ThenArgumentExceptionIsThrown()
         {
             // arrange
             var failingTask = Task.FromException<Result<string, int>>(new ArgumentException());
-            
+
             // act
-            async Task Act() => await failingTask.UnwrapOrDefaultAsync();
+            async Task Act()
+            {
+                await failingTask.UnwrapOrDefaultAsync();
+            }
 
             // assert
-            Assert.ThrowsAsync<ArgumentException>(Act);
+            Assert.ThrowsAsync<ArgumentException>(code: Act);
         }
     }
 }

--- a/Galaxus.Functional.Tests/(Result)/ResultTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultTests.cs
@@ -1,6 +1,6 @@
-using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
+using NUnit.Framework;
 
 namespace Galaxus.Functional.Tests
 {
@@ -11,15 +11,15 @@ namespace Galaxus.Functional.Tests
         {
             {
                 var ok = Result<int, string>.FromOk(666);
-                Assert.IsTrue(ok.IsOk);
-                Assert.IsTrue(ok.Ok.IsSome);
+                Assert.IsTrue(condition: ok.IsOk);
+                Assert.IsTrue(condition: ok.Ok.IsSome);
                 Assert.AreEqual(666, ok.Unwrap());
             }
 
             {
                 var err = Result<int, string>.FromErr("err");
-                Assert.IsTrue(err.IsErr);
-                Assert.IsTrue(err.Err.IsSome);
+                Assert.IsTrue(condition: err.IsErr);
+                Assert.IsTrue(condition: err.Err.IsSome);
                 Assert.AreEqual("err", err.Err.Unwrap());
             }
         }
@@ -29,15 +29,15 @@ namespace Galaxus.Functional.Tests
         {
             {
                 var ok = Result<string, string>.FromOk("ok");
-                Assert.IsTrue(ok.IsOk);
-                Assert.IsTrue(ok.Ok.IsSome);
+                Assert.IsTrue(condition: ok.IsOk);
+                Assert.IsTrue(condition: ok.Ok.IsSome);
                 Assert.AreEqual("ok", ok.Unwrap());
             }
 
             {
                 var err = Result<string, string>.FromErr("err");
-                Assert.IsTrue(err.IsErr);
-                Assert.IsTrue(err.Err.IsSome);
+                Assert.IsTrue(condition: err.IsErr);
+                Assert.IsTrue(condition: err.Err.IsSome);
                 Assert.AreEqual("err", err.Err.Unwrap());
             }
         }
@@ -47,12 +47,12 @@ namespace Galaxus.Functional.Tests
         {
             {
                 var ok = Result<int?, string>.FromOk(null);
-                Assert.IsTrue(ok.IsOk);
+                Assert.IsTrue(condition: ok.IsOk);
             }
 
             {
                 var ok = Result<string, int?>.FromErr(null);
-                Assert.IsTrue(ok.IsErr);
+                Assert.IsTrue(condition: ok.IsErr);
             }
 
             Assert.Throws<ArgumentNullException>(() => Result<string, int?>.FromOk(null));
@@ -65,46 +65,47 @@ namespace Galaxus.Functional.Tests
             var result = "hello".ToOk<string, int>();
 
             {
-                bool called = false;
+                var called = false;
                 result.Match(ok =>
                 {
                     called = true;
-                    Assert.AreEqual("hello", ok);
+                    Assert.AreEqual("hello", actual: ok);
                 }, err => Assert.Fail());
-                Assert.IsTrue(called);
+                Assert.IsTrue(condition: called);
             }
 
             {
-                bool called = false;
+                var called = false;
 
                 var number = result.Match(ok =>
                 {
                     called = true;
-                    Assert.AreEqual("hello", ok);
+                    Assert.AreEqual("hello", actual: ok);
                     return 666;
-                }, err => {
+                }, err =>
+                {
                     Assert.Fail();
                     throw new InvalidOperationException();
                 });
 
-                Assert.AreEqual(666, number);
-                Assert.IsTrue(called);
+                Assert.AreEqual(666, actual: number);
+                Assert.IsTrue(condition: called);
             }
 
             {
-                bool called = false;
+                var called = false;
                 result.IfOk(ok =>
                 {
-                    Assert.AreEqual("hello", ok);
+                    Assert.AreEqual("hello", actual: ok);
                     called = true;
                 });
-                Assert.IsTrue(called);
+                Assert.IsTrue(condition: called);
             }
 
             {
-                bool called = false;
+                var called = false;
                 result.IfErr(err => called = true);
-                Assert.IsFalse(called);
+                Assert.IsFalse(condition: called);
             }
         }
 
@@ -114,47 +115,48 @@ namespace Galaxus.Functional.Tests
             var result = Result<string, int>.FromErr(99);
 
             {
-                bool called = false;
+                var called = false;
                 result.Match(ok => Assert.Fail(), err =>
                 {
-                    Assert.AreEqual(99, err);
+                    Assert.AreEqual(99, actual: err);
                     called = true;
                 });
-                Assert.IsTrue(called);
+                Assert.IsTrue(condition: called);
             }
 
             {
-                bool called = false;
+                var called = false;
 
                 var number = result.Match(ok =>
-                {
-                    Assert.Fail();
-                    throw new InvalidOperationException();
-                },
-                err => {
-                    called = true;
-                    Assert.AreEqual(99, err);
-                    return 666;
-                });
+                    {
+                        Assert.Fail();
+                        throw new InvalidOperationException();
+                    },
+                    err =>
+                    {
+                        called = true;
+                        Assert.AreEqual(99, actual: err);
+                        return 666;
+                    });
 
-                Assert.AreEqual(666, number);
-                Assert.IsTrue(called);
+                Assert.AreEqual(666, actual: number);
+                Assert.IsTrue(condition: called);
             }
 
             {
-                bool called = false;
+                var called = false;
                 result.IfErr(err =>
                 {
-                    Assert.AreEqual(99, err);
+                    Assert.AreEqual(99, actual: err);
                     called = true;
                 });
-                Assert.IsTrue(called);
+                Assert.IsTrue(condition: called);
             }
 
             {
-                bool called = false;
+                var called = false;
                 result.IfOk(ok => called = true);
-                Assert.IsFalse(called);
+                Assert.IsFalse(condition: called);
             }
         }
 
@@ -179,16 +181,16 @@ namespace Galaxus.Functional.Tests
         {
             const string successString = "success";
 
-            Func<string, Task<string>> continuationOk = async s => await Task.FromResult(s);
+            Func<string, Task<string>> continuationOk = async s => await Task.FromResult(result: s);
 
-            Func<string, Task<string>> continuationErr = async _ =>  await Task.FromResult("error");
+            Func<string, Task<string>> continuationErr = async _ => await Task.FromResult("error");
 
-            var result = await Result<string, string>.FromOk(successString)
+            var result = await Result<string, string>.FromOk(ok: successString)
                 .MatchAsync(
-                    async ok => await continuationOk(ok),
-                    async err => await continuationErr(err));
+                    async ok => await continuationOk(arg: ok),
+                    async err => await continuationErr(arg: err));
 
-            Assert.That(result, Is.EqualTo(successString));
+            Assert.That(actual: result, Is.EqualTo(expected: successString));
         }
 
         [Test]
@@ -196,16 +198,16 @@ namespace Galaxus.Functional.Tests
         {
             const string errorString = "error";
 
-            Func<string, Task<string>> continuationOk = async s => await Task.FromResult(s);
+            Func<string, Task<string>> continuationOk = async s => await Task.FromResult(result: s);
 
-            Func<string, Task<string>> continuationErr = async _ =>  await Task.FromResult(errorString);
+            Func<string, Task<string>> continuationErr = async _ => await Task.FromResult(result: errorString);
 
             var result = await Result<string, string>.FromErr("any error message")
                 .MatchAsync(
-                    async ok => await continuationOk(ok),
-                    async err => await continuationErr(err));
+                    async ok => await continuationOk(arg: ok),
+                    async err => await continuationErr(arg: err));
 
-            Assert.That(result, Is.EqualTo(errorString));
+            Assert.That(actual: result, Is.EqualTo(expected: errorString));
         }
 
         [Test]
@@ -215,38 +217,49 @@ namespace Galaxus.Functional.Tests
                 var ok = Result<int, string>.FromOk(2);
                 var err = Result<int, string>.FromErr("late error");
 
-                Assert.AreEqual(2.ToOk<int, string>(), ok.Or(err));
+                Assert.AreEqual(2.ToOk<int, string>(), ok.Or(fallback: err));
             }
             {
                 var err = Result<int, string>.FromErr("early error");
                 var ok = Result<int, string>.FromOk(2);
 
-                Assert.AreEqual(2.ToOk<int, string>(), err.Or(ok));
+                Assert.AreEqual(2.ToOk<int, string>(), err.Or(fallback: ok));
             }
             {
                 var err1 = Result<int, string>.FromErr("not a 2");
                 var err2 = Result<int, string>.FromErr("late error");
 
-                Assert.AreEqual("late error".ToErr<int, string>(), err1.Or(err2));
+                Assert.AreEqual("late error".ToErr<int, string>(), err1.Or(fallback: err2));
             }
             {
                 var ok1 = Result<int, string>.FromOk(2);
                 var ok2 = Result<int, string>.FromOk(100);
 
-                Assert.AreEqual(2.ToOk<int, string>(), ok1.Or(ok2));
+                Assert.AreEqual(2.ToOk<int, string>(), ok1.Or(fallback: ok2));
             }
         }
 
         [Test]
         public void Result_OrElse()
         {
-            Result<int, int> Square(int i) => Result<int, int>.FromOk(i * i);
-            Result<int, int> Error(int i) => Result<int, int>.FromErr(i);
+            Result<int, int> Square(int i)
+            {
+                return Result<int, int>.FromOk(i * i);
+            }
 
-            Assert.AreEqual(Result<int, int>.FromOk(2), Result<int, int>.FromOk(2).OrElse(Square).OrElse(Square));
-            Assert.AreEqual(Result<int, int>.FromOk(2), Result<int, int>.FromOk(2).OrElse(Error).OrElse(Square));
-            Assert.AreEqual(Result<int, int>.FromOk(9), Result<int, int>.FromErr(3).OrElse(Square).OrElse(Error));
-            Assert.AreEqual(Result<int, int>.FromErr(3), Result<int, int>.FromErr(3).OrElse(Error).OrElse(Error));
+            Result<int, int> Error(int i)
+            {
+                return Result<int, int>.FromErr(err: i);
+            }
+
+            Assert.AreEqual(Result<int, int>.FromOk(2),
+                Result<int, int>.FromOk(2).OrElse(continuation: Square).OrElse(continuation: Square));
+            Assert.AreEqual(Result<int, int>.FromOk(2),
+                Result<int, int>.FromOk(2).OrElse(continuation: Error).OrElse(continuation: Square));
+            Assert.AreEqual(Result<int, int>.FromOk(9),
+                Result<int, int>.FromErr(3).OrElse(continuation: Square).OrElse(continuation: Error));
+            Assert.AreEqual(Result<int, int>.FromErr(3),
+                Result<int, int>.FromErr(3).OrElse(continuation: Error).OrElse(continuation: Error));
         }
 
         [Test]
@@ -254,13 +267,14 @@ namespace Galaxus.Functional.Tests
         {
             const string initialResult = "a";
             const string continuationResult = "b";
-            Func<string, Task<Result<string, string>>> continuation = s => Task.FromResult(Result<string, string>.FromErr(continuationResult));
-            var result = await Result<string, string>.FromErr(initialResult)
-                .OrElseAsync(continuation);
+            Func<string, Task<Result<string, string>>> continuation = s =>
+                Task.FromResult(Result<string, string>.FromErr(err: continuationResult));
+            var result = await Result<string, string>.FromErr(err: initialResult)
+                .OrElseAsync(continuation: continuation);
 
             result.Match(
                 ok => Assert.Fail(),
-                err => Assert.AreEqual(continuationResult, err));
+                err => Assert.AreEqual(expected: continuationResult, actual: err));
         }
 
         [Test]
@@ -268,13 +282,14 @@ namespace Galaxus.Functional.Tests
         {
             const string initialResult = "a";
             const string continuationResult = "b";
-            Func<string, Task<Result<string, string>>> continuation = s => Task.FromResult(Result<string, string>.FromErr(continuationResult));
+            Func<string, Task<Result<string, string>>> continuation = s =>
+                Task.FromResult(Result<string, string>.FromErr(err: continuationResult));
 
-            var result = await Result<string, string>.FromOk(initialResult)
-                .OrElseAsync(continuation);
+            var result = await Result<string, string>.FromOk(ok: initialResult)
+                .OrElseAsync(continuation: continuation);
 
             result.Match(
-                ok => Assert.AreEqual(initialResult, ok),
+                ok => Assert.AreEqual(expected: initialResult, actual: ok),
                 err => Assert.Fail());
         }
 
@@ -295,7 +310,7 @@ namespace Galaxus.Functional.Tests
             var err = 99.ToErr<string, int>();
 
             {
-                bool invoked = false;
+                var invoked = false;
 
                 Assert.AreEqual("hello", ok.UnwrapOrElse(() =>
                 {
@@ -303,11 +318,11 @@ namespace Galaxus.Functional.Tests
                     return "world";
                 }));
 
-                Assert.IsFalse(invoked);
+                Assert.IsFalse(condition: invoked);
             }
 
             {
-                bool invoked = false;
+                var invoked = false;
 
                 Assert.AreEqual("world", err.UnwrapOrElse(() =>
                 {
@@ -315,7 +330,7 @@ namespace Galaxus.Functional.Tests
                     return "world";
                 }));
 
-                Assert.IsTrue(invoked);
+                Assert.IsTrue(condition: invoked);
             }
         }
 
@@ -336,14 +351,15 @@ namespace Galaxus.Functional.Tests
             var err = 99.ToErr<string, int>();
 
             Assert.AreEqual("hello", ok.Unwrap("YOLO"));
-            Assert.Throws<AttemptToUnwrapErrWhenResultWasOkException>(() => {
+            Assert.Throws<AttemptToUnwrapErrWhenResultWasOkException>(() =>
+            {
                 try
                 {
                     err.Unwrap("YOLO");
                 }
                 catch (AttemptToUnwrapErrWhenResultWasOkException ex)
                 {
-                    Assert.AreEqual("YOLO", ex.Message);
+                    Assert.AreEqual("YOLO", actual: ex.Message);
                     throw;
                 }
             });
@@ -352,31 +368,38 @@ namespace Galaxus.Functional.Tests
         [Test]
         public void Result_UnwrapWithCustomInvokableError()
         {
-
             {
                 var ok = "hello".ToOk<string, int>();
-                bool invoked = false;
-                Assert.AreEqual("hello", ok.Unwrap(err => { invoked = true; return "YOLO"; }));
-                Assert.IsFalse(invoked);
+                var invoked = false;
+                Assert.AreEqual("hello", ok.Unwrap(err =>
+                {
+                    invoked = true;
+                    return "YOLO";
+                }));
+                Assert.IsFalse(condition: invoked);
             }
 
             {
                 var err = 0.ToErr<string, int>();
-                bool invoked = false;
+                var invoked = false;
                 Assert.Throws<AttemptToUnwrapErrWhenResultWasOkException>(() =>
                 {
                     try
                     {
-                        err.Unwrap(err_ => { invoked = true; return "YOLO"; });
+                        err.Unwrap(err_ =>
+                        {
+                            invoked = true;
+                            return "YOLO";
+                        });
                     }
                     catch (AttemptToUnwrapErrWhenResultWasOkException ex)
                     {
-                        Assert.AreEqual("YOLO", ex.Message);
+                        Assert.AreEqual("YOLO", actual: ex.Message);
                         throw;
                     }
                 });
 
-                Assert.IsTrue(invoked);
+                Assert.IsTrue(condition: invoked);
             }
         }
 
@@ -386,7 +409,7 @@ namespace Galaxus.Functional.Tests
             var ok1 = "hello".ToOk<string, string>();
             var ok2 = "hello".ToOk<string, string>();
             Assert.AreEqual(ok1.GetHashCode(), ok2.GetHashCode());
-            Assert.AreEqual(ok1, ok2);
+            Assert.AreEqual(expected: ok1, actual: ok2);
         }
 
         [Test]
@@ -395,7 +418,7 @@ namespace Galaxus.Functional.Tests
             var err1 = "hello".ToErr<string, string>();
             var err2 = "hello".ToErr<string, string>();
             Assert.AreEqual(err1.GetHashCode(), err2.GetHashCode());
-            Assert.AreEqual(err1, err2);
+            Assert.AreEqual(expected: err1, actual: err2);
         }
 
         [Test]
@@ -403,7 +426,7 @@ namespace Galaxus.Functional.Tests
         {
             var ok = "hello".ToOk<string, string>();
             var err = "hello".ToErr<string, string>();
-            Assert.AreNotEqual(ok, err);
+            Assert.AreNotEqual(expected: ok, actual: err);
         }
 
         [Test]
@@ -411,7 +434,7 @@ namespace Galaxus.Functional.Tests
         {
             var ok1 = "hello".ToOk<string, string>();
             var ok2 = "world".ToOk<string, string>();
-            Assert.AreNotEqual(ok1, ok2);
+            Assert.AreNotEqual(expected: ok1, actual: ok2);
         }
 
         [Test]
@@ -419,7 +442,7 @@ namespace Galaxus.Functional.Tests
         {
             var err1 = "hello".ToErr<string, string>();
             var err2 = "world".ToErr<string, string>();
-            Assert.AreNotEqual(err1, err2);
+            Assert.AreNotEqual(expected: err1, actual: err2);
         }
 
         [Test]
@@ -427,7 +450,7 @@ namespace Galaxus.Functional.Tests
         {
             var ok1 = "hello".ToOk<string, string>();
             var ok2 = "hello".ToOk<string, int>();
-            Assert.AreNotEqual(ok1, ok2);
+            Assert.AreNotEqual(expected: ok1, actual: ok2);
         }
 
         [Test]
@@ -437,68 +460,90 @@ namespace Galaxus.Functional.Tests
                 var ok = Result<int, string>.FromOk(2);
                 var err = Result<int, string>.FromErr("late error");
 
-                Assert.AreEqual(Result<int, string>.FromErr("late error"), ok.And(err));
+                Assert.AreEqual(Result<int, string>.FromErr("late error"), ok.And(result: err));
             }
 
             {
                 var err = Result<int, string>.FromErr("early error");
                 var ok = Result<string, string>.FromOk("hello");
 
-                Assert.AreEqual( Result<string, string>.FromErr("early error"), err.And(ok));
+                Assert.AreEqual(Result<string, string>.FromErr("early error"), err.And(result: ok));
             }
 
             {
                 var err1 = Result<int, string>.FromErr("not a 2");
                 var err2 = Result<string, string>.FromErr("late error");
 
-                Assert.AreEqual(Result<string, string>.FromErr("not a 2"), err1.And(err2));
+                Assert.AreEqual(Result<string, string>.FromErr("not a 2"), err1.And(result: err2));
             }
 
             {
                 var ok1 = Result<int, string>.FromOk(2);
                 var ok2 = Result<string, string>.FromOk("different result type");
 
-                Assert.AreEqual(Result<string, string>.FromOk("different result type"), ok1.And(ok2));
+                Assert.AreEqual(Result<string, string>.FromOk("different result type"), ok1.And(result: ok2));
             }
         }
 
         [Test]
         public void Result_AndThen()
         {
-            Result<int, int> Square(int i) => Result<int, int>.FromOk(i * i);
-            Result<int, int> Error(int i) => Result<int, int>.FromErr(i);
+            Result<int, int> Square(int i)
+            {
+                return Result<int, int>.FromOk(i * i);
+            }
 
-            Assert.AreEqual(Result<int, int>.FromOk(16), Result<int, int>.FromOk(2).AndThen(Square).AndThen(Square));
-            Assert.AreEqual(Result<int, int>.FromErr(4), Result<int, int>.FromOk(2).AndThen(Square).AndThen(Error));
-            Assert.AreEqual(Result<int, int>.FromErr(2), Result<int, int>.FromOk(2).AndThen(Error).AndThen(Square));
-            Assert.AreEqual(Result<int, int>.FromErr(3), Result<int, int>.FromErr(3).AndThen(Square).AndThen(Square));
+            Result<int, int> Error(int i)
+            {
+                return Result<int, int>.FromErr(err: i);
+            }
+
+            Assert.AreEqual(Result<int, int>.FromOk(16),
+                Result<int, int>.FromOk(2).AndThen(continuation: Square).AndThen(continuation: Square));
+            Assert.AreEqual(Result<int, int>.FromErr(4),
+                Result<int, int>.FromOk(2).AndThen(continuation: Square).AndThen(continuation: Error));
+            Assert.AreEqual(Result<int, int>.FromErr(2),
+                Result<int, int>.FromOk(2).AndThen(continuation: Error).AndThen(continuation: Square));
+            Assert.AreEqual(Result<int, int>.FromErr(3),
+                Result<int, int>.FromErr(3).AndThen(continuation: Square).AndThen(continuation: Square));
         }
 
         [Test]
         public void Result_AndThenWithAction()
         {
-            Result<int, int> Square(int i) => Result<int, int>.FromOk(i * i);
-            Result<int, int> Error(int i) => Result<int, int>.FromErr(i);
+            Result<int, int> Square(int i)
+            {
+                return Result<int, int>.FromOk(i * i);
+            }
+
+            Result<int, int> Error(int i)
+            {
+                return Result<int, int>.FromErr(err: i);
+            }
 
             {
                 var invoked = false;
-                Assert.AreEqual(Result<int, int>.FromOk(9), Result<int, int>.FromOk(3).AndThen(i => invoked = true).AndThen(Square));
-                Assert.IsTrue(invoked);
+                Assert.AreEqual(Result<int, int>.FromOk(9),
+                    Result<int, int>.FromOk(3).AndThen(i => invoked = true).AndThen(continuation: Square));
+                Assert.IsTrue(condition: invoked);
             }
             {
                 var invoked = false;
-                Assert.AreEqual(Result<int, int>.FromErr(3), Result<int, int>.FromOk(3).AndThen(i => invoked = true).AndThen(Error));
-                Assert.IsTrue(invoked);
+                Assert.AreEqual(Result<int, int>.FromErr(3),
+                    Result<int, int>.FromOk(3).AndThen(i => invoked = true).AndThen(continuation: Error));
+                Assert.IsTrue(condition: invoked);
             }
             {
                 var invoked = false;
-                Assert.AreEqual(Result<int, int>.FromErr(3), Result<int, int>.FromOk(3).AndThen(Error).AndThen(i => invoked = true));
-                Assert.IsFalse(invoked);
+                Assert.AreEqual(Result<int, int>.FromErr(3),
+                    Result<int, int>.FromOk(3).AndThen(continuation: Error).AndThen(i => invoked = true));
+                Assert.IsFalse(condition: invoked);
             }
             {
                 var invoked = false;
-                Assert.AreEqual(Result<int, int>.FromErr(5), Result<int, int>.FromErr(5).AndThen(Square).AndThen(i => invoked = true));
-                Assert.IsFalse(invoked);
+                Assert.AreEqual(Result<int, int>.FromErr(5),
+                    Result<int, int>.FromErr(5).AndThen(continuation: Square).AndThen(i => invoked = true));
+                Assert.IsFalse(condition: invoked);
             }
         }
 
@@ -506,9 +551,9 @@ namespace Galaxus.Functional.Tests
         public void Result_AndThenAction_ForwardsCurrentValue()
         {
             var result = Result<string, int>.FromOk("Success");
-            var nextResult = result.AndThen(Console.WriteLine);
+            var nextResult = result.AndThen(continuation: Console.WriteLine);
 
-            Assert.AreSame(nextResult, result);
+            Assert.AreSame(expected: nextResult, actual: result);
         }
 
         [Test]
@@ -521,9 +566,9 @@ namespace Galaxus.Functional.Tests
                 return Unit.Value;
             }
 
-            var nextResult = success.AndThen(Nop);
-            Assert.IsTrue(nextResult.IsOk);
-            Assert.AreEqual(Unit.Value, nextResult.Ok.Unwrap());
+            var nextResult = success.AndThen(continuation: Nop);
+            Assert.IsTrue(condition: nextResult.IsOk);
+            Assert.AreEqual(expected: Unit.Value, nextResult.Ok.Unwrap());
         }
 
 
@@ -534,11 +579,11 @@ namespace Galaxus.Functional.Tests
 
             Result<Unit, int> Nop(Result<string, int> x)
             {
-                return x.Match(ok => Result<Unit, int>.FromOk(Unit.Value), err => err);
+                return x.Match(ok => Result<Unit, int>.FromOk(ok: Unit.Value), err => err);
             }
 
-            var nextResult = success.AndThen(s => Nop(s));
-            Assert.IsTrue(nextResult.IsErr);
+            var nextResult = success.AndThen(s => Nop(x: s));
+            Assert.IsTrue(condition: nextResult.IsErr);
             Assert.AreEqual(5, nextResult.Err.Unwrap());
         }
 
@@ -547,10 +592,11 @@ namespace Galaxus.Functional.Tests
         {
             const string initialResult = "a";
             const string continuationResult = "b";
-            Func<string, Task<Result<string, string>>> continuation = s => Task.FromResult(Result<string, string>.FromOk(continuationResult));
-            var result = await Result<string, string>.FromOk(initialResult)
-                .AndThenAsync(continuation);
-            Assert.AreEqual(expected: continuationResult, actual: result.Ok.UnwrapOrDefault());
+            Func<string, Task<Result<string, string>>> continuation = s =>
+                Task.FromResult(Result<string, string>.FromOk(ok: continuationResult));
+            var result = await Result<string, string>.FromOk(ok: initialResult)
+                .AndThenAsync(continuation: continuation);
+            Assert.AreEqual(expected: continuationResult, result.Ok.UnwrapOrDefault());
         }
 
         [Test]
@@ -558,10 +604,11 @@ namespace Galaxus.Functional.Tests
         {
             const string initialError = "a";
             const string continuationResult = "b";
-            Func<string, Task<Result<string, string>>> continuation = s => Task.FromResult(Result<string, string>.FromOk(continuationResult));
-            var result = await Result<string, string>.FromErr(initialError)
-                .AndThenAsync(continuation);
-            Assert.IsTrue(result.IsErr);
+            Func<string, Task<Result<string, string>>> continuation = s =>
+                Task.FromResult(Result<string, string>.FromOk(ok: continuationResult));
+            var result = await Result<string, string>.FromErr(err: initialError)
+                .AndThenAsync(continuation: continuation);
+            Assert.IsTrue(condition: result.IsErr);
         }
 
         [Test]
@@ -569,10 +616,10 @@ namespace Galaxus.Functional.Tests
         {
             const string initialResult = "a";
             const string continuationResult = "b";
-            Func<string, Task<string>> continuation = s => Task.FromResult(continuationResult);
-            var result = await Result<string, string>.FromOk(initialResult)
-                .MapAsync(continuation);
-            Assert.AreEqual(expected: continuationResult, actual: result.Ok.UnwrapOrDefault());
+            Func<string, Task<string>> continuation = s => Task.FromResult(result: continuationResult);
+            var result = await Result<string, string>.FromOk(ok: initialResult)
+                .MapAsync(continuation: continuation);
+            Assert.AreEqual(expected: continuationResult, result.Ok.UnwrapOrDefault());
         }
 
         [Test]
@@ -580,10 +627,10 @@ namespace Galaxus.Functional.Tests
         {
             const string initialError = "a";
             const string continuationResult = "b";
-            Func<string, Task<string>> continuation = s => Task.FromResult(continuationResult);
-            var result = await Result<string, string>.FromErr(initialError)
-                .MapAsync(continuation);
-            Assert.IsTrue(result.IsErr);
+            Func<string, Task<string>> continuation = s => Task.FromResult(result: continuationResult);
+            var result = await Result<string, string>.FromErr(err: initialError)
+                .MapAsync(continuation: continuation);
+            Assert.IsTrue(condition: result.IsErr);
         }
 
         [Test]
@@ -594,8 +641,8 @@ namespace Galaxus.Functional.Tests
 
             Assert.ThrowsAsync<ArgumentException>(async () =>
             {
-                await Result<string, string>.FromOk(initialResult)
-                    .MapAsync(continuation);
+                await Result<string, string>.FromOk(ok: initialResult)
+                    .MapAsync(continuation: continuation);
             });
         }
 
@@ -604,10 +651,10 @@ namespace Galaxus.Functional.Tests
         {
             const string initialError = "a";
             const string continuationResult = "b";
-            Func<string, Task<string>> continuation = s => Task.FromResult(continuationResult);
-            var result = await Result<string, string>.FromErr(initialError)
-                .MapErrAsync(continuation);
-            Assert.AreEqual(expected: continuationResult, actual: result.Err.UnwrapOrDefault());
+            Func<string, Task<string>> continuation = s => Task.FromResult(result: continuationResult);
+            var result = await Result<string, string>.FromErr(err: initialError)
+                .MapErrAsync(continuation: continuation);
+            Assert.AreEqual(expected: continuationResult, result.Err.UnwrapOrDefault());
         }
 
         [Test]
@@ -615,10 +662,10 @@ namespace Galaxus.Functional.Tests
         {
             const string initialResult = "a";
             const string continuationResult = "b";
-            Func<string, Task<string>> continuation = s => Task.FromResult(continuationResult);
-            var result = await Result<string, string>.FromOk(initialResult)
-                .MapErrAsync(continuation);
-            Assert.IsTrue(result.IsOk);
+            Func<string, Task<string>> continuation = s => Task.FromResult(result: continuationResult);
+            var result = await Result<string, string>.FromOk(ok: initialResult)
+                .MapErrAsync(continuation: continuation);
+            Assert.IsTrue(condition: result.IsOk);
         }
 
         [Test]
@@ -629,8 +676,8 @@ namespace Galaxus.Functional.Tests
 
             Assert.ThrowsAsync<ArgumentException>(async () =>
             {
-                await Result<string, string>.FromErr(initialResult)
-                    .MapErrAsync(continuation);
+                await Result<string, string>.FromErr(err: initialResult)
+                    .MapErrAsync(continuation: continuation);
             });
         }
 
@@ -643,8 +690,8 @@ namespace Galaxus.Functional.Tests
 
             Assert.ThrowsAsync<ArgumentException>(async () =>
             {
-                await Result<string, string>.FromOk(initialResult)
-                    .MatchAsync(continuationOk, continuationErr);
+                await Result<string, string>.FromOk(ok: initialResult)
+                    .MatchAsync(onOk: continuationOk, onErr: continuationErr);
             });
         }
 
@@ -660,8 +707,8 @@ namespace Galaxus.Functional.Tests
         {
             var ok = Result<string, string>.FromOk("Success");
             var mappingResult = ok.Map(s => s.Length);
-            Assert.IsTrue(mappingResult.IsOk);
-            Assert.AreEqual("Success".Length, mappingResult.Ok.Unwrap());
+            Assert.IsTrue(condition: mappingResult.IsOk);
+            Assert.AreEqual(expected: "Success".Length, mappingResult.Ok.Unwrap());
         }
 
         [Test]
@@ -669,7 +716,7 @@ namespace Galaxus.Functional.Tests
         {
             var ok = Result<string, string>.FromErr("Failure");
             var mappingResult = ok.Map(s => s.Length);
-            Assert.IsTrue(mappingResult.IsErr);
+            Assert.IsTrue(condition: mappingResult.IsErr);
             Assert.AreEqual("Failure", mappingResult.Err.Unwrap());
         }
 
@@ -685,8 +732,8 @@ namespace Galaxus.Functional.Tests
         {
             var ok = Result<string, string>.FromErr("Failure");
             var mappingResult = ok.MapErr(s => s.Length);
-            Assert.IsTrue(mappingResult.IsErr);
-            Assert.AreEqual("Failure".Length, mappingResult.Err.Unwrap());
+            Assert.IsTrue(condition: mappingResult.IsErr);
+            Assert.AreEqual(expected: "Failure".Length, mappingResult.Err.Unwrap());
         }
 
         [Test]
@@ -694,7 +741,7 @@ namespace Galaxus.Functional.Tests
         {
             var ok = Result<string, string>.FromOk("Success");
             var mappingResult = ok.MapErr(s => s.Length);
-            Assert.IsTrue(mappingResult.IsOk);
+            Assert.IsTrue(condition: mappingResult.IsOk);
             Assert.AreEqual("Success", mappingResult.Ok.Unwrap());
         }
 
@@ -711,9 +758,9 @@ namespace Galaxus.Functional.Tests
                 result = s;
             };
 
-            await Result<string, string>.FromOk(continuationString).IfOkAsync(async s => await continuation(s));
+            await Result<string, string>.FromOk(ok: continuationString).IfOkAsync(async s => await continuation(arg: s));
 
-            Assert.That(result, Is.EqualTo(continuationString));
+            Assert.That(actual: result, Is.EqualTo(expected: continuationString));
         }
 
         [Test]
@@ -727,9 +774,9 @@ namespace Galaxus.Functional.Tests
                 result = s;
             };
 
-            await Result<string, string>.FromErr("err").IfOkAsync(async s => await continuation(s));
+            await Result<string, string>.FromErr("err").IfOkAsync(async s => await continuation(arg: s));
 
-            Assert.That(result, Is.EqualTo(string.Empty));
+            Assert.That(actual: result, Is.EqualTo(expected: string.Empty));
         }
 
         [Test]
@@ -745,9 +792,9 @@ namespace Galaxus.Functional.Tests
                 result = s;
             };
 
-            await Result<string, string>.FromErr(continuationString).IfErrAsync(async s => await continuation(s));
+            await Result<string, string>.FromErr(err: continuationString).IfErrAsync(async s => await continuation(arg: s));
 
-            Assert.That(result, Is.EqualTo(continuationString));
+            Assert.That(actual: result, Is.EqualTo(expected: continuationString));
         }
 
         [Test]
@@ -761,9 +808,9 @@ namespace Galaxus.Functional.Tests
                 result = s;
             };
 
-            await Result<string, string>.FromOk("success").IfErrAsync(async s => await continuation(s));
+            await Result<string, string>.FromOk("success").IfErrAsync(async s => await continuation(arg: s));
 
-            Assert.That(result, Is.EqualTo(string.Empty));
+            Assert.That(actual: result, Is.EqualTo(expected: string.Empty));
         }
     }
 }

--- a/Galaxus.Functional.Tests/(Result)/ResultTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultTests.cs
@@ -2,817 +2,816 @@ using System;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests
+namespace Galaxus.Functional.Tests;
+
+public class ResultTests
 {
-    public class ResultTests
+    [Test]
+    public void Result_From_OkAndErrAreDifferentTypes()
     {
-        [Test]
-        public void Result_From_OkAndErrAreDifferentTypes()
         {
-            {
-                var ok = Result<int, string>.FromOk(666);
-                Assert.IsTrue(condition: ok.IsOk);
-                Assert.IsTrue(condition: ok.Ok.IsSome);
-                Assert.AreEqual(666, ok.Unwrap());
-            }
-
-            {
-                var err = Result<int, string>.FromErr("err");
-                Assert.IsTrue(condition: err.IsErr);
-                Assert.IsTrue(condition: err.Err.IsSome);
-                Assert.AreEqual("err", err.Err.Unwrap());
-            }
+            var ok = Result<int, string>.FromOk(666);
+            Assert.IsTrue(ok.IsOk);
+            Assert.IsTrue(ok.Ok.IsSome);
+            Assert.AreEqual(666, ok.Unwrap());
         }
 
-        [Test]
-        public void Result_From_OkAndErrAreSameTypes()
         {
-            {
-                var ok = Result<string, string>.FromOk("ok");
-                Assert.IsTrue(condition: ok.IsOk);
-                Assert.IsTrue(condition: ok.Ok.IsSome);
-                Assert.AreEqual("ok", ok.Unwrap());
-            }
+            var err = Result<int, string>.FromErr("err");
+            Assert.IsTrue(err.IsErr);
+            Assert.IsTrue(err.Err.IsSome);
+            Assert.AreEqual("err", err.Err.Unwrap());
+        }
+    }
 
-            {
-                var err = Result<string, string>.FromErr("err");
-                Assert.IsTrue(condition: err.IsErr);
-                Assert.IsTrue(condition: err.Err.IsSome);
-                Assert.AreEqual("err", err.Err.Unwrap());
-            }
+    [Test]
+    public void Result_From_OkAndErrAreSameTypes()
+    {
+        {
+            var ok = Result<string, string>.FromOk("ok");
+            Assert.IsTrue(ok.IsOk);
+            Assert.IsTrue(ok.Ok.IsSome);
+            Assert.AreEqual("ok", ok.Unwrap());
         }
 
-        [Test]
-        public void Result_ConstructFromNull()
         {
-            {
-                var ok = Result<int?, string>.FromOk(null);
-                Assert.IsTrue(condition: ok.IsOk);
-            }
+            var err = Result<string, string>.FromErr("err");
+            Assert.IsTrue(err.IsErr);
+            Assert.IsTrue(err.Err.IsSome);
+            Assert.AreEqual("err", err.Err.Unwrap());
+        }
+    }
 
-            {
-                var ok = Result<string, int?>.FromErr(null);
-                Assert.IsTrue(condition: ok.IsErr);
-            }
-
-            Assert.Throws<ArgumentNullException>(() => Result<string, int?>.FromOk(null));
-            Assert.Throws<ArgumentNullException>(() => Result<int?, string>.FromErr(null));
+    [Test]
+    public void Result_ConstructFromNull()
+    {
+        {
+            var ok = Result<int?, string>.FromOk(null);
+            Assert.IsTrue(ok.IsOk);
         }
 
-        [Test]
-        public void Result_MatchOk()
         {
-            var result = "hello".ToOk<string, int>();
+            var ok = Result<string, int?>.FromErr(null);
+            Assert.IsTrue(ok.IsErr);
+        }
 
+        Assert.Throws<ArgumentNullException>(() => Result<string, int?>.FromOk(null));
+        Assert.Throws<ArgumentNullException>(() => Result<int?, string>.FromErr(null));
+    }
+
+    [Test]
+    public void Result_MatchOk()
+    {
+        var result = "hello".ToOk<string, int>();
+
+        {
+            var called = false;
+            result.Match(ok =>
             {
-                var called = false;
-                result.Match(ok =>
-                {
-                    called = true;
-                    Assert.AreEqual("hello", actual: ok);
-                }, err => Assert.Fail());
-                Assert.IsTrue(condition: called);
-            }
+                called = true;
+                Assert.AreEqual("hello", ok);
+            }, err => Assert.Fail());
+            Assert.IsTrue(called);
+        }
 
+        {
+            var called = false;
+
+            var number = result.Match(ok =>
             {
-                var called = false;
+                called = true;
+                Assert.AreEqual("hello", ok);
+                return 666;
+            }, err =>
+            {
+                Assert.Fail();
+                throw new InvalidOperationException();
+            });
 
-                var number = result.Match(ok =>
-                {
-                    called = true;
-                    Assert.AreEqual("hello", actual: ok);
-                    return 666;
-                }, err =>
+            Assert.AreEqual(666, number);
+            Assert.IsTrue(called);
+        }
+
+        {
+            var called = false;
+            result.IfOk(ok =>
+            {
+                Assert.AreEqual("hello", ok);
+                called = true;
+            });
+            Assert.IsTrue(called);
+        }
+
+        {
+            var called = false;
+            result.IfErr(err => called = true);
+            Assert.IsFalse(called);
+        }
+    }
+
+    [Test]
+    public void Result_MatchErr()
+    {
+        var result = Result<string, int>.FromErr(99);
+
+        {
+            var called = false;
+            result.Match(ok => Assert.Fail(), err =>
+            {
+                Assert.AreEqual(99, err);
+                called = true;
+            });
+            Assert.IsTrue(called);
+        }
+
+        {
+            var called = false;
+
+            var number = result.Match(ok =>
                 {
                     Assert.Fail();
                     throw new InvalidOperationException();
-                });
-
-                Assert.AreEqual(666, actual: number);
-                Assert.IsTrue(condition: called);
-            }
-
-            {
-                var called = false;
-                result.IfOk(ok =>
+                },
+                err =>
                 {
-                    Assert.AreEqual("hello", actual: ok);
                     called = true;
+                    Assert.AreEqual(99, err);
+                    return 666;
                 });
-                Assert.IsTrue(condition: called);
-            }
 
-            {
-                var called = false;
-                result.IfErr(err => called = true);
-                Assert.IsFalse(condition: called);
-            }
+            Assert.AreEqual(666, number);
+            Assert.IsTrue(called);
         }
 
-        [Test]
-        public void Result_MatchErr()
         {
-            var result = Result<string, int>.FromErr(99);
-
+            var called = false;
+            result.IfErr(err =>
             {
-                var called = false;
-                result.Match(ok => Assert.Fail(), err =>
-                {
-                    Assert.AreEqual(99, actual: err);
-                    called = true;
-                });
-                Assert.IsTrue(condition: called);
-            }
-
-            {
-                var called = false;
-
-                var number = result.Match(ok =>
-                    {
-                        Assert.Fail();
-                        throw new InvalidOperationException();
-                    },
-                    err =>
-                    {
-                        called = true;
-                        Assert.AreEqual(99, actual: err);
-                        return 666;
-                    });
-
-                Assert.AreEqual(666, actual: number);
-                Assert.IsTrue(condition: called);
-            }
-
-            {
-                var called = false;
-                result.IfErr(err =>
-                {
-                    Assert.AreEqual(99, actual: err);
-                    called = true;
-                });
-                Assert.IsTrue(condition: called);
-            }
-
-            {
-                var called = false;
-                result.IfOk(ok => called = true);
-                Assert.IsFalse(condition: called);
-            }
+                Assert.AreEqual(99, err);
+                called = true;
+            });
+            Assert.IsTrue(called);
         }
 
-        [Test]
-        public void ResultMatchWithNullMatchPatternThrows()
         {
-            // OK
-            Assert.Throws<ArgumentNullException>(() => { 0.ToOk<int, string>().Match(null, err => { }); });
-            Assert.Throws<ArgumentNullException>(() => { 0.ToOk<int, string>().IfOk(null); });
-
-            // ERR
-            Assert.Throws<ArgumentNullException>(() => { "hello".ToErr<int, string>().Match(v => { }, null); });
-            Assert.Throws<ArgumentNullException>(() => { "hello".ToErr<int, string>().IfErr(null); });
-
-            // OK and ERR with return value
-            Assert.Throws<ArgumentNullException>(() => { _ = 0.ToOk<int, string>().Match(null, err => 0); });
-            Assert.Throws<ArgumentNullException>(() => { _ = "hello".ToErr<int, string>().Match(v => v, null); });
+            var called = false;
+            result.IfOk(ok => called = true);
+            Assert.IsFalse(called);
         }
+    }
 
-        [Test]
-        public async Task MatchAsync_PreviousResultWasSuccess_ReturnsOk()
+    [Test]
+    public void ResultMatchWithNullMatchPatternThrows()
+    {
+        // OK
+        Assert.Throws<ArgumentNullException>(() => { 0.ToOk<int, string>().Match(null, err => { }); });
+        Assert.Throws<ArgumentNullException>(() => { 0.ToOk<int, string>().IfOk(null); });
+
+        // ERR
+        Assert.Throws<ArgumentNullException>(() => { "hello".ToErr<int, string>().Match(v => { }, null); });
+        Assert.Throws<ArgumentNullException>(() => { "hello".ToErr<int, string>().IfErr(null); });
+
+        // OK and ERR with return value
+        Assert.Throws<ArgumentNullException>(() => { _ = 0.ToOk<int, string>().Match(null, err => 0); });
+        Assert.Throws<ArgumentNullException>(() => { _ = "hello".ToErr<int, string>().Match(v => v, null); });
+    }
+
+    [Test]
+    public async Task MatchAsync_PreviousResultWasSuccess_ReturnsOk()
+    {
+        const string successString = "success";
+
+        Func<string, Task<string>> continuationOk = async s => await Task.FromResult(s);
+
+        Func<string, Task<string>> continuationErr = async _ => await Task.FromResult("error");
+
+        var result = await Result<string, string>.FromOk(successString)
+            .MatchAsync(
+                async ok => await continuationOk(ok),
+                async err => await continuationErr(err));
+
+        Assert.That(result, Is.EqualTo(successString));
+    }
+
+    [Test]
+    public async Task MatchAsync_PreviousResultWasError_ReturnsError()
+    {
+        const string errorString = "error";
+
+        Func<string, Task<string>> continuationOk = async s => await Task.FromResult(s);
+
+        Func<string, Task<string>> continuationErr = async _ => await Task.FromResult(errorString);
+
+        var result = await Result<string, string>.FromErr("any error message")
+            .MatchAsync(
+                async ok => await continuationOk(ok),
+                async err => await continuationErr(err));
+
+        Assert.That(result, Is.EqualTo(errorString));
+    }
+
+    [Test]
+    public void Result_Or()
+    {
         {
-            const string successString = "success";
+            var ok = Result<int, string>.FromOk(2);
+            var err = Result<int, string>.FromErr("late error");
 
-            Func<string, Task<string>> continuationOk = async s => await Task.FromResult(result: s);
-
-            Func<string, Task<string>> continuationErr = async _ => await Task.FromResult("error");
-
-            var result = await Result<string, string>.FromOk(ok: successString)
-                .MatchAsync(
-                    async ok => await continuationOk(arg: ok),
-                    async err => await continuationErr(arg: err));
-
-            Assert.That(actual: result, Is.EqualTo(expected: successString));
+            Assert.AreEqual(2.ToOk<int, string>(), ok.Or(err));
         }
-
-        [Test]
-        public async Task MatchAsync_PreviousResultWasError_ReturnsError()
         {
-            const string errorString = "error";
+            var err = Result<int, string>.FromErr("early error");
+            var ok = Result<int, string>.FromOk(2);
 
-            Func<string, Task<string>> continuationOk = async s => await Task.FromResult(result: s);
-
-            Func<string, Task<string>> continuationErr = async _ => await Task.FromResult(result: errorString);
-
-            var result = await Result<string, string>.FromErr("any error message")
-                .MatchAsync(
-                    async ok => await continuationOk(arg: ok),
-                    async err => await continuationErr(arg: err));
-
-            Assert.That(actual: result, Is.EqualTo(expected: errorString));
+            Assert.AreEqual(2.ToOk<int, string>(), err.Or(ok));
         }
-
-        [Test]
-        public void Result_Or()
         {
-            {
-                var ok = Result<int, string>.FromOk(2);
-                var err = Result<int, string>.FromErr("late error");
+            var err1 = Result<int, string>.FromErr("not a 2");
+            var err2 = Result<int, string>.FromErr("late error");
 
-                Assert.AreEqual(2.ToOk<int, string>(), ok.Or(fallback: err));
-            }
-            {
-                var err = Result<int, string>.FromErr("early error");
-                var ok = Result<int, string>.FromOk(2);
-
-                Assert.AreEqual(2.ToOk<int, string>(), err.Or(fallback: ok));
-            }
-            {
-                var err1 = Result<int, string>.FromErr("not a 2");
-                var err2 = Result<int, string>.FromErr("late error");
-
-                Assert.AreEqual("late error".ToErr<int, string>(), err1.Or(fallback: err2));
-            }
-            {
-                var ok1 = Result<int, string>.FromOk(2);
-                var ok2 = Result<int, string>.FromOk(100);
-
-                Assert.AreEqual(2.ToOk<int, string>(), ok1.Or(fallback: ok2));
-            }
+            Assert.AreEqual("late error".ToErr<int, string>(), err1.Or(err2));
         }
-
-        [Test]
-        public void Result_OrElse()
         {
-            Result<int, int> Square(int i)
-            {
-                return Result<int, int>.FromOk(i * i);
-            }
+            var ok1 = Result<int, string>.FromOk(2);
+            var ok2 = Result<int, string>.FromOk(100);
 
-            Result<int, int> Error(int i)
-            {
-                return Result<int, int>.FromErr(err: i);
-            }
-
-            Assert.AreEqual(Result<int, int>.FromOk(2),
-                Result<int, int>.FromOk(2).OrElse(continuation: Square).OrElse(continuation: Square));
-            Assert.AreEqual(Result<int, int>.FromOk(2),
-                Result<int, int>.FromOk(2).OrElse(continuation: Error).OrElse(continuation: Square));
-            Assert.AreEqual(Result<int, int>.FromOk(9),
-                Result<int, int>.FromErr(3).OrElse(continuation: Square).OrElse(continuation: Error));
-            Assert.AreEqual(Result<int, int>.FromErr(3),
-                Result<int, int>.FromErr(3).OrElse(continuation: Error).OrElse(continuation: Error));
+            Assert.AreEqual(2.ToOk<int, string>(), ok1.Or(ok2));
         }
+    }
 
-        [Test]
-        public async Task OrElseAsync_PreviousResultWasSuccess_ContinuationIsApplied()
+    [Test]
+    public void Result_OrElse()
+    {
+        Result<int, int> Square(int i)
         {
-            const string initialResult = "a";
-            const string continuationResult = "b";
-            Func<string, Task<Result<string, string>>> continuation = s =>
-                Task.FromResult(Result<string, string>.FromErr(err: continuationResult));
-            var result = await Result<string, string>.FromErr(err: initialResult)
-                .OrElseAsync(continuation: continuation);
-
-            result.Match(
-                ok => Assert.Fail(),
-                err => Assert.AreEqual(expected: continuationResult, actual: err));
+            return Result<int, int>.FromOk(i * i);
         }
 
-        [Test]
-        public async Task OrElseAsync_PreviousResultWasSuccess_ContinuationIsNotApplied()
+        Result<int, int> Error(int i)
         {
-            const string initialResult = "a";
-            const string continuationResult = "b";
-            Func<string, Task<Result<string, string>>> continuation = s =>
-                Task.FromResult(Result<string, string>.FromErr(err: continuationResult));
-
-            var result = await Result<string, string>.FromOk(ok: initialResult)
-                .OrElseAsync(continuation: continuation);
-
-            result.Match(
-                ok => Assert.AreEqual(expected: initialResult, actual: ok),
-                err => Assert.Fail());
+            return Result<int, int>.FromErr(i);
         }
 
-        [Test]
-        public void Result_UnwrapOr()
+        Assert.AreEqual(Result<int, int>.FromOk(2),
+            Result<int, int>.FromOk(2).OrElse(Square).OrElse(Square));
+        Assert.AreEqual(Result<int, int>.FromOk(2),
+            Result<int, int>.FromOk(2).OrElse(Error).OrElse(Square));
+        Assert.AreEqual(Result<int, int>.FromOk(9),
+            Result<int, int>.FromErr(3).OrElse(Square).OrElse(Error));
+        Assert.AreEqual(Result<int, int>.FromErr(3),
+            Result<int, int>.FromErr(3).OrElse(Error).OrElse(Error));
+    }
+
+    [Test]
+    public async Task OrElseAsync_PreviousResultWasSuccess_ContinuationIsApplied()
+    {
+        const string initialResult = "a";
+        const string continuationResult = "b";
+        Func<string, Task<Result<string, string>>> continuation = s =>
+            Task.FromResult(Result<string, string>.FromErr(continuationResult));
+        var result = await Result<string, string>.FromErr(initialResult)
+            .OrElseAsync(continuation);
+
+        result.Match(
+            ok => Assert.Fail(),
+            err => Assert.AreEqual(continuationResult, err));
+    }
+
+    [Test]
+    public async Task OrElseAsync_PreviousResultWasSuccess_ContinuationIsNotApplied()
+    {
+        const string initialResult = "a";
+        const string continuationResult = "b";
+        Func<string, Task<Result<string, string>>> continuation = s =>
+            Task.FromResult(Result<string, string>.FromErr(continuationResult));
+
+        var result = await Result<string, string>.FromOk(initialResult)
+            .OrElseAsync(continuation);
+
+        result.Match(
+            ok => Assert.AreEqual(initialResult, ok),
+            err => Assert.Fail());
+    }
+
+    [Test]
+    public void Result_UnwrapOr()
+    {
+        var ok = "hello".ToOk<string, int>();
+        var err = 99.ToErr<string, int>();
+
+        Assert.AreEqual("hello", ok.UnwrapOr("world"));
+        Assert.AreEqual("world", err.UnwrapOr("world"));
+    }
+
+    [Test]
+    public void Result_UnwrapOrWithCallback()
+    {
+        var ok = "hello".ToOk<string, int>();
+        var err = 99.ToErr<string, int>();
+
         {
-            var ok = "hello".ToOk<string, int>();
-            var err = 99.ToErr<string, int>();
+            var invoked = false;
 
-            Assert.AreEqual("hello", ok.UnwrapOr("world"));
-            Assert.AreEqual("world", err.UnwrapOr("world"));
-        }
-
-        [Test]
-        public void Result_UnwrapOrWithCallback()
-        {
-            var ok = "hello".ToOk<string, int>();
-            var err = 99.ToErr<string, int>();
-
+            Assert.AreEqual("hello", ok.UnwrapOrElse(() =>
             {
-                var invoked = false;
+                invoked = true;
+                return "world";
+            }));
 
-                Assert.AreEqual("hello", ok.UnwrapOrElse(() =>
-                {
-                    invoked = true;
-                    return "world";
-                }));
-
-                Assert.IsFalse(condition: invoked);
-            }
-
-            {
-                var invoked = false;
-
-                Assert.AreEqual("world", err.UnwrapOrElse(() =>
-                {
-                    invoked = true;
-                    return "world";
-                }));
-
-                Assert.IsTrue(condition: invoked);
-            }
+            Assert.IsFalse(invoked);
         }
 
-        [Test]
-        public void Result_Unwrap()
+        {
+            var invoked = false;
+
+            Assert.AreEqual("world", err.UnwrapOrElse(() =>
+            {
+                invoked = true;
+                return "world";
+            }));
+
+            Assert.IsTrue(invoked);
+        }
+    }
+
+    [Test]
+    public void Result_Unwrap()
+    {
+        var ok = "hello".ToOk<string, int>();
+        var err = 99.ToErr<string, int>();
+
+        Assert.AreEqual("hello", ok.Unwrap());
+        Assert.Throws<AttemptToUnwrapErrWhenResultWasOkException>(() => err.Unwrap());
+    }
+
+    [Test]
+    public void Result_UnwrapWithCustomError()
+    {
+        var ok = "hello".ToOk<string, int>();
+        var err = 99.ToErr<string, int>();
+
+        Assert.AreEqual("hello", ok.Unwrap("YOLO"));
+        Assert.Throws<AttemptToUnwrapErrWhenResultWasOkException>(() =>
+        {
+            try
+            {
+                err.Unwrap("YOLO");
+            }
+            catch (AttemptToUnwrapErrWhenResultWasOkException ex)
+            {
+                Assert.AreEqual("YOLO", ex.Message);
+                throw;
+            }
+        });
+    }
+
+    [Test]
+    public void Result_UnwrapWithCustomInvokableError()
+    {
         {
             var ok = "hello".ToOk<string, int>();
-            var err = 99.ToErr<string, int>();
-
-            Assert.AreEqual("hello", ok.Unwrap());
-            Assert.Throws<AttemptToUnwrapErrWhenResultWasOkException>(() => err.Unwrap());
+            var invoked = false;
+            Assert.AreEqual("hello", ok.Unwrap(err =>
+            {
+                invoked = true;
+                return "YOLO";
+            }));
+            Assert.IsFalse(invoked);
         }
 
-        [Test]
-        public void Result_UnwrapWithCustomError()
         {
-            var ok = "hello".ToOk<string, int>();
-            var err = 99.ToErr<string, int>();
-
-            Assert.AreEqual("hello", ok.Unwrap("YOLO"));
+            var err = 0.ToErr<string, int>();
+            var invoked = false;
             Assert.Throws<AttemptToUnwrapErrWhenResultWasOkException>(() =>
             {
                 try
                 {
-                    err.Unwrap("YOLO");
+                    err.Unwrap(err_ =>
+                    {
+                        invoked = true;
+                        return "YOLO";
+                    });
                 }
                 catch (AttemptToUnwrapErrWhenResultWasOkException ex)
                 {
-                    Assert.AreEqual("YOLO", actual: ex.Message);
+                    Assert.AreEqual("YOLO", ex.Message);
                     throw;
                 }
             });
+
+            Assert.IsTrue(invoked);
+        }
+    }
+
+    [Test]
+    public void Result_EqualsSameTypeOkVariant()
+    {
+        var ok1 = "hello".ToOk<string, string>();
+        var ok2 = "hello".ToOk<string, string>();
+        Assert.AreEqual(ok1.GetHashCode(), ok2.GetHashCode());
+        Assert.AreEqual(ok1, ok2);
+    }
+
+    [Test]
+    public void Result_EqualsSameTypeErrVariant()
+    {
+        var err1 = "hello".ToErr<string, string>();
+        var err2 = "hello".ToErr<string, string>();
+        Assert.AreEqual(err1.GetHashCode(), err2.GetHashCode());
+        Assert.AreEqual(err1, err2);
+    }
+
+    [Test]
+    public void Result_EqualsSameTypeDifferentVariants()
+    {
+        var ok = "hello".ToOk<string, string>();
+        var err = "hello".ToErr<string, string>();
+        Assert.AreNotEqual(ok, err);
+    }
+
+    [Test]
+    public void Result_EqualsSameTypeOkVariantDifferentValue()
+    {
+        var ok1 = "hello".ToOk<string, string>();
+        var ok2 = "world".ToOk<string, string>();
+        Assert.AreNotEqual(ok1, ok2);
+    }
+
+    [Test]
+    public void Result_EqualsSameTypeErrVariantDifferentValue()
+    {
+        var err1 = "hello".ToErr<string, string>();
+        var err2 = "world".ToErr<string, string>();
+        Assert.AreNotEqual(err1, err2);
+    }
+
+    [Test]
+    public void Result_EqualsDifferentType()
+    {
+        var ok1 = "hello".ToOk<string, string>();
+        var ok2 = "hello".ToOk<string, int>();
+        Assert.AreNotEqual(ok1, ok2);
+    }
+
+    [Test]
+    public void Result_And()
+    {
+        {
+            var ok = Result<int, string>.FromOk(2);
+            var err = Result<int, string>.FromErr("late error");
+
+            Assert.AreEqual(Result<int, string>.FromErr("late error"), ok.And(err));
         }
 
-        [Test]
-        public void Result_UnwrapWithCustomInvokableError()
         {
-            {
-                var ok = "hello".ToOk<string, int>();
-                var invoked = false;
-                Assert.AreEqual("hello", ok.Unwrap(err =>
-                {
-                    invoked = true;
-                    return "YOLO";
-                }));
-                Assert.IsFalse(condition: invoked);
-            }
+            var err = Result<int, string>.FromErr("early error");
+            var ok = Result<string, string>.FromOk("hello");
 
-            {
-                var err = 0.ToErr<string, int>();
-                var invoked = false;
-                Assert.Throws<AttemptToUnwrapErrWhenResultWasOkException>(() =>
-                {
-                    try
-                    {
-                        err.Unwrap(err_ =>
-                        {
-                            invoked = true;
-                            return "YOLO";
-                        });
-                    }
-                    catch (AttemptToUnwrapErrWhenResultWasOkException ex)
-                    {
-                        Assert.AreEqual("YOLO", actual: ex.Message);
-                        throw;
-                    }
-                });
-
-                Assert.IsTrue(condition: invoked);
-            }
+            Assert.AreEqual(Result<string, string>.FromErr("early error"), err.And(ok));
         }
 
-        [Test]
-        public void Result_EqualsSameTypeOkVariant()
         {
-            var ok1 = "hello".ToOk<string, string>();
-            var ok2 = "hello".ToOk<string, string>();
-            Assert.AreEqual(ok1.GetHashCode(), ok2.GetHashCode());
-            Assert.AreEqual(expected: ok1, actual: ok2);
+            var err1 = Result<int, string>.FromErr("not a 2");
+            var err2 = Result<string, string>.FromErr("late error");
+
+            Assert.AreEqual(Result<string, string>.FromErr("not a 2"), err1.And(err2));
         }
 
-        [Test]
-        public void Result_EqualsSameTypeErrVariant()
         {
-            var err1 = "hello".ToErr<string, string>();
-            var err2 = "hello".ToErr<string, string>();
-            Assert.AreEqual(err1.GetHashCode(), err2.GetHashCode());
-            Assert.AreEqual(expected: err1, actual: err2);
+            var ok1 = Result<int, string>.FromOk(2);
+            var ok2 = Result<string, string>.FromOk("different result type");
+
+            Assert.AreEqual(Result<string, string>.FromOk("different result type"), ok1.And(ok2));
+        }
+    }
+
+    [Test]
+    public void Result_AndThen()
+    {
+        Result<int, int> Square(int i)
+        {
+            return Result<int, int>.FromOk(i * i);
         }
 
-        [Test]
-        public void Result_EqualsSameTypeDifferentVariants()
+        Result<int, int> Error(int i)
         {
-            var ok = "hello".ToOk<string, string>();
-            var err = "hello".ToErr<string, string>();
-            Assert.AreNotEqual(expected: ok, actual: err);
+            return Result<int, int>.FromErr(i);
         }
 
-        [Test]
-        public void Result_EqualsSameTypeOkVariantDifferentValue()
+        Assert.AreEqual(Result<int, int>.FromOk(16),
+            Result<int, int>.FromOk(2).AndThen(Square).AndThen(Square));
+        Assert.AreEqual(Result<int, int>.FromErr(4),
+            Result<int, int>.FromOk(2).AndThen(Square).AndThen(Error));
+        Assert.AreEqual(Result<int, int>.FromErr(2),
+            Result<int, int>.FromOk(2).AndThen(Error).AndThen(Square));
+        Assert.AreEqual(Result<int, int>.FromErr(3),
+            Result<int, int>.FromErr(3).AndThen(Square).AndThen(Square));
+    }
+
+    [Test]
+    public void Result_AndThenWithAction()
+    {
+        Result<int, int> Square(int i)
         {
-            var ok1 = "hello".ToOk<string, string>();
-            var ok2 = "world".ToOk<string, string>();
-            Assert.AreNotEqual(expected: ok1, actual: ok2);
+            return Result<int, int>.FromOk(i * i);
         }
 
-        [Test]
-        public void Result_EqualsSameTypeErrVariantDifferentValue()
+        Result<int, int> Error(int i)
         {
-            var err1 = "hello".ToErr<string, string>();
-            var err2 = "world".ToErr<string, string>();
-            Assert.AreNotEqual(expected: err1, actual: err2);
+            return Result<int, int>.FromErr(i);
         }
 
-        [Test]
-        public void Result_EqualsDifferentType()
         {
-            var ok1 = "hello".ToOk<string, string>();
-            var ok2 = "hello".ToOk<string, int>();
-            Assert.AreNotEqual(expected: ok1, actual: ok2);
+            var invoked = false;
+            Assert.AreEqual(Result<int, int>.FromOk(9),
+                Result<int, int>.FromOk(3).AndThen(i => invoked = true).AndThen(Square));
+            Assert.IsTrue(invoked);
         }
-
-        [Test]
-        public void Result_And()
         {
-            {
-                var ok = Result<int, string>.FromOk(2);
-                var err = Result<int, string>.FromErr("late error");
-
-                Assert.AreEqual(Result<int, string>.FromErr("late error"), ok.And(result: err));
-            }
-
-            {
-                var err = Result<int, string>.FromErr("early error");
-                var ok = Result<string, string>.FromOk("hello");
-
-                Assert.AreEqual(Result<string, string>.FromErr("early error"), err.And(result: ok));
-            }
-
-            {
-                var err1 = Result<int, string>.FromErr("not a 2");
-                var err2 = Result<string, string>.FromErr("late error");
-
-                Assert.AreEqual(Result<string, string>.FromErr("not a 2"), err1.And(result: err2));
-            }
-
-            {
-                var ok1 = Result<int, string>.FromOk(2);
-                var ok2 = Result<string, string>.FromOk("different result type");
-
-                Assert.AreEqual(Result<string, string>.FromOk("different result type"), ok1.And(result: ok2));
-            }
-        }
-
-        [Test]
-        public void Result_AndThen()
-        {
-            Result<int, int> Square(int i)
-            {
-                return Result<int, int>.FromOk(i * i);
-            }
-
-            Result<int, int> Error(int i)
-            {
-                return Result<int, int>.FromErr(err: i);
-            }
-
-            Assert.AreEqual(Result<int, int>.FromOk(16),
-                Result<int, int>.FromOk(2).AndThen(continuation: Square).AndThen(continuation: Square));
-            Assert.AreEqual(Result<int, int>.FromErr(4),
-                Result<int, int>.FromOk(2).AndThen(continuation: Square).AndThen(continuation: Error));
-            Assert.AreEqual(Result<int, int>.FromErr(2),
-                Result<int, int>.FromOk(2).AndThen(continuation: Error).AndThen(continuation: Square));
+            var invoked = false;
             Assert.AreEqual(Result<int, int>.FromErr(3),
-                Result<int, int>.FromErr(3).AndThen(continuation: Square).AndThen(continuation: Square));
+                Result<int, int>.FromOk(3).AndThen(i => invoked = true).AndThen(Error));
+            Assert.IsTrue(invoked);
         }
-
-        [Test]
-        public void Result_AndThenWithAction()
         {
-            Result<int, int> Square(int i)
-            {
-                return Result<int, int>.FromOk(i * i);
-            }
-
-            Result<int, int> Error(int i)
-            {
-                return Result<int, int>.FromErr(err: i);
-            }
-
-            {
-                var invoked = false;
-                Assert.AreEqual(Result<int, int>.FromOk(9),
-                    Result<int, int>.FromOk(3).AndThen(i => invoked = true).AndThen(continuation: Square));
-                Assert.IsTrue(condition: invoked);
-            }
-            {
-                var invoked = false;
-                Assert.AreEqual(Result<int, int>.FromErr(3),
-                    Result<int, int>.FromOk(3).AndThen(i => invoked = true).AndThen(continuation: Error));
-                Assert.IsTrue(condition: invoked);
-            }
-            {
-                var invoked = false;
-                Assert.AreEqual(Result<int, int>.FromErr(3),
-                    Result<int, int>.FromOk(3).AndThen(continuation: Error).AndThen(i => invoked = true));
-                Assert.IsFalse(condition: invoked);
-            }
-            {
-                var invoked = false;
-                Assert.AreEqual(Result<int, int>.FromErr(5),
-                    Result<int, int>.FromErr(5).AndThen(continuation: Square).AndThen(i => invoked = true));
-                Assert.IsFalse(condition: invoked);
-            }
+            var invoked = false;
+            Assert.AreEqual(Result<int, int>.FromErr(3),
+                Result<int, int>.FromOk(3).AndThen(Error).AndThen(i => invoked = true));
+            Assert.IsFalse(invoked);
         }
-
-        [Test]
-        public void Result_AndThenAction_ForwardsCurrentValue()
         {
-            var result = Result<string, int>.FromOk("Success");
-            var nextResult = result.AndThen(continuation: Console.WriteLine);
-
-            Assert.AreSame(expected: nextResult, actual: result);
+            var invoked = false;
+            Assert.AreEqual(Result<int, int>.FromErr(5),
+                Result<int, int>.FromErr(5).AndThen(Square).AndThen(i => invoked = true));
+            Assert.IsFalse(invoked);
         }
+    }
 
-        [Test]
-        public void Result_AndThenFunc_IsOk()
+    [Test]
+    public void Result_AndThenAction_ForwardsCurrentValue()
+    {
+        var result = Result<string, int>.FromOk("Success");
+        var nextResult = result.AndThen(Console.WriteLine);
+
+        Assert.AreSame(nextResult, result);
+    }
+
+    [Test]
+    public void Result_AndThenFunc_IsOk()
+    {
+        var success = Result<string, int>.FromOk("Success");
+
+        Result<Unit, int> Nop(string s)
         {
-            var success = Result<string, int>.FromOk("Success");
-
-            Result<Unit, int> Nop(string s)
-            {
-                return Unit.Value;
-            }
-
-            var nextResult = success.AndThen(continuation: Nop);
-            Assert.IsTrue(condition: nextResult.IsOk);
-            Assert.AreEqual(expected: Unit.Value, nextResult.Ok.Unwrap());
+            return Unit.Value;
         }
 
+        var nextResult = success.AndThen(Nop);
+        Assert.IsTrue(nextResult.IsOk);
+        Assert.AreEqual(Unit.Value, nextResult.Ok.Unwrap());
+    }
 
-        [Test]
-        public void Result_AndThenFunc_IsErr()
+
+    [Test]
+    public void Result_AndThenFunc_IsErr()
+    {
+        var success = Result<string, int>.FromErr(5);
+
+        Result<Unit, int> Nop(Result<string, int> x)
         {
-            var success = Result<string, int>.FromErr(5);
-
-            Result<Unit, int> Nop(Result<string, int> x)
-            {
-                return x.Match(ok => Result<Unit, int>.FromOk(ok: Unit.Value), err => err);
-            }
-
-            var nextResult = success.AndThen(s => Nop(x: s));
-            Assert.IsTrue(condition: nextResult.IsErr);
-            Assert.AreEqual(5, nextResult.Err.Unwrap());
+            return x.Match(ok => Result<Unit, int>.FromOk(Unit.Value), err => err);
         }
 
-        [Test]
-        public async Task AndThenAsync_PreviousResultWasSuccess_ContinuationIsApplied()
+        var nextResult = success.AndThen(s => Nop(s));
+        Assert.IsTrue(nextResult.IsErr);
+        Assert.AreEqual(5, nextResult.Err.Unwrap());
+    }
+
+    [Test]
+    public async Task AndThenAsync_PreviousResultWasSuccess_ContinuationIsApplied()
+    {
+        const string initialResult = "a";
+        const string continuationResult = "b";
+        Func<string, Task<Result<string, string>>> continuation = s =>
+            Task.FromResult(Result<string, string>.FromOk(continuationResult));
+        var result = await Result<string, string>.FromOk(initialResult)
+            .AndThenAsync(continuation);
+        Assert.AreEqual(continuationResult, result.Ok.UnwrapOrDefault());
+    }
+
+    [Test]
+    public async Task AndThenAsync_PreviousResultWasError_ContinuationIsNotApplied()
+    {
+        const string initialError = "a";
+        const string continuationResult = "b";
+        Func<string, Task<Result<string, string>>> continuation = s =>
+            Task.FromResult(Result<string, string>.FromOk(continuationResult));
+        var result = await Result<string, string>.FromErr(initialError)
+            .AndThenAsync(continuation);
+        Assert.IsTrue(result.IsErr);
+    }
+
+    [Test]
+    public async Task MapAsync_PreviousResultWasSuccess_ContinuationIsApplied()
+    {
+        const string initialResult = "a";
+        const string continuationResult = "b";
+        Func<string, Task<string>> continuation = s => Task.FromResult(continuationResult);
+        var result = await Result<string, string>.FromOk(initialResult)
+            .MapAsync(continuation);
+        Assert.AreEqual(continuationResult, result.Ok.UnwrapOrDefault());
+    }
+
+    [Test]
+    public async Task MapAsync_PreviousResultWasError_ContinuationIsNotApplied()
+    {
+        const string initialError = "a";
+        const string continuationResult = "b";
+        Func<string, Task<string>> continuation = s => Task.FromResult(continuationResult);
+        var result = await Result<string, string>.FromErr(initialError)
+            .MapAsync(continuation);
+        Assert.IsTrue(result.IsErr);
+    }
+
+    [Test]
+    public void MapAsync_ContinuationThrowsException_CorrectExceptionIsPropagated()
+    {
+        const string initialResult = "a";
+        Func<string, Task<string>> continuation = s => Task.FromException<string>(new ArgumentException());
+
+        Assert.ThrowsAsync<ArgumentException>(async () =>
         {
-            const string initialResult = "a";
-            const string continuationResult = "b";
-            Func<string, Task<Result<string, string>>> continuation = s =>
-                Task.FromResult(Result<string, string>.FromOk(ok: continuationResult));
-            var result = await Result<string, string>.FromOk(ok: initialResult)
-                .AndThenAsync(continuation: continuation);
-            Assert.AreEqual(expected: continuationResult, result.Ok.UnwrapOrDefault());
-        }
+            await Result<string, string>.FromOk(initialResult)
+                .MapAsync(continuation);
+        });
+    }
 
-        [Test]
-        public async Task AndThenAsync_PreviousResultWasError_ContinuationIsNotApplied()
+    [Test]
+    public async Task MapErrAsync_PreviousResultWasError_ContinuationIsApplied()
+    {
+        const string initialError = "a";
+        const string continuationResult = "b";
+        Func<string, Task<string>> continuation = s => Task.FromResult(continuationResult);
+        var result = await Result<string, string>.FromErr(initialError)
+            .MapErrAsync(continuation);
+        Assert.AreEqual(continuationResult, result.Err.UnwrapOrDefault());
+    }
+
+    [Test]
+    public async Task MapErrAsync_PreviousResultWasSuccess_ContinuationIsNotApplied()
+    {
+        const string initialResult = "a";
+        const string continuationResult = "b";
+        Func<string, Task<string>> continuation = s => Task.FromResult(continuationResult);
+        var result = await Result<string, string>.FromOk(initialResult)
+            .MapErrAsync(continuation);
+        Assert.IsTrue(result.IsOk);
+    }
+
+    [Test]
+    public void MapErrAsync_ContinuationThrowsException_CorrectExceptionIsPropagated()
+    {
+        const string initialResult = "a";
+        Func<string, Task<string>> continuation = s => Task.FromException<string>(new ArgumentException());
+
+        Assert.ThrowsAsync<ArgumentException>(async () =>
         {
-            const string initialError = "a";
-            const string continuationResult = "b";
-            Func<string, Task<Result<string, string>>> continuation = s =>
-                Task.FromResult(Result<string, string>.FromOk(ok: continuationResult));
-            var result = await Result<string, string>.FromErr(err: initialError)
-                .AndThenAsync(continuation: continuation);
-            Assert.IsTrue(condition: result.IsErr);
-        }
+            await Result<string, string>.FromErr(initialResult)
+                .MapErrAsync(continuation);
+        });
+    }
 
-        [Test]
-        public async Task MapAsync_PreviousResultWasSuccess_ContinuationIsApplied()
+    [Test]
+    public void MatchAsync_ContinuationThrowsException_CorrectExceptionIsPropagated()
+    {
+        const string initialResult = "a";
+        Func<string, Task<string>> continuationOk = s => Task.FromException<string>(new ArgumentException());
+        Func<string, Task<string>> continuationErr = s => Task.FromResult("b");
+
+        Assert.ThrowsAsync<ArgumentException>(async () =>
         {
-            const string initialResult = "a";
-            const string continuationResult = "b";
-            Func<string, Task<string>> continuation = s => Task.FromResult(result: continuationResult);
-            var result = await Result<string, string>.FromOk(ok: initialResult)
-                .MapAsync(continuation: continuation);
-            Assert.AreEqual(expected: continuationResult, result.Ok.UnwrapOrDefault());
-        }
+            await Result<string, string>.FromOk(initialResult)
+                .MatchAsync(continuationOk, continuationErr);
+        });
+    }
 
-        [Test]
-        public async Task MapAsync_PreviousResultWasError_ContinuationIsNotApplied()
+    [Test]
+    public void Result_MapOk_NullFunc()
+    {
+        var ok = Result<string, string>.FromOk("Success");
+        Assert.Throws<ArgumentNullException>(() => ok.Map<int>(null));
+    }
+
+    [Test]
+    public void Result_MapOk_IsOk()
+    {
+        var ok = Result<string, string>.FromOk("Success");
+        var mappingResult = ok.Map(s => s.Length);
+        Assert.IsTrue(mappingResult.IsOk);
+        Assert.AreEqual("Success".Length, mappingResult.Ok.Unwrap());
+    }
+
+    [Test]
+    public void Result_MapOk_IsErrStaysTheSame()
+    {
+        var ok = Result<string, string>.FromErr("Failure");
+        var mappingResult = ok.Map(s => s.Length);
+        Assert.IsTrue(mappingResult.IsErr);
+        Assert.AreEqual("Failure", mappingResult.Err.Unwrap());
+    }
+
+    [Test]
+    public void Result_MapErr_NullFunc()
+    {
+        var ok = Result<string, string>.FromErr("Failure");
+        Assert.Throws<ArgumentNullException>(() => ok.MapErr<int>(null));
+    }
+
+    [Test]
+    public void Result_MapErr_IsErr()
+    {
+        var ok = Result<string, string>.FromErr("Failure");
+        var mappingResult = ok.MapErr(s => s.Length);
+        Assert.IsTrue(mappingResult.IsErr);
+        Assert.AreEqual("Failure".Length, mappingResult.Err.Unwrap());
+    }
+
+    [Test]
+    public void Result_MapErr_IsOkStaysTheSame()
+    {
+        var ok = Result<string, string>.FromOk("Success");
+        var mappingResult = ok.MapErr(s => s.Length);
+        Assert.IsTrue(mappingResult.IsOk);
+        Assert.AreEqual("Success", mappingResult.Ok.Unwrap());
+    }
+
+    [Test]
+    public async Task IfOkAsync_PreviousResultWasSuccess_ContinuationIsApplied()
+    {
+        const string continuationString = "b";
+
+        var result = string.Empty;
+
+        Func<string, Task> continuation = async s =>
         {
-            const string initialError = "a";
-            const string continuationResult = "b";
-            Func<string, Task<string>> continuation = s => Task.FromResult(result: continuationResult);
-            var result = await Result<string, string>.FromErr(err: initialError)
-                .MapAsync(continuation: continuation);
-            Assert.IsTrue(condition: result.IsErr);
-        }
+            await Task.Delay(1000);
+            result = s;
+        };
 
-        [Test]
-        public void MapAsync_ContinuationThrowsException_CorrectExceptionIsPropagated()
+        await Result<string, string>.FromOk(continuationString)
+            .IfOkAsync(async s => await continuation(s));
+
+        Assert.That(result, Is.EqualTo(continuationString));
+    }
+
+    [Test]
+    public async Task IfOkAsync_PreviousResultWasError_ContinuationIsNotApplied()
+    {
+        var result = string.Empty;
+
+        Func<string, Task> continuation = async s =>
         {
-            const string initialResult = "a";
-            Func<string, Task<string>> continuation = s => Task.FromException<string>(new ArgumentException());
+            await Task.Delay(1000);
+            result = s;
+        };
 
-            Assert.ThrowsAsync<ArgumentException>(async () =>
-            {
-                await Result<string, string>.FromOk(ok: initialResult)
-                    .MapAsync(continuation: continuation);
-            });
-        }
+        await Result<string, string>.FromErr("err").IfOkAsync(async s => await continuation(s));
 
-        [Test]
-        public async Task MapErrAsync_PreviousResultWasError_ContinuationIsApplied()
+        Assert.That(result, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public async Task IfErrAsync_PreviousResultWasError_ContinuationIsApplied()
+    {
+        const string continuationString = "b";
+
+        var result = string.Empty;
+
+        Func<string, Task> continuation = async s =>
         {
-            const string initialError = "a";
-            const string continuationResult = "b";
-            Func<string, Task<string>> continuation = s => Task.FromResult(result: continuationResult);
-            var result = await Result<string, string>.FromErr(err: initialError)
-                .MapErrAsync(continuation: continuation);
-            Assert.AreEqual(expected: continuationResult, result.Err.UnwrapOrDefault());
-        }
+            await Task.Delay(1000);
+            result = s;
+        };
 
-        [Test]
-        public async Task MapErrAsync_PreviousResultWasSuccess_ContinuationIsNotApplied()
+        await Result<string, string>.FromErr(continuationString)
+            .IfErrAsync(async s => await continuation(s));
+
+        Assert.That(result, Is.EqualTo(continuationString));
+    }
+
+    [Test]
+    public async Task IfErrAsync_PreviousResultWasSuccess_ContinuationIsNotApplied()
+    {
+        var result = string.Empty;
+
+        Func<string, Task> continuation = async s =>
         {
-            const string initialResult = "a";
-            const string continuationResult = "b";
-            Func<string, Task<string>> continuation = s => Task.FromResult(result: continuationResult);
-            var result = await Result<string, string>.FromOk(ok: initialResult)
-                .MapErrAsync(continuation: continuation);
-            Assert.IsTrue(condition: result.IsOk);
-        }
+            await Task.Delay(1000);
+            result = s;
+        };
 
-        [Test]
-        public void MapErrAsync_ContinuationThrowsException_CorrectExceptionIsPropagated()
-        {
-            const string initialResult = "a";
-            Func<string, Task<string>> continuation = s => Task.FromException<string>(new ArgumentException());
+        await Result<string, string>.FromOk("success").IfErrAsync(async s => await continuation(s));
 
-            Assert.ThrowsAsync<ArgumentException>(async () =>
-            {
-                await Result<string, string>.FromErr(err: initialResult)
-                    .MapErrAsync(continuation: continuation);
-            });
-        }
-
-        [Test]
-        public void MatchAsync_ContinuationThrowsException_CorrectExceptionIsPropagated()
-        {
-            const string initialResult = "a";
-            Func<string, Task<string>> continuationOk = s => Task.FromException<string>(new ArgumentException());
-            Func<string, Task<string>> continuationErr = s => Task.FromResult("b");
-
-            Assert.ThrowsAsync<ArgumentException>(async () =>
-            {
-                await Result<string, string>.FromOk(ok: initialResult)
-                    .MatchAsync(onOk: continuationOk, onErr: continuationErr);
-            });
-        }
-
-        [Test]
-        public void Result_MapOk_NullFunc()
-        {
-            var ok = Result<string, string>.FromOk("Success");
-            Assert.Throws<ArgumentNullException>(() => ok.Map<int>(null));
-        }
-
-        [Test]
-        public void Result_MapOk_IsOk()
-        {
-            var ok = Result<string, string>.FromOk("Success");
-            var mappingResult = ok.Map(s => s.Length);
-            Assert.IsTrue(condition: mappingResult.IsOk);
-            Assert.AreEqual(expected: "Success".Length, mappingResult.Ok.Unwrap());
-        }
-
-        [Test]
-        public void Result_MapOk_IsErrStaysTheSame()
-        {
-            var ok = Result<string, string>.FromErr("Failure");
-            var mappingResult = ok.Map(s => s.Length);
-            Assert.IsTrue(condition: mappingResult.IsErr);
-            Assert.AreEqual("Failure", mappingResult.Err.Unwrap());
-        }
-
-        [Test]
-        public void Result_MapErr_NullFunc()
-        {
-            var ok = Result<string, string>.FromErr("Failure");
-            Assert.Throws<ArgumentNullException>(() => ok.MapErr<int>(null));
-        }
-
-        [Test]
-        public void Result_MapErr_IsErr()
-        {
-            var ok = Result<string, string>.FromErr("Failure");
-            var mappingResult = ok.MapErr(s => s.Length);
-            Assert.IsTrue(condition: mappingResult.IsErr);
-            Assert.AreEqual(expected: "Failure".Length, mappingResult.Err.Unwrap());
-        }
-
-        [Test]
-        public void Result_MapErr_IsOkStaysTheSame()
-        {
-            var ok = Result<string, string>.FromOk("Success");
-            var mappingResult = ok.MapErr(s => s.Length);
-            Assert.IsTrue(condition: mappingResult.IsOk);
-            Assert.AreEqual("Success", mappingResult.Ok.Unwrap());
-        }
-
-        [Test]
-        public async Task IfOkAsync_PreviousResultWasSuccess_ContinuationIsApplied()
-        {
-            const string continuationString = "b";
-
-            var result = string.Empty;
-
-            Func<string, Task> continuation = async s =>
-            {
-                await Task.Delay(1000);
-                result = s;
-            };
-
-            await Result<string, string>.FromOk(ok: continuationString)
-                .IfOkAsync(async s => await continuation(arg: s));
-
-            Assert.That(actual: result, Is.EqualTo(expected: continuationString));
-        }
-
-        [Test]
-        public async Task IfOkAsync_PreviousResultWasError_ContinuationIsNotApplied()
-        {
-            var result = string.Empty;
-
-            Func<string, Task> continuation = async s =>
-            {
-                await Task.Delay(1000);
-                result = s;
-            };
-
-            await Result<string, string>.FromErr("err").IfOkAsync(async s => await continuation(arg: s));
-
-            Assert.That(actual: result, Is.EqualTo(expected: string.Empty));
-        }
-
-        [Test]
-        public async Task IfErrAsync_PreviousResultWasError_ContinuationIsApplied()
-        {
-            const string continuationString = "b";
-
-            var result = string.Empty;
-
-            Func<string, Task> continuation = async s =>
-            {
-                await Task.Delay(1000);
-                result = s;
-            };
-
-            await Result<string, string>.FromErr(err: continuationString)
-                .IfErrAsync(async s => await continuation(arg: s));
-
-            Assert.That(actual: result, Is.EqualTo(expected: continuationString));
-        }
-
-        [Test]
-        public async Task IfErrAsync_PreviousResultWasSuccess_ContinuationIsNotApplied()
-        {
-            var result = string.Empty;
-
-            Func<string, Task> continuation = async s =>
-            {
-                await Task.Delay(1000);
-                result = s;
-            };
-
-            await Result<string, string>.FromOk("success").IfErrAsync(async s => await continuation(arg: s));
-
-            Assert.That(actual: result, Is.EqualTo(expected: string.Empty));
-        }
+        Assert.That(result, Is.EqualTo(string.Empty));
     }
 }

--- a/Galaxus.Functional.Tests/(Result)/ResultTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultTests.cs
@@ -758,7 +758,8 @@ namespace Galaxus.Functional.Tests
                 result = s;
             };
 
-            await Result<string, string>.FromOk(ok: continuationString).IfOkAsync(async s => await continuation(arg: s));
+            await Result<string, string>.FromOk(ok: continuationString)
+                .IfOkAsync(async s => await continuation(arg: s));
 
             Assert.That(actual: result, Is.EqualTo(expected: continuationString));
         }
@@ -792,7 +793,8 @@ namespace Galaxus.Functional.Tests
                 result = s;
             };
 
-            await Result<string, string>.FromErr(err: continuationString).IfErrAsync(async s => await continuation(arg: s));
+            await Result<string, string>.FromErr(err: continuationString)
+                .IfErrAsync(async s => await continuation(arg: s));
 
             Assert.That(actual: result, Is.EqualTo(expected: continuationString));
         }

--- a/Galaxus.Functional.Tests/(Result)/ResultTests_Contains.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultTests_Contains.cs
@@ -1,55 +1,54 @@
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests
+namespace Galaxus.Functional.Tests;
+
+public class ResultTests_Contains
 {
-    public class ResultTests_Contains
+    [Test]
+    public void Result_ErrContains_ReturnsFalse()
     {
-        [Test]
-        public void Result_ErrContains_ReturnsFalse()
-        {
-            var result = "value".ToErr<int, string>();
-            var contains = result.Contains(3);
-            Assert.IsFalse(condition: contains);
-        }
+        var result = "value".ToErr<int, string>();
+        var contains = result.Contains(3);
+        Assert.IsFalse(contains);
+    }
 
-        [Test]
-        public void Result_OkContains_ReturnsFalse()
-        {
-            var result = 3.ToOk<int, string>();
-            var contains = result.Contains(5);
-            Assert.IsFalse(condition: contains);
-        }
+    [Test]
+    public void Result_OkContains_ReturnsFalse()
+    {
+        var result = 3.ToOk<int, string>();
+        var contains = result.Contains(5);
+        Assert.IsFalse(contains);
+    }
 
-        [Test]
-        public void Result_OkContains_ReturnsTrue()
-        {
-            var result = 3.ToOk<int, string>();
-            var contains = result.Contains(3);
-            Assert.IsTrue(condition: contains);
-        }
+    [Test]
+    public void Result_OkContains_ReturnsTrue()
+    {
+        var result = 3.ToOk<int, string>();
+        var contains = result.Contains(3);
+        Assert.IsTrue(contains);
+    }
 
-        [Test]
-        public void Result_OkContainsErr_ReturnsFalse()
-        {
-            var result = 3.ToOk<int, string>();
-            var contains = result.ContainsErr("hello");
-            Assert.IsFalse(condition: contains);
-        }
+    [Test]
+    public void Result_OkContainsErr_ReturnsFalse()
+    {
+        var result = 3.ToOk<int, string>();
+        var contains = result.ContainsErr("hello");
+        Assert.IsFalse(contains);
+    }
 
-        [Test]
-        public void Result_ErrContainsErr_ReturnsFalse()
-        {
-            var result = "hello".ToErr<int, string>();
-            var contains = result.ContainsErr("world");
-            Assert.IsFalse(condition: contains);
-        }
+    [Test]
+    public void Result_ErrContainsErr_ReturnsFalse()
+    {
+        var result = "hello".ToErr<int, string>();
+        var contains = result.ContainsErr("world");
+        Assert.IsFalse(contains);
+    }
 
-        [Test]
-        public void Result_ErrContainsErr_ReturnsTrue()
-        {
-            var result = "hello".ToErr<int, string>();
-            var contains = result.ContainsErr("hello");
-            Assert.IsTrue(condition: contains);
-        }
+    [Test]
+    public void Result_ErrContainsErr_ReturnsTrue()
+    {
+        var result = "hello".ToErr<int, string>();
+        var contains = result.ContainsErr("hello");
+        Assert.IsTrue(contains);
     }
 }

--- a/Galaxus.Functional.Tests/(Result)/ResultTests_Contains.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultTests_Contains.cs
@@ -9,7 +9,7 @@ namespace Galaxus.Functional.Tests
         {
             var result = "value".ToErr<int, string>();
             var contains = result.Contains(3);
-            Assert.IsFalse(contains);
+            Assert.IsFalse(condition: contains);
         }
 
         [Test]
@@ -17,7 +17,7 @@ namespace Galaxus.Functional.Tests
         {
             var result = 3.ToOk<int, string>();
             var contains = result.Contains(5);
-            Assert.IsFalse(contains);
+            Assert.IsFalse(condition: contains);
         }
 
         [Test]
@@ -25,7 +25,7 @@ namespace Galaxus.Functional.Tests
         {
             var result = 3.ToOk<int, string>();
             var contains = result.Contains(3);
-            Assert.IsTrue(contains);
+            Assert.IsTrue(condition: contains);
         }
 
         [Test]
@@ -33,7 +33,7 @@ namespace Galaxus.Functional.Tests
         {
             var result = 3.ToOk<int, string>();
             var contains = result.ContainsErr("hello");
-            Assert.IsFalse(contains);
+            Assert.IsFalse(condition: contains);
         }
 
         [Test]
@@ -41,7 +41,7 @@ namespace Galaxus.Functional.Tests
         {
             var result = "hello".ToErr<int, string>();
             var contains = result.ContainsErr("world");
-            Assert.IsFalse(contains);
+            Assert.IsFalse(condition: contains);
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace Galaxus.Functional.Tests
         {
             var result = "hello".ToErr<int, string>();
             var contains = result.ContainsErr("hello");
-            Assert.IsTrue(contains);
+            Assert.IsTrue(condition: contains);
         }
     }
 }

--- a/Galaxus.Functional.Tests/(Result)/ResultTests_Transpose.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultTests_Transpose.cs
@@ -1,36 +1,35 @@
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests
+namespace Galaxus.Functional.Tests;
+
+public class ResultTests_Transpose
 {
-    public class ResultTests_Transpose
+    [Test]
+    public void Result_TransposeOkSome_ReturnsSomeOk()
     {
-        [Test]
-        public void Result_TransposeOkSome_ReturnsSomeOk()
-        {
-            var result = 3.ToOption().ToOk<Option<int>, string>();
-            var option = result.Transpose();
+        var result = 3.ToOption().ToOk<Option<int>, string>();
+        var option = result.Transpose();
 
-            Assert.IsTrue(condition: option.IsSome);
-            Assert.IsTrue(condition: option.Unwrap().IsOk);
-        }
+        Assert.IsTrue(option.IsSome);
+        Assert.IsTrue(option.Unwrap().IsOk);
+    }
 
-        [Test]
-        public void Result_TransposeOkNone_ReturnsNone()
-        {
-            var result = Option<int>.None.ToOk<Option<int>, string>();
-            var option = result.Transpose();
+    [Test]
+    public void Result_TransposeOkNone_ReturnsNone()
+    {
+        var result = Option<int>.None.ToOk<Option<int>, string>();
+        var option = result.Transpose();
 
-            Assert.IsTrue(condition: option.IsNone);
-        }
+        Assert.IsTrue(option.IsNone);
+    }
 
-        [Test]
-        public void Result_TransposeErr_ReturnsSomeErr()
-        {
-            var result = "error".ToErr<Option<int>, string>();
-            var option = result.Transpose();
+    [Test]
+    public void Result_TransposeErr_ReturnsSomeErr()
+    {
+        var result = "error".ToErr<Option<int>, string>();
+        var option = result.Transpose();
 
-            Assert.IsTrue(condition: option.IsSome);
-            Assert.IsTrue(condition: option.Unwrap().IsErr);
-        }
+        Assert.IsTrue(option.IsSome);
+        Assert.IsTrue(option.Unwrap().IsErr);
     }
 }

--- a/Galaxus.Functional.Tests/(Result)/ResultTests_Transpose.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultTests_Transpose.cs
@@ -10,8 +10,8 @@ namespace Galaxus.Functional.Tests
             var result = 3.ToOption().ToOk<Option<int>, string>();
             var option = result.Transpose();
 
-            Assert.IsTrue(option.IsSome);
-            Assert.IsTrue(option.Unwrap().IsOk);
+            Assert.IsTrue(condition: option.IsSome);
+            Assert.IsTrue(condition: option.Unwrap().IsOk);
         }
 
         [Test]
@@ -20,7 +20,7 @@ namespace Galaxus.Functional.Tests
             var result = Option<int>.None.ToOk<Option<int>, string>();
             var option = result.Transpose();
 
-            Assert.IsTrue(option.IsNone);
+            Assert.IsTrue(condition: option.IsNone);
         }
 
         [Test]
@@ -29,8 +29,8 @@ namespace Galaxus.Functional.Tests
             var result = "error".ToErr<Option<int>, string>();
             var option = result.Transpose();
 
-            Assert.IsTrue(option.IsSome);
-            Assert.IsTrue(option.Unwrap().IsErr);
+            Assert.IsTrue(condition: option.IsSome);
+            Assert.IsTrue(condition: option.Unwrap().IsErr);
         }
     }
 }

--- a/Galaxus.Functional.Tests/(Unit)/UnitTests.cs
+++ b/Galaxus.Functional.Tests/(Unit)/UnitTests.cs
@@ -1,37 +1,36 @@
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests
+namespace Galaxus.Functional.Tests;
+
+public class UnitTests
 {
-    public class UnitTests
+    [Test]
+    public void Unit_AreEqual()
     {
-        [Test]
-        public void Unit_AreEqual()
-        {
-            Assert.AreEqual(expected: Unit.Value, new Unit());
-            Assert.AreEqual(new Unit(), new Unit());
-        }
+        Assert.AreEqual(Unit.Value, new Unit());
+        Assert.AreEqual(new Unit(), new Unit());
+    }
 
-        [Test]
-        public void Unit_AreNotEqual()
-        {
-            Assert.AreNotEqual(expected: Unit.Value, null);
-            Assert.AreNotEqual(expected: Unit.Value, 0);
-        }
+    [Test]
+    public void Unit_AreNotEqual()
+    {
+        Assert.AreNotEqual(Unit.Value, null);
+        Assert.AreNotEqual(Unit.Value, 0);
+    }
 
-        [Test]
-        public void Unit_Hash()
-        {
-            Assert.AreEqual(
-                Unit.Value.GetHashCode(),
-                new Unit().GetHashCode());
-        }
+    [Test]
+    public void Unit_Hash()
+    {
+        Assert.AreEqual(
+            Unit.Value.GetHashCode(),
+            new Unit().GetHashCode());
+    }
 
-        [Test]
-        public void Unit_ToString()
-        {
-            Assert.AreEqual(
-                "()",
-                Unit.Value.ToString());
-        }
+    [Test]
+    public void Unit_ToString()
+    {
+        Assert.AreEqual(
+            "()",
+            Unit.Value.ToString());
     }
 }

--- a/Galaxus.Functional.Tests/(Unit)/UnitTests.cs
+++ b/Galaxus.Functional.Tests/(Unit)/UnitTests.cs
@@ -7,15 +7,15 @@ namespace Galaxus.Functional.Tests
         [Test]
         public void Unit_AreEqual()
         {
-            Assert.AreEqual(Unit.Value, new Unit());
+            Assert.AreEqual(expected: Unit.Value, new Unit());
             Assert.AreEqual(new Unit(), new Unit());
         }
 
         [Test]
         public void Unit_AreNotEqual()
         {
-            Assert.AreNotEqual(Unit.Value, null);
-            Assert.AreNotEqual(Unit.Value, 0);
+            Assert.AreNotEqual(expected: Unit.Value, null);
+            Assert.AreNotEqual(expected: Unit.Value, 0);
         }
 
         [Test]

--- a/Galaxus.Functional.Tests/Galaxus.Functional.Tests.csproj
+++ b/Galaxus.Functional.Tests/Galaxus.Functional.Tests.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Galaxus.Functional.Tests/Galaxus.Functional.Tests.csproj
+++ b/Galaxus.Functional.Tests/Galaxus.Functional.Tests.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="NUnit" Version="3.13.2"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Galaxus.Functional\Galaxus.Functional.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Galaxus.Functional\Galaxus.Functional.csproj"/>
+    </ItemGroup>
 
 </Project>

--- a/Galaxus.Functional.Tests/Helpers/DummyReferenceType.cs
+++ b/Galaxus.Functional.Tests/Helpers/DummyReferenceType.cs
@@ -1,6 +1,5 @@
-namespace Galaxus.Functional.Tests.Helpers
+namespace Galaxus.Functional.Tests.Helpers;
+
+public class DummyReferenceType
 {
-    public class DummyReferenceType
-    {
-    }
 }

--- a/Galaxus.Functional.Tests/Helpers/DummyReferenceType.cs
+++ b/Galaxus.Functional.Tests/Helpers/DummyReferenceType.cs
@@ -2,6 +2,5 @@ namespace Galaxus.Functional.Tests.Helpers
 {
     public class DummyReferenceType
     {
-        
     }
 }

--- a/Galaxus.Functional.Tests/Helpers/FailOnNthElement.cs
+++ b/Galaxus.Functional.Tests/Helpers/FailOnNthElement.cs
@@ -17,15 +17,14 @@ namespace Galaxus.Functional.Tests.Helpers
 
         public IEnumerator<T> GetEnumerator()
         {
-            foreach (var _ in Enumerable.Range(0, _numberOfElements))
-            {
-                yield return _elementToYield;
-            }
+            foreach (var _ in Enumerable.Range(0, count: _numberOfElements)) yield return _elementToYield;
 
             Assert.Fail("Sequence was unexpectedly enumerated.");
         }
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-            => GetEnumerator();
+        {
+            return GetEnumerator();
+        }
     }
 }

--- a/Galaxus.Functional.Tests/Helpers/FailOnNthElement.cs
+++ b/Galaxus.Functional.Tests/Helpers/FailOnNthElement.cs
@@ -2,32 +2,31 @@
 using System.Linq;
 using NUnit.Framework;
 
-namespace Galaxus.Functional.Tests.Helpers
+namespace Galaxus.Functional.Tests.Helpers;
+
+internal class YieldElementsThenFail<T> : IEnumerable<T>
 {
-    internal class YieldElementsThenFail<T> : IEnumerable<T>
+    private readonly T _elementToYield;
+    private readonly int _numberOfElements;
+
+    public YieldElementsThenFail(T elementToYield, int numberOfElements)
     {
-        private readonly T _elementToYield;
-        private readonly int _numberOfElements;
+        _elementToYield = elementToYield;
+        _numberOfElements = numberOfElements;
+    }
 
-        public YieldElementsThenFail(T elementToYield, int numberOfElements)
+    public IEnumerator<T> GetEnumerator()
+    {
+        foreach (var _ in Enumerable.Range(0, _numberOfElements))
         {
-            _elementToYield = elementToYield;
-            _numberOfElements = numberOfElements;
+            yield return _elementToYield;
         }
 
-        public IEnumerator<T> GetEnumerator()
-        {
-            foreach (var _ in Enumerable.Range(0, count: _numberOfElements))
-            {
-                yield return _elementToYield;
-            }
+        Assert.Fail("Sequence was unexpectedly enumerated.");
+    }
 
-            Assert.Fail("Sequence was unexpectedly enumerated.");
-        }
-
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
     }
 }

--- a/Galaxus.Functional.Tests/Helpers/FailOnNthElement.cs
+++ b/Galaxus.Functional.Tests/Helpers/FailOnNthElement.cs
@@ -17,7 +17,10 @@ namespace Galaxus.Functional.Tests.Helpers
 
         public IEnumerator<T> GetEnumerator()
         {
-            foreach (var _ in Enumerable.Range(0, count: _numberOfElements)) yield return _elementToYield;
+            foreach (var _ in Enumerable.Range(0, count: _numberOfElements))
+            {
+                yield return _elementToYield;
+            }
 
             Assert.Fail("Sequence was unexpectedly enumerated.");
         }

--- a/Galaxus.Functional.nuspec
+++ b/Galaxus.Functional.nuspec
@@ -11,17 +11,17 @@
         <icon>logo.png</icon>
         <description>A package bringing popular functional abstractions (e.g. Option or Either) to C#.</description>
         <projectUrl>https://github.com/DigitecGalaxus/Galaxus.Functional</projectUrl>
-        <repository type="git" url="https://github.com/DigitecGalaxus/Galaxus.Functional.git" branch="master" />
+        <repository type="git" url="https://github.com/DigitecGalaxus/Galaxus.Functional.git" branch="master"/>
         <dependencies>
-            <group targetFramework="netstandard2.0" />
+            <group targetFramework="netstandard2.0"/>
         </dependencies>
     </metadata>
     <files>
-        <file src="LICENSE" target="LICENSE" />
-        <file src="README.md" target="README.md" />
-        <file src="logo.png" target="logo.png" />
-        <file src="Galaxus.Functional/bin/Release/netstandard2.0/Galaxus.Functional.dll" target="lib/netstandard2.0" />
-        <file src="Galaxus.Functional/bin/Release/netstandard2.0/Galaxus.Functional.pdb" target="lib/netstandard2.0" />
-        <file src="Galaxus.Functional/bin/Release/netstandard2.0/Galaxus.Functional.xml" target="lib/netstandard2.0" />
+        <file src="LICENSE" target="LICENSE"/>
+        <file src="README.md" target="README.md"/>
+        <file src="logo.png" target="logo.png"/>
+        <file src="Galaxus.Functional/bin/Release/netstandard2.0/Galaxus.Functional.dll" target="lib/netstandard2.0"/>
+        <file src="Galaxus.Functional/bin/Release/netstandard2.0/Galaxus.Functional.pdb" target="lib/netstandard2.0"/>
+        <file src="Galaxus.Functional/bin/Release/netstandard2.0/Galaxus.Functional.xml" target="lib/netstandard2.0"/>
     </files>
 </package>

--- a/Galaxus.Functional.nuspec
+++ b/Galaxus.Functional.nuspec
@@ -6,7 +6,7 @@
         <authors>Noël Widmer, Philipp Kiener</authors>
         <owners>DigitecGalaxus</owners>
         <license type="expression">MIT</license>
-        <copyright>2018-2021 Digitec Galaxus AG</copyright>
+        <copyright>2018-2022 Digitec Galaxus AG</copyright>
         <tags>functional option either result digitec galaxus digitecgalaxus</tags>
         <icon>logo.png</icon>
         <description>A package bringing popular functional abstractions (e.g. Option or Either) to C#.</description>

--- a/Galaxus.Functional.sln
+++ b/Galaxus.Functional.sln
@@ -9,6 +9,7 @@ ProjectSection(SolutionItems) = preProject
 	README.md = README.md
 	LICENSE = LICENSE
 	Galaxus.Functional.nuspec = Galaxus.Functional.nuspec
+	.editorconfig = .editorconfig
 EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Galaxus.Functional", "Galaxus.Functional\Galaxus.Functional.csproj", "{5CD53145-49E8-4391-8EBE-BB2A2172097C}"

--- a/Galaxus.Functional/(Either)/Discriminant2.cs
+++ b/Galaxus.Functional/(Either)/Discriminant2.cs
@@ -1,21 +1,20 @@
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// A discriminant indicates which field of a union is in use.
+    ///     A discriminant indicates which field of a union is in use.
     /// </summary>
     /// <remarks>
-    /// The order of a union's fields might change. For this reason:
-    /// Do not serialize discriminants, do not store them in databases and
-    /// do not send them across application domains or processes.
+    ///     The order of a union's fields might change. For this reason:
+    ///     Do not serialize discriminants, do not store them in databases and
+    ///     do not send them across application domains or processes.
     /// </remarks>
     public enum Discriminant2 : byte
     {
         /// <summary>
-        ///
         /// </summary>
         A,
+
         /// <summary>
-        ///
         /// </summary>
         B
     }

--- a/Galaxus.Functional/(Either)/Discriminant2.cs
+++ b/Galaxus.Functional/(Either)/Discriminant2.cs
@@ -11,10 +11,12 @@ namespace Galaxus.Functional
     public enum Discriminant2 : byte
     {
         /// <summary>
+        ///     The first field of an <see cref="Either{A, B}"/>
         /// </summary>
         A,
 
         /// <summary>
+        ///     The second field of an <see cref="Either{A, B}"/>
         /// </summary>
         B
     }

--- a/Galaxus.Functional/(Either)/Discriminant2.cs
+++ b/Galaxus.Functional/(Either)/Discriminant2.cs
@@ -10,7 +10,13 @@ namespace Galaxus.Functional
     /// </remarks>
     public enum Discriminant2 : byte
     {
+        /// <summary>
+        ///
+        /// </summary>
         A,
+        /// <summary>
+        ///
+        /// </summary>
         B
     }
 }

--- a/Galaxus.Functional/(Either)/Discriminant3.cs
+++ b/Galaxus.Functional/(Either)/Discriminant3.cs
@@ -11,14 +11,17 @@ namespace Galaxus.Functional
     public enum Discriminant3 : byte
     {
         /// <summary>
+        ///     The first field of an <see cref="Either{A, B, C}"/>
         /// </summary>
         A,
 
         /// <summary>
+        ///     The second field of an <see cref="Either{A, B, C}"/>
         /// </summary>
         B,
 
         /// <summary>
+        ///     The third field of an <see cref="Either{A, B, C}"/>
         /// </summary>
         C
     }

--- a/Galaxus.Functional/(Either)/Discriminant3.cs
+++ b/Galaxus.Functional/(Either)/Discriminant3.cs
@@ -10,8 +10,17 @@ namespace Galaxus.Functional
     /// </remarks>
     public enum Discriminant3 : byte
     {
+        /// <summary>
+        ///
+        /// </summary>
         A,
+        /// <summary>
+        ///
+        /// </summary>
         B,
+        /// <summary>
+        ///
+        /// </summary>
         C
     }
 }

--- a/Galaxus.Functional/(Either)/Discriminant3.cs
+++ b/Galaxus.Functional/(Either)/Discriminant3.cs
@@ -1,25 +1,24 @@
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// A discriminant indicates which field of a union is in use.
+    ///     A discriminant indicates which field of a union is in use.
     /// </summary>
     /// <remarks>
-    /// The order of a union's fields might change. For this reason:
-    /// Do not serialize discriminants, do not store them in databases and
-    /// do not send them across application domains or processes.
+    ///     The order of a union's fields might change. For this reason:
+    ///     Do not serialize discriminants, do not store them in databases and
+    ///     do not send them across application domains or processes.
     /// </remarks>
     public enum Discriminant3 : byte
     {
         /// <summary>
-        ///
         /// </summary>
         A,
+
         /// <summary>
-        ///
         /// </summary>
         B,
+
         /// <summary>
-        ///
         /// </summary>
         C
     }

--- a/Galaxus.Functional/(Either)/Either2.cs
+++ b/Galaxus.Functional/(Either)/Either2.cs
@@ -76,11 +76,19 @@ namespace Galaxus.Functional
         #region State
 
         /// <summary>
+        ///     The value of the first type that may be contained.
         /// </summary>
+        /// <remarks>
+        ///     When this either <see cref="IsB"/>, this value is <c>default</c>.
+        /// </remarks>
         protected readonly A _a;
 
         /// <summary>
+        ///     The value of the second type that may be contained.
         /// </summary>
+        /// <remarks>
+        ///     When this either <see cref="IsA"/>, this value is <c>default</c>.
+        /// </remarks>
         protected readonly B _b;
 
         /// <summary>

--- a/Galaxus.Functional/(Either)/Either2.cs
+++ b/Galaxus.Functional/(Either)/Either2.cs
@@ -4,18 +4,25 @@ using System.Threading.Tasks;
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// The <see cref="Either{A, B}"/> is a discriminated union which is a data structure used to hold a value that could take on two different, but fixed, types.
-    /// Only one of the types can be in use at any one time, and a discriminant explicitly indicates which one is in use.
-    /// It can be thought of as a type that has several "cases", each of which should be handled correctly when that type is accessed.
+    ///     The <see cref="Either{A, B}" /> is a discriminated union which is a data structure used to hold a value that could
+    ///     take on two different, but fixed, types.
+    ///     Only one of the types can be in use at any one time, and a discriminant explicitly indicates which one is in use.
+    ///     It can be thought of as a type that has several "cases", each of which should be handled correctly when that type
+    ///     is accessed.
     /// </summary>
     /// <typeparam name="A">The first type this union can contain.</typeparam>
     /// <typeparam name="B">The second type this union can contain.</typeparam>
     public class Either<A, B> : IEquatable<Either<A, B>>, IEither
     {
+        object IEither.ToObject()
+        {
+            return Match<object>(a => a, b => b);
+        }
+
         #region Instance Initializer
 
         /// <summary>
-        /// Constructs a union in which field "A" is in use.
+        ///     Constructs a union in which field "A" is in use.
         /// </summary>
         public Either(A a)
         {
@@ -27,7 +34,7 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Constructs a union in which field "B" is in use.
+        ///     Constructs a union in which field "B" is in use.
         /// </summary>
         public Either(B b)
         {
@@ -41,47 +48,49 @@ namespace Galaxus.Functional
         // Usages of implicit operators will only compile if A and B are different types.
 
         /// <summary>
-        /// Implicitly cast a value of type <c>A</c> to an <see cref="Either{A,B}"/> containing A.
+        ///     Implicitly cast a value of type <c>A</c> to an <see cref="Either{A,B}" /> containing A.
         /// </summary>
         /// <param name="a">The value to cast.</param>
         /// <returns>An either containing that value as A.</returns>
         public static implicit operator Either<A, B>(A a)
-            => new Either<A, B>(a);
+        {
+            return new Either<A, B>(a: a);
+        }
 
         /// <summary>
-        /// Implicitly cast a value of type <c>B</c> to an <see cref="Either{A,B}"/> containing B.
+        ///     Implicitly cast a value of type <c>B</c> to an <see cref="Either{A,B}" /> containing B.
         /// </summary>
         /// <param name="b">The value to cast.</param>
         /// <returns>An either containing that value as B.</returns>
         public static implicit operator Either<A, B>(B b)
-            => new Either<A, B>(b);
+        {
+            return new Either<A, B>(b: b);
+        }
 
         #endregion
 
         #region State
 
         /// <summary>
-        ///
         /// </summary>
         protected readonly A _a;
 
         /// <summary>
-        ///
         /// </summary>
         protected readonly B _b;
 
         /// <summary>
-        /// Indicates which field is in use.
+        ///     Indicates which field is in use.
         /// </summary>
         public Discriminant2 Discriminant { get; }
 
         /// <summary>
-        /// Indicates that field A is in use.
+        ///     Indicates that field A is in use.
         /// </summary>
         public bool IsA => Discriminant == Discriminant2.A;
 
         /// <summary>
-        /// Indicates that field B is in use.
+        ///     Indicates that field B is in use.
         /// </summary>
         public bool IsB => Discriminant == Discriminant2.B;
 
@@ -90,7 +99,8 @@ namespace Galaxus.Functional
         #region Match
 
         /// <summary>
-        /// Provides access to <b>self</b>'s content by calling either <paramref name="onA"/> or <paramref name="onB"/> and passing in <b>self</b>'s content.
+        ///     Provides access to <b>self</b>'s content by calling either <paramref name="onA" /> or <paramref name="onB" /> and
+        ///     passing in <b>self</b>'s content.
         /// </summary>
         /// <param name="onA">Called when field "A" is in use. The argument to this action is never the <b>null</b> reference.</param>
         /// <param name="onB">Called when field "B" is in use. The argument to this action is never the <b>null</b> reference.</param>
@@ -102,21 +112,23 @@ namespace Galaxus.Functional
                     if (onA == null)
                         throw new ArgumentNullException(nameof(onA));
 
-                    onA(_a);
+                    onA(obj: _a);
                     break;
                 case Discriminant2.B:
                     if (onB == null)
                         throw new ArgumentNullException(nameof(onB));
 
-                    onB(_b);
+                    onB(obj: _b);
                     break;
                 default:
-                    throw new InvalidOperationException($"{GetType()} has an invalid discriminant. This is an implementation bug.");
+                    throw new InvalidOperationException(
+                        $"{GetType()} has an invalid discriminant. This is an implementation bug.");
             }
         }
 
         /// <summary>
-        /// Provides access to <b>self</b>'s content by calling either <paramref name="onA"/> or <paramref name="onB"/> and passing in <b>self</b>'s content.
+        ///     Provides access to <b>self</b>'s content by calling either <paramref name="onA" /> or <paramref name="onB" /> and
+        ///     passing in <b>self</b>'s content.
         /// </summary>
         /// <param name="onA">Called when field "A" is in use. The argument to this action is never the <b>null</b> reference.</param>
         /// <param name="onB">Called when field "B" is in use. The argument to this action is never the <b>null</b> reference.</param>
@@ -128,63 +140,81 @@ namespace Galaxus.Functional
                     if (onA == null)
                         throw new ArgumentNullException(nameof(onA));
 
-                    return onA(_a);
+                    return onA(arg: _a);
                 case Discriminant2.B:
                     if (onB == null)
                         throw new ArgumentNullException(nameof(onB));
 
-                    return onB(_b);
+                    return onB(arg: _b);
                 default:
-                    throw new InvalidOperationException($"{GetType()} has an invalid discriminant. This is an implementation bug.");
+                    throw new InvalidOperationException(
+                        $"{GetType()} has an invalid discriminant. This is an implementation bug.");
             }
         }
 
         /// <summary>
-        /// An overload for <see cref="Match"/> using async functions.
+        ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
-        /// <param name="onA">Async function to be called when field "A" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onB">Async function to be called when field "B" is in use. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onA">
+        ///     Async function to be called when field "A" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onB">
+        ///     Async function to be called when field "B" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
         public async Task<T> MatchAsync<T>(Func<A, Task<T>> onA, Func<B, Task<T>> onB)
         {
             return await Match(
-                async a => await onA(a),
-                async b => await onB(b));
+                async a => await onA(arg: a),
+                async b => await onB(arg: b));
         }
 
         /// <summary>
-        /// An overload for <see cref="Match"/> using async functions.
+        ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
-        /// <param name="onA">Async function to be called when field "A" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onB">Non-async function to be called when field "B" is in use. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onA">
+        ///     Async function to be called when field "A" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onB">
+        ///     Non-async function to be called when field "B" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
         public async Task<T> MatchAsync<T>(Func<A, Task<T>> onA, Func<B, T> onB)
         {
             return await Match(
-                async a => await onA(a),
-                b => Task.FromResult(onB(b)));
+                async a => await onA(arg: a),
+                b => Task.FromResult(onB(arg: b)));
         }
 
         /// <summary>
-        /// An overload for <see cref="Match"/> using async functions.
+        ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
-        /// <param name="onA">Non-async function to be called when field "A" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onB">Async function to be called when field "B" is in use. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onA">
+        ///     Non-async function to be called when field "A" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onB">
+        ///     Async function to be called when field "B" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
         public async Task<T> MatchAsync<T>(Func<A, T> onA, Func<B, Task<T>> onB)
         {
             return await Match(
-                a => Task.FromResult(onA(a)),
-                async b => await onB(b));
+                a => Task.FromResult(onA(arg: a)),
+                async b => await onB(arg: b));
         }
 
         #endregion
-
-        object IEither.ToObject()
-            => Match<object>(a => a, b => b);
 
         #region Equals, GetHashCode & ToString
 
         /// <inheritdoc />
         public sealed override bool Equals(object other)
-            => Equals(other as Either<A, B>);
+        {
+            return Equals(other as Either<A, B>);
+        }
 
         /// <inheritdoc />
         public bool Equals(Either<A, B> other)
@@ -192,7 +222,7 @@ namespace Galaxus.Functional
             if (other is null)
                 return false;
 
-            if (ReferenceEquals(this, other))
+            if (ReferenceEquals(this, objB: other))
                 return true;
 
             if (Discriminant != other.Discriminant)
@@ -201,16 +231,17 @@ namespace Galaxus.Functional
             switch (Discriminant)
             {
                 case Discriminant2.A:
-                    return _a.Equals(other._a);
+                    return _a.Equals(obj: other._a);
                 case Discriminant2.B:
-                    return _b.Equals(other._b);
+                    return _b.Equals(obj: other._b);
                 default:
-                    throw new InvalidOperationException($"{GetType()} has an invalid discriminant. This is an implementation bug.");
+                    throw new InvalidOperationException(
+                        $"{GetType()} has an invalid discriminant. This is an implementation bug.");
             }
         }
 
         /// <summary>
-        /// Checks whether two eithers are equal.
+        ///     Checks whether two eithers are equal.
         /// </summary>
         /// <param name="lhs">The either to check against.</param>
         /// <param name="rhs">The either to check.</param>
@@ -220,25 +251,31 @@ namespace Galaxus.Functional
             if (lhs is null)
                 return rhs is null;
 
-            return lhs.Equals(rhs);
+            return lhs.Equals(other: rhs);
         }
 
         /// <summary>
-        /// Checks whether two eithers are not equal.
+        ///     Checks whether two eithers are not equal.
         /// </summary>
         /// <param name="lhs">The either to check against.</param>
         /// <param name="rhs">The either to check.</param>
         /// <returns><c>False</c> if the eithers are equal, <c>true</c> otherwise.</returns>
         public static bool operator !=(Either<A, B> lhs, Either<A, B> rhs)
-            => (lhs == rhs) == false;
+        {
+            return lhs == rhs == false;
+        }
 
         /// <inheritdoc />
         public override int GetHashCode()
-            => (Discriminant, _a, _b).GetHashCode();
+        {
+            return (Discriminant, _a, _b).GetHashCode();
+        }
 
         /// <inheritdoc />
         public override string ToString()
-            => Match(a => a.ToString(), b => b.ToString());
+        {
+            return Match(a => a.ToString(), b => b.ToString());
+        }
 
         #endregion
     }

--- a/Galaxus.Functional/(Either)/Either2.cs
+++ b/Galaxus.Functional/(Either)/Either2.cs
@@ -52,23 +52,23 @@ namespace Galaxus.Functional
         // Usages of implicit operators will only compile if A and B are different types.
 
         /// <summary>
-        ///     Implicitly cast a value of type <c>A</c> to an <see cref="Either{A,B}" /> containing A.
+        ///     Implicitly cast a value of type <typeparamref name="A"/> to an <see cref="Either{A,B}" /> containing A.
         /// </summary>
         /// <param name="a">The value to cast.</param>
         /// <returns>An either containing that value as A.</returns>
         public static implicit operator Either<A, B>(A a)
         {
-            return new Either<A, B>(a: a);
+            return new Either<A, B>(a);
         }
 
         /// <summary>
-        ///     Implicitly cast a value of type <c>B</c> to an <see cref="Either{A,B}" /> containing B.
+        ///     Implicitly cast a value of type <typeparamref name="B"/> to an <see cref="Either{A,B}" /> containing B.
         /// </summary>
         /// <param name="b">The value to cast.</param>
         /// <returns>An either containing that value as B.</returns>
         public static implicit operator Either<A, B>(B b)
         {
-            return new Either<A, B>(b: b);
+            return new Either<A, B>(b);
         }
 
         #endregion
@@ -126,7 +126,7 @@ namespace Galaxus.Functional
                         throw new ArgumentNullException(nameof(onA));
                     }
 
-                    onA(obj: _a);
+                    onA(_a);
                     break;
                 case Discriminant2.B:
                     if (onB == null)
@@ -134,7 +134,7 @@ namespace Galaxus.Functional
                         throw new ArgumentNullException(nameof(onB));
                     }
 
-                    onB(obj: _b);
+                    onB(_b);
                     break;
                 default:
                     throw new InvalidOperationException(
@@ -158,14 +158,14 @@ namespace Galaxus.Functional
                         throw new ArgumentNullException(nameof(onA));
                     }
 
-                    return onA(arg: _a);
+                    return onA(_a);
                 case Discriminant2.B:
                     if (onB == null)
                     {
                         throw new ArgumentNullException(nameof(onB));
                     }
 
-                    return onB(arg: _b);
+                    return onB(_b);
                 default:
                     throw new InvalidOperationException(
                         $"{GetType()} has an invalid discriminant. This is an implementation bug.");
@@ -186,8 +186,8 @@ namespace Galaxus.Functional
         public async Task<T> MatchAsync<T>(Func<A, Task<T>> onA, Func<B, Task<T>> onB)
         {
             return await Match(
-                async a => await onA(arg: a),
-                async b => await onB(arg: b));
+                async a => await onA(a),
+                async b => await onB(b));
         }
 
         /// <summary>
@@ -204,8 +204,8 @@ namespace Galaxus.Functional
         public async Task<T> MatchAsync<T>(Func<A, Task<T>> onA, Func<B, T> onB)
         {
             return await Match(
-                async a => await onA(arg: a),
-                b => Task.FromResult(onB(arg: b)));
+                async a => await onA(a),
+                b => Task.FromResult(onB(b)));
         }
 
         /// <summary>
@@ -222,8 +222,8 @@ namespace Galaxus.Functional
         public async Task<T> MatchAsync<T>(Func<A, T> onA, Func<B, Task<T>> onB)
         {
             return await Match(
-                a => Task.FromResult(onA(arg: a)),
-                async b => await onB(arg: b));
+                a => Task.FromResult(onA(a)),
+                async b => await onB(b));
         }
 
         #endregion
@@ -244,7 +244,7 @@ namespace Galaxus.Functional
                 return false;
             }
 
-            if (ReferenceEquals(this, objB: other))
+            if (ReferenceEquals(this, other))
             {
                 return true;
             }
@@ -257,9 +257,9 @@ namespace Galaxus.Functional
             switch (Discriminant)
             {
                 case Discriminant2.A:
-                    return _a.Equals(obj: other._a);
+                    return _a.Equals(other._a);
                 case Discriminant2.B:
-                    return _b.Equals(obj: other._b);
+                    return _b.Equals(other._b);
                 default:
                     throw new InvalidOperationException(
                         $"{GetType()} has an invalid discriminant. This is an implementation bug.");
@@ -279,7 +279,7 @@ namespace Galaxus.Functional
                 return rhs is null;
             }
 
-            return lhs.Equals(other: rhs);
+            return lhs.Equals(rhs);
         }
 
         /// <summary>

--- a/Galaxus.Functional/(Either)/Either2.cs
+++ b/Galaxus.Functional/(Either)/Either2.cs
@@ -27,7 +27,9 @@ namespace Galaxus.Functional
         public Either(A a)
         {
             if (typeof(A).IsValueType == false && a == null)
+            {
                 throw new ArgumentNullException(nameof(a));
+            }
 
             Discriminant = Discriminant2.A;
             _a = a;
@@ -39,7 +41,9 @@ namespace Galaxus.Functional
         public Either(B b)
         {
             if (typeof(B).IsValueType == false && b == null)
+            {
                 throw new ArgumentNullException(nameof(b));
+            }
 
             Discriminant = Discriminant2.B;
             _b = b;
@@ -110,13 +114,17 @@ namespace Galaxus.Functional
             {
                 case Discriminant2.A:
                     if (onA == null)
+                    {
                         throw new ArgumentNullException(nameof(onA));
+                    }
 
                     onA(obj: _a);
                     break;
                 case Discriminant2.B:
                     if (onB == null)
+                    {
                         throw new ArgumentNullException(nameof(onB));
+                    }
 
                     onB(obj: _b);
                     break;
@@ -138,12 +146,16 @@ namespace Galaxus.Functional
             {
                 case Discriminant2.A:
                     if (onA == null)
+                    {
                         throw new ArgumentNullException(nameof(onA));
+                    }
 
                     return onA(arg: _a);
                 case Discriminant2.B:
                     if (onB == null)
+                    {
                         throw new ArgumentNullException(nameof(onB));
+                    }
 
                     return onB(arg: _b);
                 default:
@@ -220,13 +232,19 @@ namespace Galaxus.Functional
         public bool Equals(Either<A, B> other)
         {
             if (other is null)
+            {
                 return false;
+            }
 
             if (ReferenceEquals(this, objB: other))
+            {
                 return true;
+            }
 
             if (Discriminant != other.Discriminant)
+            {
                 return false;
+            }
 
             switch (Discriminant)
             {
@@ -249,7 +267,9 @@ namespace Galaxus.Functional
         public static bool operator ==(Either<A, B> lhs, Either<A, B> rhs)
         {
             if (lhs is null)
+            {
                 return rhs is null;
+            }
 
             return lhs.Equals(other: rhs);
         }

--- a/Galaxus.Functional/(Either)/Either2.cs
+++ b/Galaxus.Functional/(Either)/Either2.cs
@@ -41,7 +41,7 @@ namespace Galaxus.Functional
         // Usages of implicit operators will only compile if A and B are different types.
 
         /// <summary>
-        /// Implicitly cast a value of type <see cref="A"/> to an <see cref="Either{A,B}"/> containing A.
+        /// Implicitly cast a value of type <c>A</c> to an <see cref="Either{A,B}"/> containing A.
         /// </summary>
         /// <param name="a">The value to cast.</param>
         /// <returns>An either containing that value as A.</returns>
@@ -49,7 +49,7 @@ namespace Galaxus.Functional
             => new Either<A, B>(a);
 
         /// <summary>
-        /// Implicitly cast a value of type <see cref="B"/> to an <see cref="Either{A,B}"/> containing B.
+        /// Implicitly cast a value of type <c>B</c> to an <see cref="Either{A,B}"/> containing B.
         /// </summary>
         /// <param name="b">The value to cast.</param>
         /// <returns>An either containing that value as B.</returns>
@@ -60,7 +60,14 @@ namespace Galaxus.Functional
 
         #region State
 
+        /// <summary>
+        ///
+        /// </summary>
         protected readonly A _a;
+
+        /// <summary>
+        ///
+        /// </summary>
         protected readonly B _b;
 
         /// <summary>

--- a/Galaxus.Functional/(Either)/Either3.cs
+++ b/Galaxus.Functional/(Either)/Either3.cs
@@ -67,33 +67,33 @@ namespace Galaxus.Functional
         // Usages of implicit operators will only compile if A, B and C are different types.
 
         /// <summary>
-        ///     Implicitly cast a value of type <c>A</c> to an <see cref="Either{A,B,C}" /> containing A.
+        ///     Implicitly cast a value of type <typeparamref name="A"/> to an <see cref="Either{A,B,C}" /> containing A.
         /// </summary>
         /// <param name="value">The value to cast.</param>
         /// <returns>An either containing that value as A.</returns>
         public static implicit operator Either<A, B, C>(A value)
         {
-            return new Either<A, B, C>(a: value);
+            return new Either<A, B, C>(value);
         }
 
         /// <summary>
-        ///     Implicitly cast a value of type <c>B</c> to an <see cref="Either{A,B,C}" /> containing B.
+        ///     Implicitly cast a value of type <typeparamref name="B"/> to an <see cref="Either{A,B,C}" /> containing B.
         /// </summary>
         /// <param name="value">The value to cast.</param>
         /// <returns>An either containing that value as B.</returns>
         public static implicit operator Either<A, B, C>(B value)
         {
-            return new Either<A, B, C>(b: value);
+            return new Either<A, B, C>(value);
         }
 
         /// <summary>
-        ///     Implicitly cast a value of type <c>C</c> to an <see cref="Either{A,B,C}" /> containing C.
+        ///     Implicitly cast a value of type <typeparamref name="C"/> to an <see cref="Either{A,B,C}" /> containing C.
         /// </summary>
         /// <param name="value">The value to cast.</param>
         /// <returns>An either containing that value as C.</returns>
         public static implicit operator Either<A, B, C>(C value)
         {
-            return new Either<A, B, C>(c: value);
+            return new Either<A, B, C>(value);
         }
 
         #endregion
@@ -165,7 +165,7 @@ namespace Galaxus.Functional
                         throw new ArgumentNullException(nameof(onA));
                     }
 
-                    onA(obj: _a);
+                    onA(_a);
                     break;
 
                 case Discriminant3.B:
@@ -174,7 +174,7 @@ namespace Galaxus.Functional
                         throw new ArgumentNullException(nameof(onB));
                     }
 
-                    onB(obj: _b);
+                    onB(_b);
                     break;
 
                 case Discriminant3.C:
@@ -183,7 +183,7 @@ namespace Galaxus.Functional
                         throw new ArgumentNullException(nameof(onC));
                     }
 
-                    onC(obj: _c);
+                    onC(_c);
                     break;
 
                 default:
@@ -209,7 +209,7 @@ namespace Galaxus.Functional
                         throw new ArgumentNullException(nameof(onA));
                     }
 
-                    return onA(arg: _a);
+                    return onA(_a);
 
                 case Discriminant3.B:
                     if (onB == null)
@@ -217,7 +217,7 @@ namespace Galaxus.Functional
                         throw new ArgumentNullException(nameof(onB));
                     }
 
-                    return onB(arg: _b);
+                    return onB(_b);
 
                 case Discriminant3.C:
                     if (onC == null)
@@ -225,7 +225,7 @@ namespace Galaxus.Functional
                         throw new ArgumentNullException(nameof(onC));
                     }
 
-                    return onC(arg: _c);
+                    return onC(_c);
 
                 default:
                     throw new InvalidOperationException(
@@ -251,9 +251,9 @@ namespace Galaxus.Functional
         public async Task<T> MatchAsync<T>(Func<A, Task<T>> onA, Func<B, Task<T>> onB, Func<C, Task<T>> onC)
         {
             return await Match(
-                async a => await onA(arg: a),
-                async b => await onB(arg: b),
-                async c => await onC(arg: c));
+                async a => await onA(a),
+                async b => await onB(b),
+                async c => await onC(c));
         }
 
         /// <summary>
@@ -274,9 +274,9 @@ namespace Galaxus.Functional
         public async Task<T> MatchAsync<T>(Func<A, T> onA, Func<B, Task<T>> onB, Func<C, Task<T>> onC)
         {
             return await Match(
-                a => Task.FromResult(onA(arg: a)),
-                async b => await onB(arg: b),
-                async c => await onC(arg: c));
+                a => Task.FromResult(onA(a)),
+                async b => await onB(b),
+                async c => await onC(c));
         }
 
         /// <summary>
@@ -297,9 +297,9 @@ namespace Galaxus.Functional
         public async Task<T> MatchAsync<T>(Func<A, Task<T>> onA, Func<B, T> onB, Func<C, Task<T>> onC)
         {
             return await Match(
-                async a => await onA(arg: a),
-                b => Task.FromResult(onB(arg: b)),
-                async c => await onC(arg: c));
+                async a => await onA(a),
+                b => Task.FromResult(onB(b)),
+                async c => await onC(c));
         }
 
         /// <summary>
@@ -320,9 +320,9 @@ namespace Galaxus.Functional
         public async Task<T> MatchAsync<T>(Func<A, Task<T>> onA, Func<B, Task<T>> onB, Func<C, T> onC)
         {
             return await Match(
-                async a => await onA(arg: a),
-                async b => await onB(arg: b),
-                c => Task.FromResult(onC(arg: c)));
+                async a => await onA(a),
+                async b => await onB(b),
+                c => Task.FromResult(onC(c)));
         }
 
         /// <summary>
@@ -343,9 +343,9 @@ namespace Galaxus.Functional
         public async Task<T> MatchAsync<T>(Func<A, T> onA, Func<B, T> onB, Func<C, Task<T>> onC)
         {
             return await Match(
-                a => Task.FromResult(onA(arg: a)),
-                b => Task.FromResult(onB(arg: b)),
-                async c => await onC(arg: c));
+                a => Task.FromResult(onA(a)),
+                b => Task.FromResult(onB(b)),
+                async c => await onC(c));
         }
 
         /// <summary>
@@ -366,9 +366,9 @@ namespace Galaxus.Functional
         public async Task<T> MatchAsync<T>(Func<A, T> onA, Func<B, Task<T>> onB, Func<C, T> onC)
         {
             return await Match(
-                a => Task.FromResult(onA(arg: a)),
-                async b => await onB(arg: b),
-                c => Task.FromResult(onC(arg: c)));
+                a => Task.FromResult(onA(a)),
+                async b => await onB(b),
+                c => Task.FromResult(onC(c)));
         }
 
         /// <summary>
@@ -389,9 +389,9 @@ namespace Galaxus.Functional
         public async Task<T> MatchAsync<T>(Func<A, Task<T>> onA, Func<B, T> onB, Func<C, T> onC)
         {
             return await Match(
-                async a => await onA(arg: a),
-                b => Task.FromResult(onB(arg: b)),
-                c => Task.FromResult(onC(arg: c)));
+                async a => await onA(a),
+                b => Task.FromResult(onB(b)),
+                c => Task.FromResult(onC(c)));
         }
 
         #endregion
@@ -412,7 +412,7 @@ namespace Galaxus.Functional
                 return false;
             }
 
-            if (ReferenceEquals(this, objB: other))
+            if (ReferenceEquals(this, other))
             {
                 return true;
             }
@@ -425,11 +425,11 @@ namespace Galaxus.Functional
             switch (Discriminant)
             {
                 case Discriminant3.A:
-                    return _a.Equals(obj: other._a);
+                    return _a.Equals(other._a);
                 case Discriminant3.B:
-                    return _b.Equals(obj: other._b);
+                    return _b.Equals(other._b);
                 case Discriminant3.C:
-                    return _c.Equals(obj: other._c);
+                    return _c.Equals(other._c);
                 default:
                     throw new InvalidOperationException(
                         $"{GetType()} has an invalid discriminant. This is an implementation bug.");
@@ -449,7 +449,7 @@ namespace Galaxus.Functional
                 return rhs is null;
             }
 
-            return lhs.Equals(other: rhs);
+            return lhs.Equals(rhs);
         }
 
         /// <summary>

--- a/Galaxus.Functional/(Either)/Either3.cs
+++ b/Galaxus.Functional/(Either)/Either3.cs
@@ -101,15 +101,27 @@ namespace Galaxus.Functional
         #region State
 
         /// <summary>
+        ///     The value of the first type that may be contained.
         /// </summary>
+        /// <remarks>
+        ///     When this either <see cref="IsB"/> or <see cref="IsC"/>, this value is <c>default</c>.
+        /// </remarks>
         protected readonly A _a;
 
         /// <summary>
+        ///     The value of the second type that may be contained.
         /// </summary>
+        /// <remarks>
+        ///     When this either <see cref="IsA"/> or <see cref="IsC"/>, this value is <c>default</c>.
+        /// </remarks>
         protected readonly B _b;
 
         /// <summary>
+        ///     The value of the third type that may be contained.
         /// </summary>
+        /// <remarks>
+        ///     When this either <see cref="IsA"/> or <see cref="IsB"/>, this value is <c>default</c>.
+        /// </remarks>
         protected readonly C _c;
 
         /// <summary>

--- a/Galaxus.Functional/(Either)/Either3.cs
+++ b/Galaxus.Functional/(Either)/Either3.cs
@@ -4,19 +4,26 @@ using System.Threading.Tasks;
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// The <see cref="Either{A, B, C}"/> is a discriminated union which is a data structure used to hold a value that could take on three different, but fixed, types.
-    /// Only one of the types can be in use at any one time, and a discriminant explicitly indicates which one is in use.
-    /// It can be thought of as a type that has several "cases", each of which should be handled correctly when that type is accessed.
+    ///     The <see cref="Either{A, B, C}" /> is a discriminated union which is a data structure used to hold a value that
+    ///     could take on three different, but fixed, types.
+    ///     Only one of the types can be in use at any one time, and a discriminant explicitly indicates which one is in use.
+    ///     It can be thought of as a type that has several "cases", each of which should be handled correctly when that type
+    ///     is accessed.
     /// </summary>
     /// <typeparam name="A">The first type this union can contain.</typeparam>
     /// <typeparam name="B">The second type this union can contain.</typeparam>
     /// <typeparam name="C">The third type this union can contain.</typeparam>
     public class Either<A, B, C> : IEquatable<Either<A, B, C>>, IEither
     {
+        object IEither.ToObject()
+        {
+            return Match<object>(a => a, b => b, c => c);
+        }
+
         #region Instance Initializer
 
         /// <summary>
-        /// Constructs a union in which field "A" is in use.
+        ///     Constructs a union in which field "A" is in use.
         /// </summary>
         public Either(A a)
         {
@@ -28,7 +35,7 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Constructs a union in which field "B" is in use.
+        ///     Constructs a union in which field "B" is in use.
         /// </summary>
         public Either(B b)
         {
@@ -40,7 +47,7 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Constructs a union in which field "C" is in use.
+        ///     Constructs a union in which field "C" is in use.
         /// </summary>
         public Either(C c)
         {
@@ -54,65 +61,68 @@ namespace Galaxus.Functional
         // Usages of implicit operators will only compile if A, B and C are different types.
 
         /// <summary>
-        /// Implicitly cast a value of type <c>A</c> to an <see cref="Either{A,B,C}"/> containing A.
+        ///     Implicitly cast a value of type <c>A</c> to an <see cref="Either{A,B,C}" /> containing A.
         /// </summary>
         /// <param name="value">The value to cast.</param>
         /// <returns>An either containing that value as A.</returns>
         public static implicit operator Either<A, B, C>(A value)
-            => new Either<A, B, C>(value);
+        {
+            return new Either<A, B, C>(a: value);
+        }
 
         /// <summary>
-        /// Implicitly cast a value of type <c>B</c> to an <see cref="Either{A,B,C}"/> containing B.
+        ///     Implicitly cast a value of type <c>B</c> to an <see cref="Either{A,B,C}" /> containing B.
         /// </summary>
         /// <param name="value">The value to cast.</param>
         /// <returns>An either containing that value as B.</returns>
         public static implicit operator Either<A, B, C>(B value)
-            => new Either<A, B, C>(value);
+        {
+            return new Either<A, B, C>(b: value);
+        }
 
         /// <summary>
-        /// Implicitly cast a value of type <c>C</c> to an <see cref="Either{A,B,C}"/> containing C.
+        ///     Implicitly cast a value of type <c>C</c> to an <see cref="Either{A,B,C}" /> containing C.
         /// </summary>
         /// <param name="value">The value to cast.</param>
         /// <returns>An either containing that value as C.</returns>
         public static implicit operator Either<A, B, C>(C value)
-            => new Either<A, B, C>(value);
+        {
+            return new Either<A, B, C>(c: value);
+        }
 
         #endregion
 
         #region State
 
         /// <summary>
-        ///
         /// </summary>
         protected readonly A _a;
 
         /// <summary>
-        ///
         /// </summary>
         protected readonly B _b;
 
         /// <summary>
-        ///
         /// </summary>
         protected readonly C _c;
 
         /// <summary>
-        /// Indicates which field is in use.
+        ///     Indicates which field is in use.
         /// </summary>
         public Discriminant3 Discriminant { get; }
 
         /// <summary>
-        /// Indicates that field A is in use.
+        ///     Indicates that field A is in use.
         /// </summary>
         public bool IsA => Discriminant == Discriminant3.A;
 
         /// <summary>
-        /// Indicates that field B is in use.
+        ///     Indicates that field B is in use.
         /// </summary>
         public bool IsB => Discriminant == Discriminant3.B;
 
         /// <summary>
-        /// Indicates that field C is in use.
+        ///     Indicates that field C is in use.
         /// </summary>
         public bool IsC => Discriminant == Discriminant3.C;
 
@@ -121,7 +131,8 @@ namespace Galaxus.Functional
         #region Match
 
         /// <summary>
-        /// Provides access to <b>self</b>'s content by calling either <paramref name="onA"/>, <paramref name="onB"/> or <paramref name="onC"/> and passing in <b>self</b>'s content.
+        ///     Provides access to <b>self</b>'s content by calling either <paramref name="onA" />, <paramref name="onB" /> or
+        ///     <paramref name="onC" /> and passing in <b>self</b>'s content.
         /// </summary>
         /// <param name="onA">Called when field "A" is in use. The argument to this action is never the <b>null</b> reference.</param>
         /// <param name="onB">Called when field "B" is in use. The argument to this action is never the <b>null</b> reference.</param>
@@ -134,30 +145,32 @@ namespace Galaxus.Functional
                     if (onA == null)
                         throw new ArgumentNullException(nameof(onA));
 
-                    onA(_a);
+                    onA(obj: _a);
                     break;
 
                 case Discriminant3.B:
                     if (onB == null)
                         throw new ArgumentNullException(nameof(onB));
 
-                    onB(_b);
+                    onB(obj: _b);
                     break;
 
                 case Discriminant3.C:
                     if (onC == null)
                         throw new ArgumentNullException(nameof(onC));
 
-                    onC(_c);
+                    onC(obj: _c);
                     break;
 
                 default:
-                    throw new InvalidOperationException($"{GetType()} has an invalid discriminant. This is an implementation bug.");
+                    throw new InvalidOperationException(
+                        $"{GetType()} has an invalid discriminant. This is an implementation bug.");
             }
         }
 
         /// <summary>
-        /// Provides access to <b>self</b>'s content by calling either <paramref name="onA"/>, <paramref name="onB"/> or <paramref name="onC"/> and passing in <b>self</b>'s content.
+        ///     Provides access to <b>self</b>'s content by calling either <paramref name="onA" />, <paramref name="onB" /> or
+        ///     <paramref name="onC" /> and passing in <b>self</b>'s content.
         /// </summary>
         /// <param name="onA">Called when field "A" is in use. The argument to this action is never the <b>null</b> reference.</param>
         /// <param name="onB">Called when field "B" is in use. The argument to this action is never the <b>null</b> reference.</param>
@@ -167,136 +180,199 @@ namespace Galaxus.Functional
             switch (Discriminant)
             {
                 case Discriminant3.A:
-                    if(onA == null)
+                    if (onA == null)
                         throw new ArgumentNullException(nameof(onA));
 
-                    return onA(_a);
+                    return onA(arg: _a);
 
                 case Discriminant3.B:
                     if (onB == null)
                         throw new ArgumentNullException(nameof(onB));
 
-                    return onB(_b);
+                    return onB(arg: _b);
 
                 case Discriminant3.C:
                     if (onC == null)
                         throw new ArgumentNullException(nameof(onC));
 
-                    return onC(_c);
+                    return onC(arg: _c);
 
                 default:
-                    throw new InvalidOperationException($"{GetType()} has an invalid discriminant. This is an implementation bug.");
+                    throw new InvalidOperationException(
+                        $"{GetType()} has an invalid discriminant. This is an implementation bug.");
             }
         }
 
         /// <summary>
-        /// An overload for <see cref="Match"/> using async functions.
+        ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
-        /// <param name="onA">Async function to be called when field "A" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onB">Async function to be called when field "B" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onC">Async function to be called when field "C" is in use. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onA">
+        ///     Async function to be called when field "A" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onB">
+        ///     Async function to be called when field "B" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onC">
+        ///     Async function to be called when field "C" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
         public async Task<T> MatchAsync<T>(Func<A, Task<T>> onA, Func<B, Task<T>> onB, Func<C, Task<T>> onC)
         {
             return await Match(
-                async a => await onA(a),
-                async b => await onB(b),
-                async c => await onC(c));
+                async a => await onA(arg: a),
+                async b => await onB(arg: b),
+                async c => await onC(arg: c));
         }
 
         /// <summary>
-        /// An overload for <see cref="Match"/> using async functions.
+        ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
-        /// <param name="onA">Non-async function to be called when field "A" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onB">Async function to be called when field "B" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onC">Async function to be called when field "C" is in use. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onA">
+        ///     Non-async function to be called when field "A" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onB">
+        ///     Async function to be called when field "B" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onC">
+        ///     Async function to be called when field "C" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
         public async Task<T> MatchAsync<T>(Func<A, T> onA, Func<B, Task<T>> onB, Func<C, Task<T>> onC)
         {
             return await Match(
-                a => Task.FromResult(onA(a)),
-                async b => await onB(b),
-                async c => await onC(c));
+                a => Task.FromResult(onA(arg: a)),
+                async b => await onB(arg: b),
+                async c => await onC(arg: c));
         }
 
         /// <summary>
-        /// An overload for <see cref="Match"/> using async functions.
+        ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
-        /// <param name="onA">Async function to be called when field "A" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onB">Non-async function to be called when field "B" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onC">Async function to be called when field "C" is in use. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onA">
+        ///     Async function to be called when field "A" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onB">
+        ///     Non-async function to be called when field "B" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onC">
+        ///     Async function to be called when field "C" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
         public async Task<T> MatchAsync<T>(Func<A, Task<T>> onA, Func<B, T> onB, Func<C, Task<T>> onC)
         {
             return await Match(
-                async a => await onA(a),
-                b => Task.FromResult(onB(b)),
-                async c => await onC(c));
+                async a => await onA(arg: a),
+                b => Task.FromResult(onB(arg: b)),
+                async c => await onC(arg: c));
         }
 
         /// <summary>
-        /// An overload for <see cref="Match"/> using async functions.
+        ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
-        /// <param name="onA">Async function to be called when field "A" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onB">Async function to be called when field "B" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onC">Non-async function to be called when field "C" is in use. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onA">
+        ///     Async function to be called when field "A" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onB">
+        ///     Async function to be called when field "B" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onC">
+        ///     Non-async function to be called when field "C" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
         public async Task<T> MatchAsync<T>(Func<A, Task<T>> onA, Func<B, Task<T>> onB, Func<C, T> onC)
         {
             return await Match(
-                async a => await onA(a),
-                async b => await onB(b),
-                c => Task.FromResult(onC(c)));
+                async a => await onA(arg: a),
+                async b => await onB(arg: b),
+                c => Task.FromResult(onC(arg: c)));
         }
 
         /// <summary>
-        /// An overload for <see cref="Match"/> using async functions.
+        ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
-        /// <param name="onA">Non-async function to be called when field "A" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onB">Non-async function to be called when field "B" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onC">Async function to be called when field "C" is in use. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onA">
+        ///     Non-async function to be called when field "A" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onB">
+        ///     Non-async function to be called when field "B" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onC">
+        ///     Async function to be called when field "C" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
         public async Task<T> MatchAsync<T>(Func<A, T> onA, Func<B, T> onB, Func<C, Task<T>> onC)
         {
             return await Match(
-                a => Task.FromResult(onA(a)),
-                b => Task.FromResult(onB(b)),
-                async c => await onC(c));
+                a => Task.FromResult(onA(arg: a)),
+                b => Task.FromResult(onB(arg: b)),
+                async c => await onC(arg: c));
         }
 
         /// <summary>
-        /// An overload for <see cref="Match"/> using async functions.
+        ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
-        /// <param name="onA">Non-async function to be called when field "A" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onB">Async function to be called when field "B" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onC">Non-async function to be called when field "C" is in use. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onA">
+        ///     Non-async function to be called when field "A" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onB">
+        ///     Async function to be called when field "B" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onC">
+        ///     Non-async function to be called when field "C" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
         public async Task<T> MatchAsync<T>(Func<A, T> onA, Func<B, Task<T>> onB, Func<C, T> onC)
         {
             return await Match(
-                a => Task.FromResult(onA(a)),
-                async b => await onB(b),
-                c => Task.FromResult(onC(c)));
+                a => Task.FromResult(onA(arg: a)),
+                async b => await onB(arg: b),
+                c => Task.FromResult(onC(arg: c)));
         }
 
         /// <summary>
-        /// An overload for <see cref="Match"/> using async functions.
+        ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
-        /// <param name="onA">Async function to be called when field "A" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onB">Non-async function to be called when field "B" is in use. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onC">Non-async function to be called when field "C" is in use. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onA">
+        ///     Async function to be called when field "A" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onB">
+        ///     Non-async function to be called when field "B" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
+        /// <param name="onC">
+        ///     Non-async function to be called when field "C" is in use. The argument to this action is never the
+        ///     <b>null</b> reference.
+        /// </param>
         public async Task<T> MatchAsync<T>(Func<A, Task<T>> onA, Func<B, T> onB, Func<C, T> onC)
         {
             return await Match(
-                async a => await onA(a),
-                b => Task.FromResult(onB(b)),
-                c => Task.FromResult(onC(c)));
+                async a => await onA(arg: a),
+                b => Task.FromResult(onB(arg: b)),
+                c => Task.FromResult(onC(arg: c)));
         }
 
         #endregion
-
-        object IEither.ToObject()
-            => Match<object>(a => a, b => b, c => c);
 
         #region Equals, GetHashCode & ToString
 
         /// <inheritdoc />
         public sealed override bool Equals(object other)
-            => Equals(other as Either<A, B, C>);
+        {
+            return Equals(other as Either<A, B, C>);
+        }
 
         /// <inheritdoc />
         public bool Equals(Either<A, B, C> other)
@@ -304,7 +380,7 @@ namespace Galaxus.Functional
             if (other is null)
                 return false;
 
-            if (ReferenceEquals(this, other))
+            if (ReferenceEquals(this, objB: other))
                 return true;
 
             if (Discriminant != other.Discriminant)
@@ -313,18 +389,19 @@ namespace Galaxus.Functional
             switch (Discriminant)
             {
                 case Discriminant3.A:
-                    return _a.Equals(other._a);
+                    return _a.Equals(obj: other._a);
                 case Discriminant3.B:
-                    return _b.Equals(other._b);
+                    return _b.Equals(obj: other._b);
                 case Discriminant3.C:
-                    return _c.Equals(other._c);
+                    return _c.Equals(obj: other._c);
                 default:
-                    throw new InvalidOperationException($"{GetType()} has an invalid discriminant. This is an implementation bug.");
+                    throw new InvalidOperationException(
+                        $"{GetType()} has an invalid discriminant. This is an implementation bug.");
             }
         }
 
         /// <summary>
-        /// Checks whether two eithers are equal.
+        ///     Checks whether two eithers are equal.
         /// </summary>
         /// <param name="lhs">The either to check against.</param>
         /// <param name="rhs">The either to check.</param>
@@ -334,25 +411,31 @@ namespace Galaxus.Functional
             if (lhs is null)
                 return rhs is null;
 
-            return lhs.Equals(rhs);
+            return lhs.Equals(other: rhs);
         }
 
         /// <summary>
-        /// Checks whether two eithers are not equal.
+        ///     Checks whether two eithers are not equal.
         /// </summary>
         /// <param name="lhs">The either to check against.</param>
         /// <param name="rhs">The either to check.</param>
         /// <returns><c>False</c> if the eithers are equal, <c>true</c> otherwise.</returns>
         public static bool operator !=(Either<A, B, C> lhs, Either<A, B, C> rhs)
-            => (lhs == rhs) == false;
+        {
+            return lhs == rhs == false;
+        }
 
         /// <inheritdoc />
         public override int GetHashCode()
-            => (Discriminant, _a, _b, _c).GetHashCode();
+        {
+            return (Discriminant, _a, _b, _c).GetHashCode();
+        }
 
         /// <inheritdoc />
         public override string ToString()
-            => Match(a => a.ToString(), b => b.ToString(), c => c.ToString());
+        {
+            return Match(a => a.ToString(), b => b.ToString(), c => c.ToString());
+        }
 
         #endregion
     }

--- a/Galaxus.Functional/(Either)/Either3.cs
+++ b/Galaxus.Functional/(Either)/Either3.cs
@@ -28,7 +28,9 @@ namespace Galaxus.Functional
         public Either(A a)
         {
             if (typeof(A).IsValueType == false && a == null)
+            {
                 throw new ArgumentNullException(nameof(a));
+            }
 
             Discriminant = Discriminant3.A;
             _a = a;
@@ -40,7 +42,9 @@ namespace Galaxus.Functional
         public Either(B b)
         {
             if (typeof(B).IsValueType == false && b == null)
+            {
                 throw new ArgumentNullException(nameof(b));
+            }
 
             Discriminant = Discriminant3.B;
             _b = b;
@@ -52,7 +56,9 @@ namespace Galaxus.Functional
         public Either(C c)
         {
             if (typeof(C).IsValueType == false && c == null)
+            {
                 throw new ArgumentNullException(nameof(c));
+            }
 
             Discriminant = Discriminant3.C;
             _c = c;
@@ -143,21 +149,27 @@ namespace Galaxus.Functional
             {
                 case Discriminant3.A:
                     if (onA == null)
+                    {
                         throw new ArgumentNullException(nameof(onA));
+                    }
 
                     onA(obj: _a);
                     break;
 
                 case Discriminant3.B:
                     if (onB == null)
+                    {
                         throw new ArgumentNullException(nameof(onB));
+                    }
 
                     onB(obj: _b);
                     break;
 
                 case Discriminant3.C:
                     if (onC == null)
+                    {
                         throw new ArgumentNullException(nameof(onC));
+                    }
 
                     onC(obj: _c);
                     break;
@@ -181,19 +193,25 @@ namespace Galaxus.Functional
             {
                 case Discriminant3.A:
                     if (onA == null)
+                    {
                         throw new ArgumentNullException(nameof(onA));
+                    }
 
                     return onA(arg: _a);
 
                 case Discriminant3.B:
                     if (onB == null)
+                    {
                         throw new ArgumentNullException(nameof(onB));
+                    }
 
                     return onB(arg: _b);
 
                 case Discriminant3.C:
                     if (onC == null)
+                    {
                         throw new ArgumentNullException(nameof(onC));
+                    }
 
                     return onC(arg: _c);
 
@@ -378,13 +396,19 @@ namespace Galaxus.Functional
         public bool Equals(Either<A, B, C> other)
         {
             if (other is null)
+            {
                 return false;
+            }
 
             if (ReferenceEquals(this, objB: other))
+            {
                 return true;
+            }
 
             if (Discriminant != other.Discriminant)
+            {
                 return false;
+            }
 
             switch (Discriminant)
             {
@@ -409,7 +433,9 @@ namespace Galaxus.Functional
         public static bool operator ==(Either<A, B, C> lhs, Either<A, B, C> rhs)
         {
             if (lhs is null)
+            {
                 return rhs is null;
+            }
 
             return lhs.Equals(other: rhs);
         }

--- a/Galaxus.Functional/(Either)/Either3.cs
+++ b/Galaxus.Functional/(Either)/Either3.cs
@@ -54,7 +54,7 @@ namespace Galaxus.Functional
         // Usages of implicit operators will only compile if A, B and C are different types.
 
         /// <summary>
-        /// Implicitly cast a value of type <see cref="A"/> to an <see cref="Either{A,B,C}"/> containing A.
+        /// Implicitly cast a value of type <c>A</c> to an <see cref="Either{A,B,C}"/> containing A.
         /// </summary>
         /// <param name="value">The value to cast.</param>
         /// <returns>An either containing that value as A.</returns>
@@ -62,7 +62,7 @@ namespace Galaxus.Functional
             => new Either<A, B, C>(value);
 
         /// <summary>
-        /// Implicitly cast a value of type <see cref="B"/> to an <see cref="Either{A,B,C}"/> containing B.
+        /// Implicitly cast a value of type <c>B</c> to an <see cref="Either{A,B,C}"/> containing B.
         /// </summary>
         /// <param name="value">The value to cast.</param>
         /// <returns>An either containing that value as B.</returns>
@@ -70,7 +70,7 @@ namespace Galaxus.Functional
             => new Either<A, B, C>(value);
 
         /// <summary>
-        /// Implicitly cast a value of type <see cref="C"/> to an <see cref="Either{A,B,C}"/> containing C.
+        /// Implicitly cast a value of type <c>C</c> to an <see cref="Either{A,B,C}"/> containing C.
         /// </summary>
         /// <param name="value">The value to cast.</param>
         /// <returns>An either containing that value as C.</returns>
@@ -81,8 +81,19 @@ namespace Galaxus.Functional
 
         #region State
 
+        /// <summary>
+        ///
+        /// </summary>
         protected readonly A _a;
+
+        /// <summary>
+        ///
+        /// </summary>
         protected readonly B _b;
+
+        /// <summary>
+        ///
+        /// </summary>
         protected readonly C _c;
 
         /// <summary>

--- a/Galaxus.Functional/(Either)/EitherExtensions.cs
+++ b/Galaxus.Functional/(Either)/EitherExtensions.cs
@@ -84,7 +84,7 @@ namespace Galaxus.Functional
         /// <param name="fallback">The value to be used, if option contains none</param>
         public static Either<TSome, TNone> ToEither<TSome, TNone>(this Option<TSome> option, TNone fallback)
         {
-            return option.MapOr<Either<TSome, TNone>>(some => some, fallback: fallback);
+            return option.MapOr<Either<TSome, TNone>>(some => some, fallback);
         }
     }
 }

--- a/Galaxus.Functional/(Either)/EitherExtensions.cs
+++ b/Galaxus.Functional/(Either)/EitherExtensions.cs
@@ -5,12 +5,12 @@ using System.Linq;
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// Extensions for Either
+    ///     Extensions for Either
     /// </summary>
     public static class EitherExtensions
     {
         /// <summary>
-        /// Select all "A" fields
+        ///     Select all "A" fields
         /// </summary>
         public static IEnumerable<A> SelectA<A, B>(this IEnumerable<Either<A, B>> eithers)
         {
@@ -23,7 +23,7 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Select all "B" fields
+        ///     Select all "B" fields
         /// </summary>
         public static IEnumerable<B> SelectB<A, B>(this IEnumerable<Either<A, B>> eithers)
         {
@@ -36,7 +36,7 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Select all "A" fields
+        ///     Select all "A" fields
         /// </summary>
         public static IEnumerable<A> SelectA<A, B, C>(this IEnumerable<Either<A, B, C>> eithers)
         {
@@ -50,7 +50,7 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Select all "B" fields
+        ///     Select all "B" fields
         /// </summary>
         public static IEnumerable<B> SelectB<A, B, C>(this IEnumerable<Either<A, B, C>> eithers)
         {
@@ -64,7 +64,7 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Select all "C" fields
+        ///     Select all "C" fields
         /// </summary>
         public static IEnumerable<C> SelectC<A, B, C>(this IEnumerable<Either<A, B, C>> eithers)
         {
@@ -78,11 +78,13 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Maps an Option to an Either using the option's value or a fallback
+        ///     Maps an Option to an Either using the option's value or a fallback
         /// </summary>
         /// <param name="option">The Option to be mapped</param>
         /// <param name="fallback">The value to be used, if option contains none</param>
         public static Either<TSome, TNone> ToEither<TSome, TNone>(this Option<TSome> option, TNone fallback)
-            => option.MapOr<Either<TSome, TNone>>(some => some, fallback);
+        {
+            return option.MapOr<Either<TSome, TNone>>(some => some, fallback: fallback);
+        }
     }
 }

--- a/Galaxus.Functional/(Either)/IEither.cs
+++ b/Galaxus.Functional/(Either)/IEither.cs
@@ -1,12 +1,12 @@
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// General interface for objects that roughly represent a discriminated union.
+    ///     General interface for objects that roughly represent a discriminated union.
     /// </summary>
     public interface IEither
     {
         /// <summary>
-        /// Returns the contained value as an <see cref="object"/>.
+        ///     Returns the contained value as an <see cref="object" />.
         /// </summary>
         object ToObject();
     }

--- a/Galaxus.Functional/(Option)/(Features)/Option.AndThen.cs
+++ b/Galaxus.Functional/(Option)/(Features)/Option.AndThen.cs
@@ -22,10 +22,14 @@ namespace Galaxus.Functional
         public Option<U> AndThen<U>(Func<T, Option<U>> continuation)
         {
             if (IsNone)
+            {
                 return Option<U>.None;
+            }
 
             if (continuation is null)
+            {
                 throw new ArgumentNullException(nameof(continuation));
+            }
 
             return continuation(arg: _some);
         }

--- a/Galaxus.Functional/(Option)/(Features)/Option.AndThen.cs
+++ b/Galaxus.Functional/(Option)/(Features)/Option.AndThen.cs
@@ -5,15 +5,18 @@ namespace Galaxus.Functional
     public readonly partial struct Option<T>
     {
         /// <summary>
-        /// Returns <b>None</b> if <b>self</b> contains <b>None</b>, otherwise returns <paramref name="fallback"/>.
+        ///     Returns <b>None</b> if <b>self</b> contains <b>None</b>, otherwise returns <paramref name="fallback" />.
         /// </summary>
         /// <param name="fallback">The value to return if <b>self</b> contains <b>Some</b>.</param>
         public Option<U> And<U>(Option<U> fallback)
-            => IsNone ? Option<U>.None : fallback;
+        {
+            return IsNone ? Option<U>.None : fallback;
+        }
 
         /// <summary>
-        /// Returns <b>None</b> if <b>self</b> contains <b>None</b>, otherwise calls <paramref name="continuation"/> with the wrapped value and returns the result.
-        /// Some languages call this operation flatmap.
+        ///     Returns <b>None</b> if <b>self</b> contains <b>None</b>, otherwise calls <paramref name="continuation" /> with the
+        ///     wrapped value and returns the result.
+        ///     Some languages call this operation flatmap.
         /// </summary>
         /// <param name="continuation">The function to call if <b>self</b> contains <b>Some</b>.</param>
         public Option<U> AndThen<U>(Func<T, Option<U>> continuation)
@@ -24,17 +27,18 @@ namespace Galaxus.Functional
             if (continuation is null)
                 throw new ArgumentNullException(nameof(continuation));
 
-            return continuation(_some);
+            return continuation(arg: _some);
         }
 
         /// <summary>
-        /// Returns <b>None</b> if <b>self</b> contains <b>None</b>, otherwise calls <paramref name="continuation"/> with the wrapped value.
-        /// Some languages call this operation flatmap.
+        ///     Returns <b>None</b> if <b>self</b> contains <b>None</b>, otherwise calls <paramref name="continuation" /> with the
+        ///     wrapped value.
+        ///     Some languages call this operation flatmap.
         /// </summary>
         /// <param name="continuation">The function to call if <b>self</b> contains <b>Some</b>.</param>
         public Option<T> AndThen(Action<T> continuation)
         {
-            IfSome(continuation);
+            IfSome(onSome: continuation);
             return this;
         }
     }

--- a/Galaxus.Functional/(Option)/(Features)/Option.AndThen.cs
+++ b/Galaxus.Functional/(Option)/(Features)/Option.AndThen.cs
@@ -31,7 +31,7 @@ namespace Galaxus.Functional
                 throw new ArgumentNullException(nameof(continuation));
             }
 
-            return continuation(arg: _some);
+            return continuation(_some);
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace Galaxus.Functional
         /// <param name="continuation">The function to call if <b>self</b> contains <b>Some</b>.</param>
         public Option<T> AndThen(Action<T> continuation)
         {
-            IfSome(onSome: continuation);
+            IfSome(continuation);
             return this;
         }
     }

--- a/Galaxus.Functional/(Option)/(Features)/Option.If.cs
+++ b/Galaxus.Functional/(Option)/(Features)/Option.If.cs
@@ -5,9 +5,13 @@ namespace Galaxus.Functional
     public readonly partial struct Option<T>
     {
         /// <summary>
-        /// Provides access to <b>self</b>'s <b>Some</b> value by calling <paramref name="onSome"/> if <b>self</b> contains <b>Some</b>.
+        ///     Provides access to <b>self</b>'s <b>Some</b> value by calling <paramref name="onSome" /> if <b>self</b> contains
+        ///     <b>Some</b>.
         /// </summary>
-        /// <param name="onSome">Called if <b>self</b> contains <b>Some</b>. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onSome">
+        ///     Called if <b>self</b> contains <b>Some</b>. The argument to this action is never the <b>null</b>
+        ///     reference.
+        /// </param>
         public void IfSome(Action<T> onSome)
         {
             if (IsSome)
@@ -15,7 +19,7 @@ namespace Galaxus.Functional
                 if (onSome is null)
                     throw new ArgumentNullException(nameof(onSome));
 
-                onSome(_some);
+                onSome(obj: _some);
             }
         }
 

--- a/Galaxus.Functional/(Option)/(Features)/Option.If.cs
+++ b/Galaxus.Functional/(Option)/(Features)/Option.If.cs
@@ -21,7 +21,7 @@ namespace Galaxus.Functional
                     throw new ArgumentNullException(nameof(onSome));
                 }
 
-                onSome(obj: _some);
+                onSome(_some);
             }
         }
 

--- a/Galaxus.Functional/(Option)/(Features)/Option.If.cs
+++ b/Galaxus.Functional/(Option)/(Features)/Option.If.cs
@@ -17,7 +17,9 @@ namespace Galaxus.Functional
             if (IsSome)
             {
                 if (onSome is null)
+                {
                     throw new ArgumentNullException(nameof(onSome));
+                }
 
                 onSome(obj: _some);
             }

--- a/Galaxus.Functional/(Option)/(Features)/Option.Map.cs
+++ b/Galaxus.Functional/(Option)/(Features)/Option.Map.cs
@@ -16,7 +16,9 @@ namespace Galaxus.Functional
                 some =>
                 {
                     if (map == null)
+                    {
                         throw new ArgumentNullException(nameof(map));
+                    }
 
                     return map(arg: some).ToOption();
                 },
@@ -36,7 +38,9 @@ namespace Galaxus.Functional
                 some =>
                 {
                     if (map == null)
+                    {
                         throw new ArgumentNullException(nameof(map));
+                    }
 
                     return map(arg: some);
                 },

--- a/Galaxus.Functional/(Option)/(Features)/Option.Map.cs
+++ b/Galaxus.Functional/(Option)/(Features)/Option.Map.cs
@@ -20,7 +20,7 @@ namespace Galaxus.Functional
                         throw new ArgumentNullException(nameof(map));
                     }
 
-                    return map(arg: some).ToOption();
+                    return map(some).ToOption();
                 },
                 () => Option<TTo>.None
             );
@@ -42,7 +42,7 @@ namespace Galaxus.Functional
                         throw new ArgumentNullException(nameof(map));
                     }
 
-                    return map(arg: some);
+                    return map(some);
                 },
                 () => fallback
             );

--- a/Galaxus.Functional/(Option)/(Features)/Option.Map.cs
+++ b/Galaxus.Functional/(Option)/(Features)/Option.Map.cs
@@ -5,7 +5,8 @@ namespace Galaxus.Functional
     public readonly partial struct Option<T>
     {
         /// <summary>
-        /// Maps a <see cref="Option{T}"/> to <see cref="Option{U}"/> by applying a function to a contained <b>Some</b> value.
+        ///     Maps a <see cref="Option{T}" /> to <see cref="Option{U}" /> by applying a function to a contained <b>Some</b>
+        ///     value.
         /// </summary>
         /// <typeparam name="TTo">The type to map to.</typeparam>
         /// <param name="map">The mapping function.</param>
@@ -17,14 +18,14 @@ namespace Galaxus.Functional
                     if (map == null)
                         throw new ArgumentNullException(nameof(map));
 
-                    return map(some).ToOption();
+                    return map(arg: some).ToOption();
                 },
                 () => Option<TTo>.None
             );
         }
 
         /// <summary>
-        /// Applies a function to the contained <b>Some</b> value (if any). Returns <paramref name="fallback"/> otherwise.
+        ///     Applies a function to the contained <b>Some</b> value (if any). Returns <paramref name="fallback" /> otherwise.
         /// </summary>
         /// <typeparam name="TTo">The type to map to.</typeparam>
         /// <param name="fallback">The value to return if <b>self</b> contains <b>None</b>.</param>
@@ -37,7 +38,7 @@ namespace Galaxus.Functional
                     if (map == null)
                         throw new ArgumentNullException(nameof(map));
 
-                    return map(some);
+                    return map(arg: some);
                 },
                 () => fallback
             );

--- a/Galaxus.Functional/(Option)/(Features)/Option.Match.cs
+++ b/Galaxus.Functional/(Option)/(Features)/Option.Match.cs
@@ -5,10 +5,13 @@ namespace Galaxus.Functional
     public readonly partial struct Option<T>
     {
         /// <summary>
-        /// Provides access to <b>self</b>'s content by calling <paramref name="onSome"/> and passing in <b>Some</b>
-        /// or calling <paramref name="onNone"/>.
+        ///     Provides access to <b>self</b>'s content by calling <paramref name="onSome" /> and passing in <b>Some</b>
+        ///     or calling <paramref name="onNone" />.
         /// </summary>
-        /// <param name="onSome">Called when <b>self</b> contains <b>Some</b>. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onSome">
+        ///     Called when <b>self</b> contains <b>Some</b>. The argument to this action is never the <b>null</b>
+        ///     reference.
+        /// </param>
         /// <param name="onNone">Called when <b>self</b> contains <b>None</b>.</param>
         public void Match(Action<T> onSome, Action onNone)
         {
@@ -17,7 +20,7 @@ namespace Galaxus.Functional
                 if (onSome is null)
                     throw new ArgumentNullException(nameof(onSome));
 
-                onSome(_some);
+                onSome(obj: _some);
             }
             else
             {
@@ -29,10 +32,13 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Provides access to <b>self</b>'s content by calling <paramref name="onSome"/> and passing in <b>Some</b>
-        /// or calling <paramref name="onNone"/>.
+        ///     Provides access to <b>self</b>'s content by calling <paramref name="onSome" /> and passing in <b>Some</b>
+        ///     or calling <paramref name="onNone" />.
         /// </summary>
-        /// <param name="onSome">Called when <b>self</b> contains <b>Some</b>. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onSome">
+        ///     Called when <b>self</b> contains <b>Some</b>. The argument to this action is never the <b>null</b>
+        ///     reference.
+        /// </param>
         /// <param name="onNone">Called when <b>self</b> contains <b>None</b>.</param>
         public U Match<U>(Func<T, U> onSome, Func<U> onNone)
         {
@@ -41,7 +47,7 @@ namespace Galaxus.Functional
                 if (onSome is null)
                     throw new ArgumentNullException(nameof(onSome));
 
-                return onSome(_some);
+                return onSome(arg: _some);
             }
 
             if (onNone is null)

--- a/Galaxus.Functional/(Option)/(Features)/Option.Match.cs
+++ b/Galaxus.Functional/(Option)/(Features)/Option.Match.cs
@@ -22,7 +22,7 @@ namespace Galaxus.Functional
                     throw new ArgumentNullException(nameof(onSome));
                 }
 
-                onSome(obj: _some);
+                onSome(_some);
             }
             else
             {
@@ -53,7 +53,7 @@ namespace Galaxus.Functional
                     throw new ArgumentNullException(nameof(onSome));
                 }
 
-                return onSome(arg: _some);
+                return onSome(_some);
             }
 
             if (onNone is null)

--- a/Galaxus.Functional/(Option)/(Features)/Option.Match.cs
+++ b/Galaxus.Functional/(Option)/(Features)/Option.Match.cs
@@ -18,14 +18,18 @@ namespace Galaxus.Functional
             if (IsSome)
             {
                 if (onSome is null)
+                {
                     throw new ArgumentNullException(nameof(onSome));
+                }
 
                 onSome(obj: _some);
             }
             else
             {
                 if (onNone is null)
+                {
                     throw new ArgumentNullException(nameof(onNone));
+                }
 
                 onNone();
             }
@@ -45,13 +49,17 @@ namespace Galaxus.Functional
             if (IsSome)
             {
                 if (onSome is null)
+                {
                     throw new ArgumentNullException(nameof(onSome));
+                }
 
                 return onSome(arg: _some);
             }
 
             if (onNone is null)
+            {
                 throw new ArgumentNullException(nameof(onNone));
+            }
 
             return onNone();
         }

--- a/Galaxus.Functional/(Option)/(Features)/Option.OrElse.cs
+++ b/Galaxus.Functional/(Option)/(Features)/Option.OrElse.cs
@@ -10,7 +10,7 @@ namespace Galaxus.Functional
         /// <param name="fallback">
         ///     The value to return if <b>self</b> contains <b>None</b>.
         ///     This argument is eagerly evaluated; if you are passing the result of a function call,
-        ///     it is recommended to use <see cref="OrElse(System.Func{Galaxus.Functional.Option{T}}())" />, which is lazily
+        ///     it is recommended to use <see cref="OrElse(System.Func{Galaxus.Functional.Option{T}})" />, which is lazily
         ///     evaluated.
         /// </param>
         public Option<T> Or(Option<T> fallback)

--- a/Galaxus.Functional/(Option)/(Features)/Option.OrElse.cs
+++ b/Galaxus.Functional/(Option)/(Features)/Option.OrElse.cs
@@ -26,10 +26,14 @@ namespace Galaxus.Functional
         public Option<T> OrElse(Func<Option<T>> fallback)
         {
             if (IsSome)
+            {
                 return this;
+            }
 
             if (fallback is null)
+            {
                 throw new ArgumentNullException(nameof(fallback));
+            }
 
             return fallback();
         }
@@ -42,7 +46,9 @@ namespace Galaxus.Functional
         public Option<T> Xor(Option<T> fallback)
         {
             if (IsSome == fallback.IsSome)
+            {
                 return None;
+            }
 
             return IsSome ? this : fallback;
         }

--- a/Galaxus.Functional/(Option)/(Features)/Option.OrElse.cs
+++ b/Galaxus.Functional/(Option)/(Features)/Option.OrElse.cs
@@ -5,18 +5,22 @@ namespace Galaxus.Functional
     public readonly partial struct Option<T>
     {
         /// <summary>
-        /// Returns <b>self</b> if it contains <b>Some</b>, otherwise returns <paramref name="fallback"/>.
+        ///     Returns <b>self</b> if it contains <b>Some</b>, otherwise returns <paramref name="fallback" />.
         /// </summary>
         /// <param name="fallback">
-        /// The value to return if <b>self</b> contains <b>None</b>.
-        /// This argument is eagerly evaluated; if you are passing the result of a function call,
-        /// it is recommended to use <see cref="OrElse(Func{Option{T}})"/>, which is lazily evaluated.
+        ///     The value to return if <b>self</b> contains <b>None</b>.
+        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
+        ///     it is recommended to use <see cref="OrElse(System.Func{Galaxus.Functional.Option{T}}())" />, which is lazily
+        ///     evaluated.
         /// </param>
         public Option<T> Or(Option<T> fallback)
-            => IsSome ? this : fallback;
+        {
+            return IsSome ? this : fallback;
+        }
 
         /// <summary>
-        /// Returns <b>self</b> if it contains <b>Some</b>, otherwise calls <paramref name="fallback"/> and returns the result.
+        ///     Returns <b>self</b> if it contains <b>Some</b>, otherwise calls <paramref name="fallback" /> and returns the
+        ///     result.
         /// </summary>
         /// <param name="fallback">The function to call if <b>self</b> contains <b>None</b>.</param>
         public Option<T> OrElse(Func<Option<T>> fallback)
@@ -31,9 +35,10 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Returns <b>Some</b> if exactly one of <b>self</b> and <paramref name="fallback"/> is <b>Some</b>, otherwise returns <b>None</b>.
+        ///     Returns <b>Some</b> if exactly one of <b>self</b> and <paramref name="fallback" /> is <b>Some</b>, otherwise
+        ///     returns <b>None</b>.
         /// </summary>
-        /// <param name="fallback">The <see cref="Option{T}"/> to compare against.</param>
+        /// <param name="fallback">The <see cref="Option{T}" /> to compare against.</param>
         public Option<T> Xor(Option<T> fallback)
         {
             if (IsSome == fallback.IsSome)

--- a/Galaxus.Functional/(Option)/AttemptToUnwrapNoneWhenOptionContainedSomeException.cs
+++ b/Galaxus.Functional/(Option)/AttemptToUnwrapNoneWhenOptionContainedSomeException.cs
@@ -11,7 +11,7 @@ namespace Galaxus.Functional
         ///     Create an <see cref="AttemptToUnwrapNoneWhenOptionContainedSomeException" /> object.
         /// </summary>
         /// <param name="message">The message for the exception.</param>
-        public AttemptToUnwrapNoneWhenOptionContainedSomeException(string message) : base(message: message)
+        public AttemptToUnwrapNoneWhenOptionContainedSomeException(string message) : base(message)
         {
         }
     }

--- a/Galaxus.Functional/(Option)/AttemptToUnwrapNoneWhenOptionContainedSomeException.cs
+++ b/Galaxus.Functional/(Option)/AttemptToUnwrapNoneWhenOptionContainedSomeException.cs
@@ -3,15 +3,15 @@ using System;
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// Thrown when an attempt was made to unwrap an <see cref="Option{T}"/> containing <see cref="None"/>.
+    ///     Thrown when an attempt was made to unwrap an <see cref="Option{T}" /> containing <see cref="None" />.
     /// </summary>
     public class AttemptToUnwrapNoneWhenOptionContainedSomeException : Exception
     {
         /// <summary>
-        /// Create an <see cref="AttemptToUnwrapNoneWhenOptionContainedSomeException"/> object.
+        ///     Create an <see cref="AttemptToUnwrapNoneWhenOptionContainedSomeException" /> object.
         /// </summary>
         /// <param name="message">The message for the exception.</param>
-        public AttemptToUnwrapNoneWhenOptionContainedSomeException(string message) : base(message)
+        public AttemptToUnwrapNoneWhenOptionContainedSomeException(string message) : base(message: message)
         {
         }
     }

--- a/Galaxus.Functional/(Option)/IOption.cs
+++ b/Galaxus.Functional/(Option)/IOption.cs
@@ -1,13 +1,13 @@
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// General interface for objects that represent an optional value.
+    ///     General interface for objects that represent an optional value.
     /// </summary>
     public interface IOption
     {
         /// <summary>
-        /// Returns <b>Some</b> as an <see cref="object"/> if <b>self</b> contains <b>Some</b>.
-        /// Returns <b>null</b> otherwise.
+        ///     Returns <b>Some</b> as an <see cref="object" /> if <b>self</b> contains <b>Some</b>.
+        ///     Returns <b>null</b> otherwise.
         /// </summary>
         object ToObject();
     }

--- a/Galaxus.Functional/(Option)/None.cs
+++ b/Galaxus.Functional/(Option)/None.cs
@@ -3,30 +3,38 @@ using System;
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// Denotes the absence of <b>Some</b>.
-    /// This type is most often used to implicitly convert from its value to an <see cref="Option{T}"/>.
+    ///     Denotes the absence of <b>Some</b>.
+    ///     This type is most often used to implicitly convert from its value to an <see cref="Option{T}" />.
     /// </summary>
     public struct None : IEquatable<None>
     {
         /// <summary>
-        /// The <b>None</b> value.
+        ///     The <b>None</b> value.
         /// </summary>
         public static readonly None Value = default;
 
         /// <inheritdoc />
         public override bool Equals(object other)
-            => other is None;
+        {
+            return other is None;
+        }
 
         /// <inheritdoc />
         public bool Equals(None obj)
-            => true;
+        {
+            return true;
+        }
 
         /// <inheritdoc />
         public override int GetHashCode()
-            => -1;
+        {
+            return -1;
+        }
 
         /// <inheritdoc />
         public override string ToString()
-            => "None";
+        {
+            return "None";
+        }
     }
 }

--- a/Galaxus.Functional/(Option)/Option.cs
+++ b/Galaxus.Functional/(Option)/Option.cs
@@ -105,10 +105,14 @@ namespace Galaxus.Functional
         public Result<T, TErr> OkOrElse<TErr>(Func<TErr> fallback)
         {
             if (IsSome)
+            {
                 return Result<T, TErr>.FromOk(ok: _some);
+            }
 
             if (fallback is null)
+            {
                 throw new ArgumentNullException(nameof(fallback));
+            }
 
             return Result<T, TErr>.FromErr(fallback());
         }
@@ -138,7 +142,9 @@ namespace Galaxus.Functional
         public T Unwrap(string error)
         {
             if (IsSome == false)
+            {
                 throw new AttemptToUnwrapNoneWhenOptionContainedSomeException(message: error);
+            }
 
             return _some;
         }
@@ -153,7 +159,9 @@ namespace Galaxus.Functional
             if (IsSome == false)
             {
                 if (error is null)
+                {
                     throw new ArgumentNullException(nameof(error));
+                }
 
                 throw new AttemptToUnwrapNoneWhenOptionContainedSomeException(error());
             }
@@ -183,10 +191,14 @@ namespace Galaxus.Functional
         public T UnwrapOrElse(Func<T> fallback)
         {
             if (IsSome)
+            {
                 return _some;
+            }
 
             if (fallback is null)
+            {
                 throw new ArgumentNullException(nameof(fallback));
+            }
 
             return fallback();
         }
@@ -250,11 +262,9 @@ namespace Galaxus.Functional
         /// <inheritdoc />
         public bool Equals(Option<T> other)
         {
-            return
-                IsSome
-                    ? other.IsSome && _some.Equals(obj: other._some)
-                    : other.IsSome == false
-                ;
+            return IsSome
+                ? other.IsSome && _some.Equals(obj: other._some)
+                : other.IsSome == false;
         }
 
         /// <summary>

--- a/Galaxus.Functional/(Option)/Option.cs
+++ b/Galaxus.Functional/(Option)/Option.cs
@@ -44,7 +44,7 @@ namespace Galaxus.Functional
         /// <param name="some">The value to use as <b>Some</b>.</param>
         public static Option<T> Some(T some)
         {
-            return new Option<T>(some: some);
+            return new Option<T>(some);
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Galaxus.Functional
         /// </param>
         public Result<T, TErr> OkOr<TErr>(TErr err)
         {
-            return IsSome ? Result<T, TErr>.FromOk(ok: _some) : Result<T, TErr>.FromErr(err: err);
+            return IsSome ? Result<T, TErr>.FromOk(_some) : Result<T, TErr>.FromErr(err);
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace Galaxus.Functional
         {
             if (IsSome)
             {
-                return Result<T, TErr>.FromOk(ok: _some);
+                return Result<T, TErr>.FromOk(_some);
             }
 
             if (fallback is null)
@@ -143,7 +143,7 @@ namespace Galaxus.Functional
         {
             if (IsSome == false)
             {
-                throw new AttemptToUnwrapNoneWhenOptionContainedSomeException(message: error);
+                throw new AttemptToUnwrapNoneWhenOptionContainedSomeException(error);
             }
 
             return _some;
@@ -228,7 +228,7 @@ namespace Galaxus.Functional
             var this_ = this;
 
             return Match(
-                v => filter(arg: v) ? this_ : None,
+                v => filter(v) ? this_ : None,
                 () => None
             );
         }
@@ -239,7 +239,7 @@ namespace Galaxus.Functional
         /// <param name="value">The value to check against.</param>
         public bool Contains(T value)
         {
-            return Match(v => v.Equals(obj: value), () => false);
+            return Match(v => v.Equals(value), () => false);
         }
 
         /// <summary>
@@ -256,14 +256,14 @@ namespace Galaxus.Functional
         /// <inheritdoc />
         public override bool Equals(object other)
         {
-            return other is Option<T> option && Equals(other: option);
+            return other is Option<T> option && Equals(option);
         }
 
         /// <inheritdoc />
         public bool Equals(Option<T> other)
         {
             return IsSome
-                ? other.IsSome && _some.Equals(obj: other._some)
+                ? other.IsSome && _some.Equals(other._some)
                 : other.IsSome == false;
         }
 
@@ -275,7 +275,7 @@ namespace Galaxus.Functional
         /// <returns><c>True</c> if the options are equal, <c>false</c> otherwise.</returns>
         public static bool operator ==(Option<T> a, Option<T> b)
         {
-            return a.Equals(other: b);
+            return a.Equals(b);
         }
 
         /// <summary>
@@ -286,7 +286,7 @@ namespace Galaxus.Functional
         /// <returns><c>True</c> if the options are equal, <c>false</c> otherwise.</returns>
         public static bool operator !=(Option<T> a, Option<T> b)
         {
-            return a.Equals(other: b) == false;
+            return a.Equals(b) == false;
         }
 
         /// <inheritdoc />

--- a/Galaxus.Functional/(Option)/Option.cs
+++ b/Galaxus.Functional/(Option)/Option.cs
@@ -3,15 +3,15 @@ using System;
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// Type <see cref="Option{T}"/> represents an optional value: every <see cref="Option{T}"/> is either <b>Some</b> and contains a value, or <b>None</b>, and does not.
-    ///
-    /// Option types are very common, as they have a number of uses:
-    /// 1) Initial values,
-    /// 2) Return values for functions that are not defined over their entire input range (partial functions),
-    /// 3) Return value for otherwise reporting simple errors, where <b>None</b> is returned on error,
-    /// 4) Optional fields,
-    /// 5) Optional function arguments,
-    /// 6) Nullable References.
+    ///     Type <see cref="Option{T}" /> represents an optional value: every <see cref="Option{T}" /> is either <b>Some</b>
+    ///     and contains a value, or <b>None</b>, and does not.
+    ///     Option types are very common, as they have a number of uses:
+    ///     1) Initial values,
+    ///     2) Return values for functions that are not defined over their entire input range (partial functions),
+    ///     3) Return value for otherwise reporting simple errors, where <b>None</b> is returned on error,
+    ///     4) Optional fields,
+    ///     5) Optional function arguments,
+    ///     6) Nullable References.
     /// </summary>
     public readonly partial struct Option<T> : IOption, IEquatable<Option<T>>
     {
@@ -31,26 +31,31 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Constructs an <see cref="Option{T}"/> containing <b>None</b>.
+        ///     Constructs an <see cref="Option{T}" /> containing <b>None</b>.
         /// </summary>
         public static Option<T> None
             => default;
 
         /// <summary>
-        /// Constructs an <see cref="Option{T}"/> containing <b>Some</b>.
-        /// Except if <paramref name="some"/> is the <b>null</b> reference, then the <see cref="Option{T}"/> will contain <b>None</b>.
+        ///     Constructs an <see cref="Option{T}" /> containing <b>Some</b>.
+        ///     Except if <paramref name="some" /> is the <b>null</b> reference, then the <see cref="Option{T}" /> will contain
+        ///     <b>None</b>.
         /// </summary>
         /// <param name="some">The value to use as <b>Some</b>.</param>
         public static Option<T> Some(T some)
-            => new Option<T>(some);
+        {
+            return new Option<T>(some: some);
+        }
 
         /// <summary>
-        /// Implicitly cast a <see cref="None"/> to an option containing none.
+        ///     Implicitly cast a <see cref="None" /> to an option containing none.
         /// </summary>
-        /// <param name="none">The <see cref="None"/> to implicitly cast.</param>
+        /// <param name="none">The <see cref="None" /> to implicitly cast.</param>
         /// <returns>An option containing none.</returns>
         public static implicit operator Option<T>(None none)
-            => None;
+        {
+            return None;
+        }
 
         // Note on implicit conversion:
         // An implicit operator from T to Option<T> is not implemented because we tried that and it caused unexpected runtime issues.
@@ -64,12 +69,12 @@ namespace Galaxus.Functional
         private readonly T _some;
 
         /// <summary>
-        /// True if the option contains "Some".
+        ///     True if the option contains "Some".
         /// </summary>
         public bool IsSome { get; }
 
         /// <summary>
-        /// True if the option contains "None".
+        ///     True if the option contains "None".
         /// </summary>
         public bool IsNone
             => IsSome == false;
@@ -79,24 +84,28 @@ namespace Galaxus.Functional
         #region Ok
 
         /// <summary>
-        /// Transforms <b>self</b> into a <see cref="Result{T,TErr}"/>, mapping <b>Some(v)</b> to <b>Ok(v)</b> and <b>None</b> to <b>Err(err)</b>.
+        ///     Transforms <b>self</b> into a <see cref="Result{T,TErr}" />, mapping <b>Some(v)</b> to <b>Ok(v)</b> and <b>None</b>
+        ///     to <b>Err(err)</b>.
         /// </summary>
         /// <param name="err">
-        /// The value to return as <b>Err</b> if <b>self</b> contains <b>None</b>.
-        /// This argument is eagerly evaluated; if you are passing the result of a function call,
-        /// it is recommended to use <see cref="OkOrElse{TErr}(Func{TErr})"/>, which is lazily evaluated.
+        ///     The value to return as <b>Err</b> if <b>self</b> contains <b>None</b>.
+        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
+        ///     it is recommended to use <see cref="OkOrElse{TErr}(Func{TErr})" />, which is lazily evaluated.
         /// </param>
         public Result<T, TErr> OkOr<TErr>(TErr err)
-            => IsSome ? Result<T, TErr>.FromOk(_some) : Result<T, TErr>.FromErr(err);
+        {
+            return IsSome ? Result<T, TErr>.FromOk(ok: _some) : Result<T, TErr>.FromErr(err: err);
+        }
 
         /// <summary>
-        /// Transforms <b>self</b> into a <see cref="Result{TOk, TErr}"/>, mapping <b>Some(v)</b> to <b>Ok(v)</b> and <b>None</b> to <b>Err(err)</b>.
+        ///     Transforms <b>self</b> into a <see cref="Result{TOk, TErr}" />, mapping <b>Some(v)</b> to <b>Ok(v)</b> and
+        ///     <b>None</b> to <b>Err(err)</b>.
         /// </summary>
         /// <param name="fallback">The value to return as <b>Err</b> if <b>self</b> contains <b>None</b>.</param>
         public Result<T, TErr> OkOrElse<TErr>(Func<TErr> fallback)
         {
             if (IsSome)
-                return Result<T, TErr>.FromOk(_some);
+                return Result<T, TErr>.FromOk(ok: _some);
 
             if (fallback is null)
                 throw new ArgumentNullException(nameof(fallback));
@@ -109,31 +118,34 @@ namespace Galaxus.Functional
         #region Unwrap
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Some</b>.
-        /// <i>Throws if <b>self</b> contains <b>None</b>!</i>
+        ///     Unwraps <b>self</b> and returns <b>Some</b>.
+        ///     <i>Throws if <b>self</b> contains <b>None</b>!</i>
         /// </summary>
         public T Unwrap()
-            => Unwrap(() => $"Cannot unwrap \"None\" of type {typeof(T)}.");
+        {
+            return Unwrap(() => $"Cannot unwrap \"None\" of type {typeof(T)}.");
+        }
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Some</b>.
-        /// <i>Throws if <b>self</b> contains <b>None</b>!</i>
+        ///     Unwraps <b>self</b> and returns <b>Some</b>.
+        ///     <i>Throws if <b>self</b> contains <b>None</b>!</i>
         /// </summary>
         /// <param name="error">
-        /// A custom error to use as the exception message.
-        /// This argument is eagerly evaluated; if you are passing the result of a function call,
-        /// it is recommended to use <see cref="Unwrap(Func{string})"/>, which is lazily evaluated.</param>
+        ///     A custom error to use as the exception message.
+        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
+        ///     it is recommended to use <see cref="Unwrap(Func{string})" />, which is lazily evaluated.
+        /// </param>
         public T Unwrap(string error)
         {
             if (IsSome == false)
-                throw new AttemptToUnwrapNoneWhenOptionContainedSomeException(error);
+                throw new AttemptToUnwrapNoneWhenOptionContainedSomeException(message: error);
 
             return _some;
         }
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Ok</b>.
-        /// <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        ///     Unwraps <b>self</b> and returns <b>Ok</b>.
+        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
         /// </summary>
         /// <param name="error">A function that returns a custom error to use as the exception message.</param>
         public T Unwrap(Func<string> error)
@@ -150,17 +162,22 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns <paramref name="fallback"/> otherwise.
+        ///     Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns
+        ///     <paramref name="fallback" /> otherwise.
         /// </summary>
         /// <param name="fallback">
-        /// The value to return if <b>self</b> is <b>Some</b>.
-        /// This argument is eagerly evaluated; if you are passing the result of a function call,
-        /// it is recommended to use <see cref="UnwrapOrElse(Func{T})"/>, which is lazily evaluated.</param>
+        ///     The value to return if <b>self</b> is <b>Some</b>.
+        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
+        ///     it is recommended to use <see cref="UnwrapOrElse(Func{T})" />, which is lazily evaluated.
+        /// </param>
         public T UnwrapOr(T fallback)
-            => IsSome ? _some : fallback;
+        {
+            return IsSome ? _some : fallback;
+        }
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns the result of <paramref name="fallback"/> otherwise.
+        ///     Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns the result of
+        ///     <paramref name="fallback" /> otherwise.
         /// </summary>
         /// <param name="fallback">The function to call if <b>self</b> contains <b>None</b>.</param>
         public T UnwrapOrElse(Func<T> fallback)
@@ -175,18 +192,23 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns the default value of <typeparamref name="T"/> otherwise.
+        ///     Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns the default value of
+        ///     <typeparamref name="T" /> otherwise.
         /// </summary>
         public T UnwrapOrDefault()
-            => IsSome ? _some : default;
+        {
+            return IsSome ? _some : default;
+        }
 
         #endregion
 
         /// <summary>
-        /// Returns <b>None</b> if the option is <b>None</b>. Otherwise calls <paramref name="filter"/> with the wrapped value and returns:
-        /// <b>Some(t)</b> if <paramref name="filter"/> returns <b>true</b> (where t is the wrapped value), and
-        /// <b>None</b> if <paramref name="filter"/> returns <b>false</b>.
-        /// You can imagine the <see cref="Option{T}"/> being an iterator over one or zero elements. <see cref="Filter(Func{T, bool})"/> lets you decide which elements to keep.
+        ///     Returns <b>None</b> if the option is <b>None</b>. Otherwise calls <paramref name="filter" /> with the wrapped value
+        ///     and returns:
+        ///     <b>Some(t)</b> if <paramref name="filter" /> returns <b>true</b> (where t is the wrapped value), and
+        ///     <b>None</b> if <paramref name="filter" /> returns <b>false</b>.
+        ///     You can imagine the <see cref="Option{T}" /> being an iterator over one or zero elements.
+        ///     <see cref="Filter(Func{T, bool})" /> lets you decide which elements to keep.
         /// </summary>
         /// <param name="filter">The filter to apply.</param>
         public Option<T> Filter(Func<T, bool> filter)
@@ -194,68 +216,80 @@ namespace Galaxus.Functional
             var this_ = this;
 
             return Match(
-                v => filter(v) ? this_ : None,
+                v => filter(arg: v) ? this_ : None,
                 () => None
             );
         }
 
         /// <summary>
-        /// Returns true if the option contains the given value.
+        ///     Returns true if the option contains the given value.
         /// </summary>
         /// <param name="value">The value to check against.</param>
         public bool Contains(T value)
         {
-            return Match(v => v.Equals(value), () => false);
+            return Match(v => v.Equals(obj: value), () => false);
         }
 
         /// <summary>
-        /// Returns the contained value as an <see cref="object"/> if the option contains <b>Some</b>.
-        /// Returns the <b>null</b> reference otherwise.
+        ///     Returns the contained value as an <see cref="object" /> if the option contains <b>Some</b>.
+        ///     Returns the <b>null</b> reference otherwise.
         /// </summary>
         object IOption.ToObject()
-            => IsSome ? _some : default(object);
+        {
+            return IsSome ? _some : default(object);
+        }
 
         #region Equals, GetHashCode & ToString
 
         /// <inheritdoc />
         public override bool Equals(object other)
-            => other is Option<T> option && Equals(option);
+        {
+            return other is Option<T> option && Equals(other: option);
+        }
 
         /// <inheritdoc />
         public bool Equals(Option<T> other)
         {
             return
                 IsSome
-                    ? other.IsSome && _some.Equals(other._some)
+                    ? other.IsSome && _some.Equals(obj: other._some)
                     : other.IsSome == false
                 ;
         }
 
         /// <summary>
-        /// Check whether two options are equal.
+        ///     Check whether two options are equal.
         /// </summary>
         /// <param name="a">The option to check against.</param>
         /// <param name="b">The option to check.</param>
         /// <returns><c>True</c> if the options are equal, <c>false</c> otherwise.</returns>
         public static bool operator ==(Option<T> a, Option<T> b)
-            => a.Equals(b);
+        {
+            return a.Equals(other: b);
+        }
 
         /// <summary>
-        /// Check whether two options are equal.
+        ///     Check whether two options are equal.
         /// </summary>
         /// <param name="a">The option to check against.</param>
         /// <param name="b">The option to check.</param>
         /// <returns><c>True</c> if the options are equal, <c>false</c> otherwise.</returns>
         public static bool operator !=(Option<T> a, Option<T> b)
-            => a.Equals(b) == false;
+        {
+            return a.Equals(other: b) == false;
+        }
 
         /// <inheritdoc />
         public override int GetHashCode()
-            => (IsSome, _some).GetHashCode();
+        {
+            return (IsSome, _some).GetHashCode();
+        }
 
         /// <inheritdoc />
         public override string ToString()
-            => Match(some => some.ToString(), () => Functional.None.Value.ToString());
+        {
+            return Match(some => some.ToString(), () => Functional.None.Value.ToString());
+        }
 
         #endregion
     }

--- a/Galaxus.Functional/(Option)/OptionExtensions.cs
+++ b/Galaxus.Functional/(Option)/OptionExtensions.cs
@@ -5,6 +5,9 @@ using System.Threading.Tasks;
 
 namespace Galaxus.Functional
 {
+    /// <summary>
+    /// Extensions for the option type, providing some quality of life-shorthands.
+    /// </summary>
     public static class OptionExtensions
     {
         #region Enumeration
@@ -47,11 +50,29 @@ namespace Galaxus.Functional
 
         #region Flatten
 
+        /// <summary>
+        /// Flatten an option containing an option into a single option.
+        /// </summary>
+        /// <param name="option">The option to flatten.</param>
+        /// <typeparam name="T">Type contained in the option.</typeparam>
+        /// <returns>
+        ///     <see cref="Option{T}"/> containing <c>Some</c> if both the outer as well as the inner option are <c>Some</c>;
+        ///     otherwise, returns <see cref="None"/>
+        /// </returns>
         public static Option<T> Flatten<T>(this Option<Option<T>> option)
         {
             return option.UnwrapOr(Option<T>.None);
         }
 
+        /// <summary>
+        /// Flatten an option containing an option within an option into a single option.
+        /// </summary>
+        /// <param name="option">The option to flatten.</param>
+        /// <typeparam name="T">Type contained in the option.</typeparam>
+        /// <returns>
+        ///     <see cref="Option{T}"/> containing <c>Some</c> if all layers in the given option are <c>Some</c>;
+        ///     otherwise, returns <see cref="None"/>
+        /// </returns>
         public static Option<T> Flatten<T>(this Option<Option<Option<T>>> option)
         {
             return option.UnwrapOr(Option<Option<T>>.None).UnwrapOr(Option<T>.None);

--- a/Galaxus.Functional/(Option)/OptionExtensions.cs
+++ b/Galaxus.Functional/(Option)/OptionExtensions.cs
@@ -6,219 +6,45 @@ using System.Threading.Tasks;
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// Extensions for the option type, providing some quality of life-shorthands.
+    ///     Extensions for the option type, providing some quality of life-shorthands.
     /// </summary>
     public static class OptionExtensions
     {
-        #region Enumeration
-
-        /// <summary>
-        /// Returns a subset of <paramref name="self"/> which contains all values in <paramref name="self"/> that contained "Some".
-        /// </summary>
-        public static IEnumerable<T> SelectSome<T>(this IEnumerable<Option<T>> self)
-            => self.Where(v => v.IsSome).Select(v => v.Unwrap());
-
-        /// <summary>
-        /// Returns a subset of <paramref name="self"/> which contains all values in <paramref name="self"/> that contained "Some" and runs it through the <paramref name="selector"/>.
-        /// </summary>
-        public static IEnumerable<TSelection> SelectSome<T, TSelection>(this IEnumerable<Option<T>> self, Func<T, TSelection> selector)
-            => self.SelectSome().Select(selector);
-
-        #endregion
-
         #region C# type system compatibility
 
         /// <summary>
-        /// Transforms an option of a value type into a nullable of the same value type.
+        ///     Transforms an option of a value type into a nullable of the same value type.
         /// </summary>
         public static T? ToNullable<T>(this Option<T> self) where T : struct
-            => self.Match(v => v, () => default(T?));
+        {
+            return self.Match(v => v, () => default(T?));
+        }
 
         #endregion
 
         #region Static Map
 
         /// <summary>
-        /// Automatically maps the contained value to another type.
+        ///     Automatically maps the contained value to another type.
         /// </summary>
-        /// <typeparam name="TFrom">The current type of the options' content. This type must derive from <typeparamref name="TTo"/>.</typeparam>
+        /// <typeparam name="TFrom">
+        ///     The current type of the options' content. This type must derive from
+        ///     <typeparamref name="TTo" />.
+        /// </typeparam>
         /// <typeparam name="TTo">The type to map the option's content to.</typeparam>
         public static Option<TTo> Map<TFrom, TTo>(this Option<TFrom> self) where TFrom : TTo
-            => self.Match(v => v.ToOption<TTo>(), () => Option<TTo>.None);
-
-        #endregion
-
-        #region Flatten
-
-        /// <summary>
-        /// Flatten an option containing an option into a single option.
-        /// </summary>
-        /// <param name="option">The option to flatten.</param>
-        /// <typeparam name="T">Type contained in the option.</typeparam>
-        /// <returns>
-        ///     <see cref="Option{T}"/> containing <c>Some</c> if both the outer as well as the inner option are <c>Some</c>;
-        ///     otherwise, returns <see cref="None"/>
-        /// </returns>
-        public static Option<T> Flatten<T>(this Option<Option<T>> option)
         {
-            return option.UnwrapOr(Option<T>.None);
-        }
-
-        /// <summary>
-        /// Flatten an option containing an option within an option into a single option.
-        /// </summary>
-        /// <param name="option">The option to flatten.</param>
-        /// <typeparam name="T">Type contained in the option.</typeparam>
-        /// <returns>
-        ///     <see cref="Option{T}"/> containing <c>Some</c> if all layers in the given option are <c>Some</c>;
-        ///     otherwise, returns <see cref="None"/>
-        /// </returns>
-        public static Option<T> Flatten<T>(this Option<Option<Option<T>>> option)
-        {
-            return option.UnwrapOr(Option<Option<T>>.None).UnwrapOr(Option<T>.None);
+            return self.Match(v => v.ToOption<TTo>(), () => Option<TTo>.None);
         }
 
         #endregion
 
-        #region ToOption
-
         /// <summary>
-        /// Wraps a value into an option. Non-null values will result in Option.Some and null values in Option.None. Therefore it is safe to invoke this method
-        /// on a "null" reference.
-        /// </summary>
-        public static Option<T> ToOption<T>(this T self)
-            => Option<T>.Some(self);
-
-        /// <summary>
-        /// Transforms a nullable value type into an option of the same value type. Non-null values will result in Option.Some and null values in Option.None.
-        /// </summary>
-        public static Option<T> ToOption<T>(this T? self) where T : struct
-            => self?.ToOption() ?? Option<T>.None;
-
-        #endregion
-
-        #region UnwrapAsync
-
-        /// <summary>
-        /// Unwraps asynchronous <b>self</b> and returns <b>Some</b>.
-        /// <i>Throws if <b>self</b> contains <b>None</b>!</i>
-        /// </summary>
-        /// <param name="self"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns><b>some</b></returns>
-        public static async Task<T> UnwrapAsync<T>(this Task<Option<T>> self) => (await self).Unwrap();
-
-        /// <summary>
-        /// Unwraps asynchronous <b>self</b> and returns <b>Some</b>.
-        /// <i>Throws if <b>self</b> contains <b>None</b>!</i>
-        /// </summary>
-        /// <param name="self"></param>
-        /// <param name="error">
-        /// A custom error to use as the exception message.
-        /// This argument is eagerly evaluated; if you are passing the result of a function call,
-        /// it is recommended to use <see cref="UnwrapAsync{T}(System.Threading.Tasks.Task{Galaxus.Functional.Option{T}})"/>, which is lazily evaluated.</param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns><b>some</b></returns>
-        public static async Task<T> UnwrapAsync<T>(this Task<Option<T>> self, string error) =>
-            (await self).Unwrap(error);
-
-        /// <summary>
-        /// Unwraps asynchronous <b>self</b> and returns <b>Ok</b>.
-        /// <i>Throws if <b>self</b> contains <b>Err</b>!</i>
-        /// </summary>
-        /// <param name="self"></param>
-        /// <param name="error"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns><b>some</b></returns>
-        public static async Task<T> UnwrapAsync<T>(this Task<Option<T>> self, Func<string> error)
-            => (await self).Unwrap(error);
-
-        /// <summary>
-        /// Unwraps asynchronous <b>self</b> and returns <b>Ok</b>.
-        /// <i>Throws if <b>self</b> contains <b>Err</b>!</i>
-        /// </summary>
-        /// <param name="self"></param>
-        /// <param name="error"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns><b>some</b></returns>
-        public static async Task<T> UnwrapAsync<T>(this Task<Option<T>> self, Func<Task<string>> error)
-        {
-            var res = await self;
-            if (res.IsNone)
-            {
-                if (error is null)
-                    throw new ArgumentNullException(nameof(error));
-
-                throw new AttemptToUnwrapNoneWhenOptionContainedSomeException(await error());
-            }
-
-            return res.Unwrap();
-        }
-
-        /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns <paramref name="fallback"/> otherwise.
-        /// </summary>
-        /// <param name="self"></param>
-        /// <param name="fallback">
-        /// The value to return if <b>self</b> is <b>Some</b>.
-        /// This argument is eagerly evaluated; if you are passing the result of a function call,
-        /// it is recommended to use <see cref="UnwrapOrElseAsync{T}(System.Threading.Tasks.Task{Galaxus.Functional.Option{T}},System.Func{T})"/>, which is lazily evaluated.</param>
-        public static async Task<T> UnwrapOrAsync<T>(this Task<Option<T>> self, T fallback) =>
-            (await self).UnwrapOr(fallback);
-
-        /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns <paramref name="fallback"/> otherwise.
-        /// </summary>
-        /// <param name="self"></param>
-        /// <param name="fallback">
-        /// The value to return if <b>self</b> is <b>Some</b>.
-        /// This argument is eagerly evaluated; if you are passing the result of a function call,
-        /// it is recommended to use <see cref="UnwrapOrElseAsync{T}(System.Threading.Tasks.Task{Galaxus.Functional.Option{T}},System.Func{System.Threading.Tasks.Task{T}})"/>, which is lazily evaluated.</param>
-        public static async Task<T> UnwrapOrAsync<T>(this Task<Option<T>> self, Task<T> fallback) =>
-            (await self).UnwrapOr(await fallback);
-
-        /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns the result of <paramref name="fallback"/> otherwise.
-        /// </summary>
-        /// <param name="self"></param>
-        /// <param name="fallback">The function to call if <b>self</b> contains <b>None</b>.</param>
-        public static async Task<T> UnwrapOrElseAsync<T>(this Task<Option<T>> self, Func<T> fallback) =>
-            (await self).UnwrapOrElse(fallback);
-
-        /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns the result of <paramref name="fallback"/> otherwise.
-        /// </summary>
-        /// <param name="self"></param>
-        /// <param name="fallback">The function to call if <b>self</b> contains <b>None</b>.</param>
-        public static async Task<T> UnwrapOrElseAsync<T>(this Task<Option<T>> self, Func<Task<T>> fallback)
-        {
-            var opt = await self;
-            if (opt.IsSome)
-            {
-                return opt.Unwrap();
-            }
-
-            if (fallback is null)
-                throw new ArgumentNullException(nameof(fallback));
-
-            return await fallback();
-        }
-
-        /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns the default value of <typeparamref name="T"/> otherwise.
-        /// </summary>
-        /// <param name="self"></param>
-        /// <typeparam name="T"></typeparam>
-        public static async Task<T> UnwrapOrDefaultAsync<T>(this Task<Option<T>> self) =>
-            (await self).UnwrapOrDefault();
-
-        #endregion
-
-        /// <summary>
-        /// Transposes an <see cref="Option{T}"/> containing a <see cref="Result{TOk, TErr}"/> into a <see cref="Result{TOk, TErr}"/> containing an <see cref="Option{T}"/> as its <b>Ok</b> value.
-        /// <b>None</b> will be mapped to <b>Ok(None)</b>.
-        /// <b>Some(Ok(TOk))</b> will be mapped to <b>Ok(Some(TOk))</b>.
-        /// <b>Some(Err(TErr))</b> will be mapped to <b>Err(TErr)</b>.
+        ///     Transposes an <see cref="Option{T}" /> containing a <see cref="Result{TOk, TErr}" /> into a
+        ///     <see cref="Result{TOk, TErr}" /> containing an <see cref="Option{T}" /> as its <b>Ok</b> value.
+        ///     <b>None</b> will be mapped to <b>Ok(None)</b>.
+        ///     <b>Some(Ok(TOk))</b> will be mapped to <b>Ok(Some(TOk))</b>.
+        ///     <b>Some(Err(TErr))</b> will be mapped to <b>Err(TErr)</b>.
         /// </summary>
         /// <typeparam name="TOk"></typeparam>
         /// <typeparam name="TErr"></typeparam>
@@ -234,5 +60,234 @@ namespace Galaxus.Functional
                 () => Option<TOk>.None.ToOk<Option<TOk>, TErr>()
             );
         }
+
+        #region Enumeration
+
+        /// <summary>
+        ///     Returns a subset of <paramref name="self" /> which contains all values in <paramref name="self" /> that contained
+        ///     "Some".
+        /// </summary>
+        public static IEnumerable<T> SelectSome<T>(this IEnumerable<Option<T>> self)
+        {
+            return self.Where(v => v.IsSome).Select(v => v.Unwrap());
+        }
+
+        /// <summary>
+        ///     Returns a subset of <paramref name="self" /> which contains all values in <paramref name="self" /> that contained
+        ///     "Some" and runs it through the <paramref name="selector" />.
+        /// </summary>
+        public static IEnumerable<TSelection> SelectSome<T, TSelection>(this IEnumerable<Option<T>> self,
+            Func<T, TSelection> selector)
+        {
+            return self.SelectSome().Select(selector: selector);
+        }
+
+        #endregion
+
+        #region Flatten
+
+        /// <summary>
+        ///     Flatten an option containing an option into a single option.
+        /// </summary>
+        /// <param name="option">The option to flatten.</param>
+        /// <typeparam name="T">Type contained in the option.</typeparam>
+        /// <returns>
+        ///     <see cref="Option{T}" /> containing <c>Some</c> if both the outer as well as the inner option are <c>Some</c>;
+        ///     otherwise, returns <see cref="None" />
+        /// </returns>
+        public static Option<T> Flatten<T>(this Option<Option<T>> option)
+        {
+            return option.UnwrapOr(fallback: Option<T>.None);
+        }
+
+        /// <summary>
+        ///     Flatten an option containing an option within an option into a single option.
+        /// </summary>
+        /// <param name="option">The option to flatten.</param>
+        /// <typeparam name="T">Type contained in the option.</typeparam>
+        /// <returns>
+        ///     <see cref="Option{T}" /> containing <c>Some</c> if all layers in the given option are <c>Some</c>;
+        ///     otherwise, returns <see cref="None" />
+        /// </returns>
+        public static Option<T> Flatten<T>(this Option<Option<Option<T>>> option)
+        {
+            return option.UnwrapOr(fallback: Option<Option<T>>.None).UnwrapOr(fallback: Option<T>.None);
+        }
+
+        #endregion
+
+        #region ToOption
+
+        /// <summary>
+        ///     Wraps a value into an option. Non-null values will result in Option.Some and null values in Option.None. Therefore
+        ///     it is safe to invoke this method
+        ///     on a "null" reference.
+        /// </summary>
+        public static Option<T> ToOption<T>(this T self)
+        {
+            return Option<T>.Some(some: self);
+        }
+
+        /// <summary>
+        ///     Transforms a nullable value type into an option of the same value type. Non-null values will result in Option.Some
+        ///     and null values in Option.None.
+        /// </summary>
+        public static Option<T> ToOption<T>(this T? self) where T : struct
+        {
+            return self?.ToOption() ?? Option<T>.None;
+        }
+
+        #endregion
+
+        #region UnwrapAsync
+
+        /// <summary>
+        ///     Unwraps asynchronous <b>self</b> and returns <b>Some</b>.
+        ///     <i>Throws if <b>self</b> contains <b>None</b>!</i>
+        /// </summary>
+        /// <param name="self"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>
+        ///     <b>some</b>
+        /// </returns>
+        public static async Task<T> UnwrapAsync<T>(this Task<Option<T>> self)
+        {
+            return (await self).Unwrap();
+        }
+
+        /// <summary>
+        ///     Unwraps asynchronous <b>self</b> and returns <b>Some</b>.
+        ///     <i>Throws if <b>self</b> contains <b>None</b>!</i>
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="error">
+        ///     A custom error to use as the exception message.
+        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
+        ///     it is recommended to use <see cref="UnwrapAsync{T}(System.Threading.Tasks.Task{Galaxus.Functional.Option{T}})" />,
+        ///     which is lazily evaluated.
+        /// </param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>
+        ///     <b>some</b>
+        /// </returns>
+        public static async Task<T> UnwrapAsync<T>(this Task<Option<T>> self, string error)
+        {
+            return (await self).Unwrap(error: error);
+        }
+
+        /// <summary>
+        ///     Unwraps asynchronous <b>self</b> and returns <b>Ok</b>.
+        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="error"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>
+        ///     <b>some</b>
+        /// </returns>
+        public static async Task<T> UnwrapAsync<T>(this Task<Option<T>> self, Func<string> error)
+        {
+            return (await self).Unwrap(error: error);
+        }
+
+        /// <summary>
+        ///     Unwraps asynchronous <b>self</b> and returns <b>Ok</b>.
+        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="error"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>
+        ///     <b>some</b>
+        /// </returns>
+        public static async Task<T> UnwrapAsync<T>(this Task<Option<T>> self, Func<Task<string>> error)
+        {
+            var res = await self;
+            if (res.IsNone)
+            {
+                if (error is null)
+                    throw new ArgumentNullException(nameof(error));
+
+                throw new AttemptToUnwrapNoneWhenOptionContainedSomeException(await error());
+            }
+
+            return res.Unwrap();
+        }
+
+        /// <summary>
+        ///     Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns
+        ///     <paramref name="fallback" /> otherwise.
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="fallback">
+        ///     The value to return if <b>self</b> is <b>Some</b>.
+        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
+        ///     it is recommended to use
+        ///     <see cref="UnwrapOrElseAsync{T}(System.Threading.Tasks.Task{Galaxus.Functional.Option{T}},System.Func{T})" />,
+        ///     which is lazily evaluated.
+        /// </param>
+        public static async Task<T> UnwrapOrAsync<T>(this Task<Option<T>> self, T fallback)
+        {
+            return (await self).UnwrapOr(fallback: fallback);
+        }
+
+        /// <summary>
+        ///     Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns
+        ///     <paramref name="fallback" /> otherwise.
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="fallback">
+        ///     The value to return if <b>self</b> is <b>Some</b>.
+        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
+        ///     it is recommended to use
+        ///     <see
+        ///         cref="UnwrapOrElseAsync{T}(System.Threading.Tasks.Task{Galaxus.Functional.Option{T}},System.Func{System.Threading.Tasks.Task{T}})" />
+        ///     , which is lazily evaluated.
+        /// </param>
+        public static async Task<T> UnwrapOrAsync<T>(this Task<Option<T>> self, Task<T> fallback)
+        {
+            return (await self).UnwrapOr(await fallback);
+        }
+
+        /// <summary>
+        ///     Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns the result of
+        ///     <paramref name="fallback" /> otherwise.
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="fallback">The function to call if <b>self</b> contains <b>None</b>.</param>
+        public static async Task<T> UnwrapOrElseAsync<T>(this Task<Option<T>> self, Func<T> fallback)
+        {
+            return (await self).UnwrapOrElse(fallback: fallback);
+        }
+
+        /// <summary>
+        ///     Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns the result of
+        ///     <paramref name="fallback" /> otherwise.
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="fallback">The function to call if <b>self</b> contains <b>None</b>.</param>
+        public static async Task<T> UnwrapOrElseAsync<T>(this Task<Option<T>> self, Func<Task<T>> fallback)
+        {
+            var opt = await self;
+            if (opt.IsSome) return opt.Unwrap();
+
+            if (fallback is null)
+                throw new ArgumentNullException(nameof(fallback));
+
+            return await fallback();
+        }
+
+        /// <summary>
+        ///     Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns the default value of
+        ///     <typeparamref name="T" /> otherwise.
+        /// </summary>
+        /// <param name="self"></param>
+        /// <typeparam name="T"></typeparam>
+        public static async Task<T> UnwrapOrDefaultAsync<T>(this Task<Option<T>> self)
+        {
+            return (await self).UnwrapOrDefault();
+        }
+
+        #endregion
     }
 }

--- a/Galaxus.Functional/(Option)/OptionExtensions.cs
+++ b/Galaxus.Functional/(Option)/OptionExtensions.cs
@@ -83,7 +83,7 @@ namespace Galaxus.Functional
         public static IEnumerable<TSelection> SelectSome<T, TSelection>(this IEnumerable<Option<T>> self,
             Func<T, TSelection> selector)
         {
-            return self.SelectSome().Select(selector: selector);
+            return self.SelectSome().Select(selector);
         }
 
         #endregion
@@ -101,7 +101,7 @@ namespace Galaxus.Functional
         /// </returns>
         public static Option<T> Flatten<T>(this Option<Option<T>> option)
         {
-            return option.UnwrapOr(fallback: Option<T>.None);
+            return option.UnwrapOr(Option<T>.None);
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace Galaxus.Functional
         /// </returns>
         public static Option<T> Flatten<T>(this Option<Option<Option<T>>> option)
         {
-            return option.UnwrapOr(fallback: Option<Option<T>>.None).UnwrapOr(fallback: Option<T>.None);
+            return option.UnwrapOr(Option<Option<T>>.None).UnwrapOr(Option<T>.None);
         }
 
         #endregion
@@ -129,7 +129,7 @@ namespace Galaxus.Functional
         /// </summary>
         public static Option<T> ToOption<T>(this T self)
         {
-            return Option<T>.Some(some: self);
+            return Option<T>.Some(self);
         }
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace Galaxus.Functional
         /// <inheritdoc cref="Option{T}.Unwrap(string)"/>
         public static async Task<T> UnwrapAsync<T>(this Task<Option<T>> self, string error)
         {
-            return (await self).Unwrap(error: error);
+            return (await self).Unwrap(error);
         }
 
         /// <summary>
@@ -169,7 +169,7 @@ namespace Galaxus.Functional
         /// <inheritdoc cref="Option{T}.Unwrap(Func{string})"/>
         public static async Task<T> UnwrapAsync<T>(this Task<Option<T>> self, Func<string> error)
         {
-            return (await self).Unwrap(error: error);
+            return (await self).Unwrap(error);
         }
 
         /// <summary>
@@ -198,7 +198,7 @@ namespace Galaxus.Functional
         /// <inheritdoc cref="Option{T}.UnwrapOr"/>
         public static async Task<T> UnwrapOrAsync<T>(this Task<Option<T>> self, T fallback)
         {
-            return (await self).UnwrapOr(fallback: fallback);
+            return (await self).UnwrapOr(fallback);
         }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace Galaxus.Functional
         /// <inheritdoc cref="Option{T}.UnwrapOrElse"/>
         public static async Task<T> UnwrapOrElseAsync<T>(this Task<Option<T>> self, Func<T> fallback)
         {
-            return (await self).UnwrapOrElse(fallback: fallback);
+            return (await self).UnwrapOrElse(fallback);
         }
 
         /// <summary>

--- a/Galaxus.Functional/(Option)/OptionExtensions.cs
+++ b/Galaxus.Functional/(Option)/OptionExtensions.cs
@@ -41,15 +41,19 @@ namespace Galaxus.Functional
 
         /// <summary>
         ///     Transposes an <see cref="Option{T}" /> containing a <see cref="Result{TOk, TErr}" /> into a
-        ///     <see cref="Result{TOk, TErr}" /> containing an <see cref="Option{T}" /> as its <b>Ok</b> value.
-        ///     <b>None</b> will be mapped to <b>Ok(None)</b>.
-        ///     <b>Some(Ok(TOk))</b> will be mapped to <b>Ok(Some(TOk))</b>.
-        ///     <b>Some(Err(TErr))</b> will be mapped to <b>Err(TErr)</b>.
+        ///     <see cref="Result{TOk, TErr}" /> containing an <see cref="Option{T}" /> as its <c>Ok</c> value.
+        ///     <c>None</c> will be mapped to <c>Ok(None)</c>.
+        ///     <c>Some(Ok(TOk))</c> will be mapped to <c>Ok(Some(TOk))</c>.
+        ///     <c>Some(Err(TErr))</c> will be mapped to <c>Err(TErr)</c>.
         /// </summary>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <param name="self"></param>
-        /// <returns></returns>
+        /// <typeparam name="TOk">Ok-type of the resulting <see cref="Result{TOk,TErr}"/></typeparam>
+        /// <typeparam name="TErr">Err-type of the resulting <see cref="Result{TOk,TErr}"/></typeparam>
+        /// <param name="self">The <see cref="Option{T}"/> to transpose.</param>
+        /// <returns>
+        ///     <c>None</c>, if <paramref name="self"/> is <c>Ok(None)</c>.<br/>
+        ///     <c>Some(Ok)</c>, if <paramref name="self"/> is <c>Ok(Some)</c>.<br/>
+        ///     <c>Some(Err)</c>, if <paramref name="self"/> is <c>Err</c>.<br/>
+        /// </returns>
         public static Result<Option<TOk>, TErr> Transpose<TOk, TErr>(this Option<Result<TOk, TErr>> self)
         {
             return self.Match(
@@ -142,64 +146,36 @@ namespace Galaxus.Functional
         #region UnwrapAsync
 
         /// <summary>
-        ///     Unwraps asynchronous <b>self</b> and returns <b>Some</b>.
-        ///     <i>Throws if <b>self</b> contains <b>None</b>!</i>
+        ///     Async overload for <see cref="Option{T}.Unwrap()"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns>
-        ///     <b>some</b>
-        /// </returns>
+        /// <inheritdoc cref="Option{T}.Unwrap()"/>
         public static async Task<T> UnwrapAsync<T>(this Task<Option<T>> self)
         {
             return (await self).Unwrap();
         }
 
         /// <summary>
-        ///     Unwraps asynchronous <b>self</b> and returns <b>Some</b>.
-        ///     <i>Throws if <b>self</b> contains <b>None</b>!</i>
+        ///     Async overload for <see cref="Option{T}.Unwrap(string)"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="error">
-        ///     A custom error to use as the exception message.
-        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
-        ///     it is recommended to use <see cref="UnwrapAsync{T}(System.Threading.Tasks.Task{Galaxus.Functional.Option{T}})" />,
-        ///     which is lazily evaluated.
-        /// </param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns>
-        ///     <b>some</b>
-        /// </returns>
+        /// <inheritdoc cref="Option{T}.Unwrap(string)"/>
         public static async Task<T> UnwrapAsync<T>(this Task<Option<T>> self, string error)
         {
             return (await self).Unwrap(error: error);
         }
 
         /// <summary>
-        ///     Unwraps asynchronous <b>self</b> and returns <b>Ok</b>.
-        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        ///     Async overload for <see cref="Option{T}.Unwrap(Func{string})"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="error"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns>
-        ///     <b>some</b>
-        /// </returns>
+        /// <inheritdoc cref="Option{T}.Unwrap(Func{string})"/>
         public static async Task<T> UnwrapAsync<T>(this Task<Option<T>> self, Func<string> error)
         {
             return (await self).Unwrap(error: error);
         }
 
         /// <summary>
-        ///     Unwraps asynchronous <b>self</b> and returns <b>Ok</b>.
-        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        ///     Async overload for <see cref="Option{T}.Unwrap(string)"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="error"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns>
-        ///     <b>some</b>
-        /// </returns>
+        /// <inheritdoc cref="Option{T}.Unwrap(string)"/>
         public static async Task<T> UnwrapAsync<T>(this Task<Option<T>> self, Func<Task<string>> error)
         {
             var res = await self;
@@ -217,57 +193,36 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///     Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns
-        ///     <paramref name="fallback" /> otherwise.
+        ///     Async overload for <see cref="Option{T}.UnwrapOr"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="fallback">
-        ///     The value to return if <b>self</b> is <b>Some</b>.
-        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
-        ///     it is recommended to use
-        ///     <see cref="UnwrapOrElseAsync{T}(System.Threading.Tasks.Task{Galaxus.Functional.Option{T}},System.Func{T})" />,
-        ///     which is lazily evaluated.
-        /// </param>
+        /// <inheritdoc cref="Option{T}.UnwrapOr"/>
         public static async Task<T> UnwrapOrAsync<T>(this Task<Option<T>> self, T fallback)
         {
             return (await self).UnwrapOr(fallback: fallback);
         }
 
         /// <summary>
-        ///     Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns
-        ///     <paramref name="fallback" /> otherwise.
+        ///     Async overload for <see cref="Option{T}.UnwrapOr"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="fallback">
-        ///     The value to return if <b>self</b> is <b>Some</b>.
-        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
-        ///     it is recommended to use
-        ///     <see
-        ///         cref="UnwrapOrElseAsync{T}(System.Threading.Tasks.Task{Galaxus.Functional.Option{T}},System.Func{System.Threading.Tasks.Task{T}})" />
-        ///     , which is lazily evaluated.
-        /// </param>
+        /// <inheritdoc cref="Option{T}.UnwrapOr"/>
         public static async Task<T> UnwrapOrAsync<T>(this Task<Option<T>> self, Task<T> fallback)
         {
             return (await self).UnwrapOr(await fallback);
         }
 
         /// <summary>
-        ///     Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns the result of
-        ///     <paramref name="fallback" /> otherwise.
+        ///     Async overload for <see cref="Option{T}.UnwrapOrElse"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="fallback">The function to call if <b>self</b> contains <b>None</b>.</param>
+        /// <inheritdoc cref="Option{T}.UnwrapOrElse"/>
         public static async Task<T> UnwrapOrElseAsync<T>(this Task<Option<T>> self, Func<T> fallback)
         {
             return (await self).UnwrapOrElse(fallback: fallback);
         }
 
         /// <summary>
-        ///     Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns the result of
-        ///     <paramref name="fallback" /> otherwise.
+        ///     Async overload for <see cref="Option{T}.UnwrapOrElse"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="fallback">The function to call if <b>self</b> contains <b>None</b>.</param>
+        /// <inheritdoc cref="Option{T}.UnwrapOrElse"/>
         public static async Task<T> UnwrapOrElseAsync<T>(this Task<Option<T>> self, Func<Task<T>> fallback)
         {
             var opt = await self;
@@ -285,11 +240,9 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///     Unwraps <b>self</b> and returns <b>Some</b> if <b>self</b> contains <b>Some</b>. Returns the default value of
-        ///     <typeparamref name="T" /> otherwise.
+        ///     Async overload for <see cref="Option{T}.UnwrapOrDefault"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <typeparam name="T"></typeparam>
+        /// <inheritdoc cref="Option{T}.UnwrapOrDefault"/>
         public static async Task<T> UnwrapOrDefaultAsync<T>(this Task<Option<T>> self)
         {
             return (await self).UnwrapOrDefault();

--- a/Galaxus.Functional/(Option)/OptionExtensions.cs
+++ b/Galaxus.Functional/(Option)/OptionExtensions.cs
@@ -206,7 +206,9 @@ namespace Galaxus.Functional
             if (res.IsNone)
             {
                 if (error is null)
+                {
                     throw new ArgumentNullException(nameof(error));
+                }
 
                 throw new AttemptToUnwrapNoneWhenOptionContainedSomeException(await error());
             }
@@ -269,10 +271,15 @@ namespace Galaxus.Functional
         public static async Task<T> UnwrapOrElseAsync<T>(this Task<Option<T>> self, Func<Task<T>> fallback)
         {
             var opt = await self;
-            if (opt.IsSome) return opt.Unwrap();
+            if (opt.IsSome)
+            {
+                return opt.Unwrap();
+            }
 
             if (fallback is null)
+            {
                 throw new ArgumentNullException(nameof(fallback));
+            }
 
             return await fallback();
         }

--- a/Galaxus.Functional/(Result)/(Features)/Result.AndThen.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.AndThen.cs
@@ -17,7 +17,9 @@ namespace Galaxus.Functional
                 ok =>
                 {
                     if (result is null)
+                    {
                         throw new ArgumentNullException(nameof(result));
+                    }
 
                     return result;
                 },
@@ -42,7 +44,9 @@ namespace Galaxus.Functional
                 ok =>
                 {
                     if (continuation is null)
+                    {
                         throw new ArgumentNullException(nameof(continuation));
+                    }
 
                     return continuation(arg: ok);
                 },

--- a/Galaxus.Functional/(Result)/(Features)/Result.AndThen.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.AndThen.cs
@@ -6,9 +6,10 @@ namespace Galaxus.Functional
     public sealed partial class Result<TOk, TErr>
     {
         /// <summary>
-        /// Returns <paramref name="result"/> if <b>self</b> contains <b>Ok</b>, otherwise returns the <b>Err</b> value contained in <b>self</b>.
+        ///     Returns <paramref name="result" /> if <b>self</b> contains <b>Ok</b>, otherwise returns the <b>Err</b> value
+        ///     contained in <b>self</b>.
         /// </summary>
-        /// <typeparam name="TNewOk">The <b>Ok</b> type of <paramref name="result"/>.</typeparam>
+        /// <typeparam name="TNewOk">The <b>Ok</b> type of <paramref name="result" />.</typeparam>
         /// <param name="result">The result to return if <b>self</b> is <b>Ok</b>.</param>
         public Result<TNewOk, TErr> And<TNewOk>(Result<TNewOk, TErr> result)
         {
@@ -25,12 +26,17 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Calls <paramref name="continuation"/> if <b>self</b> contains <b>Ok</b>, otherwise returns the <b>Err</b> value contained in <b>self</b>.
-        /// This function can be used for control flow based on <see cref="Result{TOk, TErr}"/>s.
+        ///     Calls <paramref name="continuation" /> if <b>self</b> contains <b>Ok</b>, otherwise returns the <b>Err</b> value
+        ///     contained in <b>self</b>.
+        ///     This function can be used for control flow based on <see cref="Result{TOk, TErr}" />s.
         /// </summary>
-        /// <typeparam name="TContinuationOk">The <b>Ok</b> type of the <paramref name="continuation"/>'s <see cref="Result{TOk, TErr}"/>.</typeparam>
+        /// <typeparam name="TContinuationOk">
+        ///     The <b>Ok</b> type of the <paramref name="continuation" />'s
+        ///     <see cref="Result{TOk, TErr}" />.
+        /// </typeparam>
         /// <param name="continuation">The function to call if <b>self</b> contains <b>Ok</b>.</param>
-        public Result<TContinuationOk, TErr> AndThen<TContinuationOk>(Func<TOk, Result<TContinuationOk, TErr>> continuation)
+        public Result<TContinuationOk, TErr> AndThen<TContinuationOk>(
+            Func<TOk, Result<TContinuationOk, TErr>> continuation)
         {
             return Match(
                 ok =>
@@ -38,33 +44,39 @@ namespace Galaxus.Functional
                     if (continuation is null)
                         throw new ArgumentNullException(nameof(continuation));
 
-                    return continuation(ok);
+                    return continuation(arg: ok);
                 },
                 err => err
             );
         }
 
         /// <summary>
-        /// Calls <paramref name="continuation"/> if <b>self</b> contains <b>Ok</b>, otherwise returns the <b>Err</b> value contained in <b>self</b>.
-        /// This function can be used for control flow based on <see cref="Result{TOk, TErr}"/>s.
+        ///     Calls <paramref name="continuation" /> if <b>self</b> contains <b>Ok</b>, otherwise returns the <b>Err</b> value
+        ///     contained in <b>self</b>.
+        ///     This function can be used for control flow based on <see cref="Result{TOk, TErr}" />s.
         /// </summary>
         /// <param name="continuation">The function to call if <b>self</b> is <b>Ok</b>.</param>
         public Result<TOk, TErr> AndThen(Action<TOk> continuation)
         {
-            IfOk(continuation);
+            IfOk(onOk: continuation);
             return this;
         }
 
         /// <summary>
-        /// Calls <paramref name="continuation"/> if <b>self</b> contains <b>Ok</b>, otherwise returns the <b>Err</b> value contained in <b>self</b>.
-        /// This function can be used for control flow based on <see cref="Result{TOk, TErr}"/>s.
+        ///     Calls <paramref name="continuation" /> if <b>self</b> contains <b>Ok</b>, otherwise returns the <b>Err</b> value
+        ///     contained in <b>self</b>.
+        ///     This function can be used for control flow based on <see cref="Result{TOk, TErr}" />s.
         /// </summary>
-        /// <typeparam name="TContinuationOk">The <b>Ok</b> type of the <paramref name="continuation"/>'s <see cref="Result{TOk, TErr}"/>.</typeparam>
+        /// <typeparam name="TContinuationOk">
+        ///     The <b>Ok</b> type of the <paramref name="continuation" />'s
+        ///     <see cref="Result{TOk, TErr}" />.
+        /// </typeparam>
         /// <param name="continuation">The function to call if <b>self</b> contains <b>Ok</b>.</param>
-        public Task<Result<TContinuationOk, TErr>> AndThenAsync<TContinuationOk>(Func<TOk, Task<Result<TContinuationOk, TErr>>> continuation)
+        public Task<Result<TContinuationOk, TErr>> AndThenAsync<TContinuationOk>(
+            Func<TOk, Task<Result<TContinuationOk, TErr>>> continuation)
         {
             return Match(
-                continuation,
+                onOk: continuation,
                 err => Task.FromResult(err.ToErr<TContinuationOk, TErr>()));
         }
     }

--- a/Galaxus.Functional/(Result)/(Features)/Result.AndThen.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.AndThen.cs
@@ -48,7 +48,7 @@ namespace Galaxus.Functional
                         throw new ArgumentNullException(nameof(continuation));
                     }
 
-                    return continuation(arg: ok);
+                    return continuation(ok);
                 },
                 err => err
             );
@@ -62,7 +62,7 @@ namespace Galaxus.Functional
         /// <param name="continuation">The function to call if <b>self</b> is <b>Ok</b>.</param>
         public Result<TOk, TErr> AndThen(Action<TOk> continuation)
         {
-            IfOk(onOk: continuation);
+            IfOk(continuation);
             return this;
         }
 
@@ -80,7 +80,7 @@ namespace Galaxus.Functional
             Func<TOk, Task<Result<TContinuationOk, TErr>>> continuation)
         {
             return Match(
-                onOk: continuation,
+                continuation,
                 err => Task.FromResult(err.ToErr<TContinuationOk, TErr>()));
         }
     }

--- a/Galaxus.Functional/(Result)/(Features)/Result.If.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.If.cs
@@ -6,9 +6,13 @@ namespace Galaxus.Functional
     public sealed partial class Result<TOk, TErr>
     {
         /// <summary>
-        /// Provides access to <b>self</b>'s <b>Ok</b> value by calling <paramref name="onOk"/> if <b>self</b> contains <b>Ok</b>.
+        ///     Provides access to <b>self</b>'s <b>Ok</b> value by calling <paramref name="onOk" /> if <b>self</b> contains
+        ///     <b>Ok</b>.
         /// </summary>
-        /// <param name="onOk">Called when <b>self</b> contains <b>Ok</b>. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onOk">
+        ///     Called when <b>self</b> contains <b>Ok</b>. The argument to this action is never the <b>null</b>
+        ///     reference.
+        /// </param>
         public void IfOk(Action<TOk> onOk)
         {
             if (IsOk)
@@ -16,14 +20,18 @@ namespace Galaxus.Functional
                 if (onOk is null)
                     throw new ArgumentNullException(nameof(onOk));
 
-                onOk(_ok);
+                onOk(obj: _ok);
             }
         }
 
         /// <summary>
-        /// Provides access to <b>self</b>'s <b>Ok</b> value by calling <paramref name="onOk"/> if <b>self</b> contains <b>Ok</b>.
+        ///     Provides access to <b>self</b>'s <b>Ok</b> value by calling <paramref name="onOk" /> if <b>self</b> contains
+        ///     <b>Ok</b>.
         /// </summary>
-        /// <param name="onOk">Called when <b>self</b> contains <b>Ok</b>. The argument to this function is never the <b>null</b> reference.</param>
+        /// <param name="onOk">
+        ///     Called when <b>self</b> contains <b>Ok</b>. The argument to this function is never the <b>null</b>
+        ///     reference.
+        /// </param>
         public Task IfOkAsync(Func<TOk, Task> onOk)
         {
             if (IsOk)
@@ -31,16 +39,20 @@ namespace Galaxus.Functional
                 if (onOk is null)
                     throw new ArgumentNullException(nameof(onOk));
 
-                return onOk(_ok);
+                return onOk(arg: _ok);
             }
 
             return Task.CompletedTask;
         }
 
         /// <summary>
-        /// Provides access to <b>self</b>'s <b>Err</b> value by calling <paramref name="onErr"/> if <b>self</b> contains <b>Err</b>.
+        ///     Provides access to <b>self</b>'s <b>Err</b> value by calling <paramref name="onErr" /> if <b>self</b> contains
+        ///     <b>Err</b>.
         /// </summary>
-        /// <param name="onErr">Called when <b>self</b> contains <b>Err</b>. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onErr">
+        ///     Called when <b>self</b> contains <b>Err</b>. The argument to this action is never the <b>null</b>
+        ///     reference.
+        /// </param>
         public void IfErr(Action<TErr> onErr)
         {
             if (IsErr)
@@ -48,14 +60,18 @@ namespace Galaxus.Functional
                 if (onErr is null)
                     throw new ArgumentNullException(nameof(onErr));
 
-                onErr(_err);
+                onErr(obj: _err);
             }
         }
 
         /// <summary>
-        /// Provides access to <b>self</b>'s <b>Err</b> value by calling <paramref name="onErr"/> if <b>self</b> contains <b>Err</b>.
+        ///     Provides access to <b>self</b>'s <b>Err</b> value by calling <paramref name="onErr" /> if <b>self</b> contains
+        ///     <b>Err</b>.
         /// </summary>
-        /// <param name="onErr">Called when <b>self</b> contains <b>Err</b>. The argument to this function is never the <b>null</b> reference.</param>
+        /// <param name="onErr">
+        ///     Called when <b>self</b> contains <b>Err</b>. The argument to this function is never the <b>null</b>
+        ///     reference.
+        /// </param>
         public Task IfErrAsync(Func<TErr, Task> onErr)
         {
             if (IsErr)
@@ -63,7 +79,7 @@ namespace Galaxus.Functional
                 if (onErr is null)
                     throw new ArgumentNullException(nameof(onErr));
 
-                return onErr(_err);
+                return onErr(arg: _err);
             }
 
             return Task.CompletedTask;

--- a/Galaxus.Functional/(Result)/(Features)/Result.If.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.If.cs
@@ -22,7 +22,7 @@ namespace Galaxus.Functional
                     throw new ArgumentNullException(nameof(onOk));
                 }
 
-                onOk(obj: _ok);
+                onOk(_ok);
             }
         }
 
@@ -43,7 +43,7 @@ namespace Galaxus.Functional
                     throw new ArgumentNullException(nameof(onOk));
                 }
 
-                return onOk(arg: _ok);
+                return onOk(_ok);
             }
 
             return Task.CompletedTask;
@@ -66,7 +66,7 @@ namespace Galaxus.Functional
                     throw new ArgumentNullException(nameof(onErr));
                 }
 
-                onErr(obj: _err);
+                onErr(_err);
             }
         }
 
@@ -87,7 +87,7 @@ namespace Galaxus.Functional
                     throw new ArgumentNullException(nameof(onErr));
                 }
 
-                return onErr(arg: _err);
+                return onErr(_err);
             }
 
             return Task.CompletedTask;

--- a/Galaxus.Functional/(Result)/(Features)/Result.If.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.If.cs
@@ -18,7 +18,9 @@ namespace Galaxus.Functional
             if (IsOk)
             {
                 if (onOk is null)
+                {
                     throw new ArgumentNullException(nameof(onOk));
+                }
 
                 onOk(obj: _ok);
             }
@@ -37,7 +39,9 @@ namespace Galaxus.Functional
             if (IsOk)
             {
                 if (onOk is null)
+                {
                     throw new ArgumentNullException(nameof(onOk));
+                }
 
                 return onOk(arg: _ok);
             }
@@ -58,7 +62,9 @@ namespace Galaxus.Functional
             if (IsErr)
             {
                 if (onErr is null)
+                {
                     throw new ArgumentNullException(nameof(onErr));
+                }
 
                 onErr(obj: _err);
             }
@@ -77,7 +83,9 @@ namespace Galaxus.Functional
             if (IsErr)
             {
                 if (onErr is null)
+                {
                     throw new ArgumentNullException(nameof(onErr));
+                }
 
                 return onErr(arg: _err);
             }

--- a/Galaxus.Functional/(Result)/(Features)/Result.Map.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.Map.cs
@@ -29,12 +29,9 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///     Maps a <see cref="Result{TOk, TErr}" /> to <see cref="Result{TOkTo, TErr}" /> by applying a function to a contained
-        ///     <b>Ok</b> value,
-        ///     leaving an <b>Err</b> value untouched. This function can be used to compose the results of two functions.
+        ///     Async overload for <see cref="Map{TOkTo}"/>
         /// </summary>
-        /// <typeparam name="TOkTo">The type to map <b>Ok</b> to.</typeparam>
-        /// <param name="continuation">The mapping function.</param>
+        /// <inheritdoc cref="Map{TOkTo}"/>
         public Task<Result<TOkTo, TErr>> MapAsync<TOkTo>(Func<TOk, Task<TOkTo>> continuation)
         {
             return MatchAsync(
@@ -65,13 +62,11 @@ namespace Galaxus.Functional
             );
         }
 
+
         /// <summary>
-        ///     Maps a <see cref="Result{TOk, TErr}" /> to <see cref="Result{TOk, TErrTo}" /> by applying a function to a contained
-        ///     <b>Err</b> value,
-        ///     leaving an <b>Ok</b> value untouched. This function can be used to compose the results of two functions.
+        ///     Async overload for <see cref="MapErr{TErrTo}"/>
         /// </summary>
-        /// <typeparam name="TErrTo">The type to map "Err" to.</typeparam>
-        /// <param name="continuation">The mapping function.</param>
+        /// <inheritdoc cref="MapErr{TErrTo}"/>
         public Task<Result<TOk, TErrTo>> MapErrAsync<TErrTo>(Func<TErr, Task<TErrTo>> continuation)
         {
             return MatchAsync(

--- a/Galaxus.Functional/(Result)/(Features)/Result.Map.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.Map.cs
@@ -22,7 +22,7 @@ namespace Galaxus.Functional
                         throw new ArgumentNullException(nameof(map));
                     }
 
-                    return map(arg: ok);
+                    return map(ok);
                 },
                 err => err.ToErr<TOkTo, TErr>()
             );
@@ -35,7 +35,7 @@ namespace Galaxus.Functional
         public Task<Result<TOkTo, TErr>> MapAsync<TOkTo>(Func<TOk, Task<TOkTo>> continuation)
         {
             return MatchAsync(
-                async ok => new Result<TOkTo, TErr>(await continuation(arg: ok)),
+                async ok => new Result<TOkTo, TErr>(await continuation(ok)),
                 err => err.ToErr<TOkTo, TErr>());
         }
 
@@ -57,7 +57,7 @@ namespace Galaxus.Functional
                         throw new ArgumentNullException(nameof(map));
                     }
 
-                    return map(arg: err);
+                    return map(err);
                 }
             );
         }
@@ -71,7 +71,7 @@ namespace Galaxus.Functional
         {
             return MatchAsync(
                 ok => ok.ToOk<TOk, TErrTo>(),
-                async err => new Result<TOk, TErrTo>(await continuation(arg: err)));
+                async err => new Result<TOk, TErrTo>(await continuation(err)));
         }
     }
 }

--- a/Galaxus.Functional/(Result)/(Features)/Result.Map.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.Map.cs
@@ -6,8 +6,9 @@ namespace Galaxus.Functional
     public sealed partial class Result<TOk, TErr>
     {
         /// <summary>
-        /// Maps a <see cref="Result{TOk, TErr}"/> to <see cref="Result{TOkTo, TErr}"/> by applying a function to a contained <b>Ok</b> value,
-        /// leaving an <b>Err</b> value untouched. This function can be used to compose the results of two functions.
+        ///     Maps a <see cref="Result{TOk, TErr}" /> to <see cref="Result{TOkTo, TErr}" /> by applying a function to a contained
+        ///     <b>Ok</b> value,
+        ///     leaving an <b>Err</b> value untouched. This function can be used to compose the results of two functions.
         /// </summary>
         /// <typeparam name="TOkTo">The type to map <b>Ok</b> to.</typeparam>
         /// <param name="map">The mapping function.</param>
@@ -19,28 +20,30 @@ namespace Galaxus.Functional
                     if (map == null)
                         throw new ArgumentNullException(nameof(map));
 
-                    return map(ok);
+                    return map(arg: ok);
                 },
                 err => err.ToErr<TOkTo, TErr>()
             );
         }
 
         /// <summary>
-        /// Maps a <see cref="Result{TOk, TErr}"/> to <see cref="Result{TOkTo, TErr}"/> by applying a function to a contained <b>Ok</b> value,
-        /// leaving an <b>Err</b> value untouched. This function can be used to compose the results of two functions.
+        ///     Maps a <see cref="Result{TOk, TErr}" /> to <see cref="Result{TOkTo, TErr}" /> by applying a function to a contained
+        ///     <b>Ok</b> value,
+        ///     leaving an <b>Err</b> value untouched. This function can be used to compose the results of two functions.
         /// </summary>
         /// <typeparam name="TOkTo">The type to map <b>Ok</b> to.</typeparam>
         /// <param name="continuation">The mapping function.</param>
         public Task<Result<TOkTo, TErr>> MapAsync<TOkTo>(Func<TOk, Task<TOkTo>> continuation)
         {
             return MatchAsync(
-                async ok => new Result<TOkTo, TErr>(await continuation(ok)),
+                async ok => new Result<TOkTo, TErr>(await continuation(arg: ok)),
                 err => err.ToErr<TOkTo, TErr>());
         }
 
         /// <summary>
-        /// Maps a <see cref="Result{TOk, TErr}"/> to <see cref="Result{TOk, TErrTo}"/> by applying a function to a contained <b>Err</b> value,
-        /// leaving an <b>Ok</b> value untouched. This function can be used to compose the results of two functions.
+        ///     Maps a <see cref="Result{TOk, TErr}" /> to <see cref="Result{TOk, TErrTo}" /> by applying a function to a contained
+        ///     <b>Err</b> value,
+        ///     leaving an <b>Ok</b> value untouched. This function can be used to compose the results of two functions.
         /// </summary>
         /// <typeparam name="TErrTo">The type to map "Err" to.</typeparam>
         /// <param name="map">The mapping function.</param>
@@ -53,14 +56,15 @@ namespace Galaxus.Functional
                     if (map == null)
                         throw new ArgumentNullException(nameof(map));
 
-                    return map(err);
+                    return map(arg: err);
                 }
             );
         }
 
         /// <summary>
-        /// Maps a <see cref="Result{TOk, TErr}"/> to <see cref="Result{TOk, TErrTo}"/> by applying a function to a contained <b>Err</b> value,
-        /// leaving an <b>Ok</b> value untouched. This function can be used to compose the results of two functions.
+        ///     Maps a <see cref="Result{TOk, TErr}" /> to <see cref="Result{TOk, TErrTo}" /> by applying a function to a contained
+        ///     <b>Err</b> value,
+        ///     leaving an <b>Ok</b> value untouched. This function can be used to compose the results of two functions.
         /// </summary>
         /// <typeparam name="TErrTo">The type to map "Err" to.</typeparam>
         /// <param name="continuation">The mapping function.</param>
@@ -68,7 +72,7 @@ namespace Galaxus.Functional
         {
             return MatchAsync(
                 ok => ok.ToOk<TOk, TErrTo>(),
-                async err => new Result<TOk, TErrTo>(await continuation(err)));
+                async err => new Result<TOk, TErrTo>(await continuation(arg: err)));
         }
     }
 }

--- a/Galaxus.Functional/(Result)/(Features)/Result.Map.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.Map.cs
@@ -18,7 +18,9 @@ namespace Galaxus.Functional
                 ok =>
                 {
                     if (map == null)
+                    {
                         throw new ArgumentNullException(nameof(map));
+                    }
 
                     return map(arg: ok);
                 },
@@ -54,7 +56,9 @@ namespace Galaxus.Functional
                 err =>
                 {
                     if (map == null)
+                    {
                         throw new ArgumentNullException(nameof(map));
+                    }
 
                     return map(arg: err);
                 }

--- a/Galaxus.Functional/(Result)/(Features)/Result.Match.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.Match.cs
@@ -26,7 +26,7 @@ namespace Galaxus.Functional
                     throw new ArgumentNullException(nameof(onOk));
                 }
 
-                onOk(obj: _ok);
+                onOk(_ok);
             }
             else
             {
@@ -35,7 +35,7 @@ namespace Galaxus.Functional
                     throw new ArgumentNullException(nameof(onErr));
                 }
 
-                onErr(obj: _err);
+                onErr(_err);
             }
         }
 
@@ -60,7 +60,7 @@ namespace Galaxus.Functional
                     throw new ArgumentNullException(nameof(onOk));
                 }
 
-                return onOk(arg: _ok);
+                return onOk(_ok);
             }
 
             if (onErr is null)
@@ -68,7 +68,7 @@ namespace Galaxus.Functional
                 throw new ArgumentNullException(nameof(onErr));
             }
 
-            return onErr(arg: _err);
+            return onErr(_err);
         }
 
         /// <summary>
@@ -78,8 +78,8 @@ namespace Galaxus.Functional
         public async Task<TResult> MatchAsync<TResult>(Func<TOk, Task<TResult>> onOk, Func<TErr, Task<TResult>> onErr)
         {
             return await Match(
-                async ok => await onOk(arg: ok),
-                async err => await onErr(arg: err));
+                async ok => await onOk(ok),
+                async err => await onErr(err));
         }
 
         /// <summary>
@@ -89,8 +89,8 @@ namespace Galaxus.Functional
         public async Task<TResult> MatchAsync<TResult>(Func<TOk, Task<TResult>> onOk, Func<TErr, TResult> onErr)
         {
             return await Match(
-                async ok => await onOk(arg: ok),
-                err => Task.FromResult(onErr(arg: err)));
+                async ok => await onOk(ok),
+                err => Task.FromResult(onErr(err)));
         }
 
         /// <summary>
@@ -100,8 +100,8 @@ namespace Galaxus.Functional
         public async Task<TResult> MatchAsync<TResult>(Func<TOk, TResult> onOk, Func<TErr, Task<TResult>> onErr)
         {
             return await Match(
-                ok => Task.FromResult(onOk(arg: ok)),
-                async err => await onErr(arg: err));
+                ok => Task.FromResult(onOk(ok)),
+                async err => await onErr(err));
         }
     }
 }

--- a/Galaxus.Functional/(Result)/(Features)/Result.Match.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.Match.cs
@@ -22,14 +22,18 @@ namespace Galaxus.Functional
             if (IsOk)
             {
                 if (onOk is null)
+                {
                     throw new ArgumentNullException(nameof(onOk));
+                }
 
                 onOk(obj: _ok);
             }
             else
             {
                 if (onErr is null)
+                {
                     throw new ArgumentNullException(nameof(onErr));
+                }
 
                 onErr(obj: _err);
             }
@@ -52,13 +56,17 @@ namespace Galaxus.Functional
             if (IsOk)
             {
                 if (onOk is null)
+                {
                     throw new ArgumentNullException(nameof(onOk));
+                }
 
                 return onOk(arg: _ok);
             }
 
             if (onErr is null)
+            {
                 throw new ArgumentNullException(nameof(onErr));
+            }
 
             return onErr(arg: _err);
         }

--- a/Galaxus.Functional/(Result)/(Features)/Result.Match.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.Match.cs
@@ -6,11 +6,17 @@ namespace Galaxus.Functional
     public sealed partial class Result<TOk, TErr>
     {
         /// <summary>
-        /// Provides access to <b>self</b>'s content by calling <paramref name="onOk"/> and passing in <b>Ok</b>
-        /// or calling <paramref name="onErr"/> and passing in <b>Err</b>.
+        ///     Provides access to <b>self</b>'s content by calling <paramref name="onOk" /> and passing in <b>Ok</b>
+        ///     or calling <paramref name="onErr" /> and passing in <b>Err</b>.
         /// </summary>
-        /// <param name="onOk">Called when <b>self</b> contains <b>Ok</b>. The argument to this action is never the <b>null</b> reference.</param>
-        /// <param name="onErr">Called when <b>self</b> contains <b>Err</b>. The argument to this action is never the <b>null</b> reference.</param>
+        /// <param name="onOk">
+        ///     Called when <b>self</b> contains <b>Ok</b>. The argument to this action is never the <b>null</b>
+        ///     reference.
+        /// </param>
+        /// <param name="onErr">
+        ///     Called when <b>self</b> contains <b>Err</b>. The argument to this action is never the <b>null</b>
+        ///     reference.
+        /// </param>
         public void Match(Action<TOk> onOk, Action<TErr> onErr)
         {
             if (IsOk)
@@ -18,23 +24,29 @@ namespace Galaxus.Functional
                 if (onOk is null)
                     throw new ArgumentNullException(nameof(onOk));
 
-                onOk(_ok);
+                onOk(obj: _ok);
             }
             else
             {
                 if (onErr is null)
                     throw new ArgumentNullException(nameof(onErr));
 
-                onErr(_err);
+                onErr(obj: _err);
             }
         }
 
         /// <summary>
-        /// Provides access to <b>self</b>'s content by calling <paramref name="onOk"/> and passing in <b>Ok</b>
-        /// or calling <paramref name="onErr"/> and passing in <b>Err</b>.
+        ///     Provides access to <b>self</b>'s content by calling <paramref name="onOk" /> and passing in <b>Ok</b>
+        ///     or calling <paramref name="onErr" /> and passing in <b>Err</b>.
         /// </summary>
-        /// <param name="onOk">Called when <b>self</b> contains <b>Ok</b>. The argument to this function is never the <b>null</b> reference.</param>
-        /// <param name="onErr">Called when <b>self</b> contains <b>Err</b>. The argument to this function is never the <b>null</b> reference.</param>
+        /// <param name="onOk">
+        ///     Called when <b>self</b> contains <b>Ok</b>. The argument to this function is never the <b>null</b>
+        ///     reference.
+        /// </param>
+        /// <param name="onErr">
+        ///     Called when <b>self</b> contains <b>Err</b>. The argument to this function is never the <b>null</b>
+        ///     reference.
+        /// </param>
         public T Match<T>(Func<TOk, T> onOk, Func<TErr, T> onErr)
         {
             if (IsOk)
@@ -42,55 +54,55 @@ namespace Galaxus.Functional
                 if (onOk is null)
                     throw new ArgumentNullException(nameof(onOk));
 
-                return onOk(_ok);
+                return onOk(arg: _ok);
             }
 
             if (onErr is null)
                 throw new ArgumentNullException(nameof(onErr));
 
-            return onErr(_err);
+            return onErr(arg: _err);
         }
 
         /// <summary>
-        /// An overload for <see cref="Match"/> using async functions.
+        ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
         /// <param name="onOk">The async function to be called on an <b>Ok</b>.</param>
         /// <param name="onErr">The async function to be called on an <b>Ok</b>.</param>
-        /// <typeparam name="TResult">The resulting <see cref="Result{TOk,TErr}"/> type.</typeparam>
+        /// <typeparam name="TResult">The resulting <see cref="Result{TOk,TErr}" /> type.</typeparam>
         /// <returns></returns>
         public async Task<TResult> MatchAsync<TResult>(Func<TOk, Task<TResult>> onOk, Func<TErr, Task<TResult>> onErr)
         {
             return await Match(
-                async ok => await onOk(ok),
-                async err => await onErr(err));
+                async ok => await onOk(arg: ok),
+                async err => await onErr(arg: err));
         }
 
         /// <summary>
-        /// An overload for <see cref="Match"/> using async functions.
+        ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
         /// <param name="onOk">The async function to be called on an <b>Ok</b>.</param>
         /// <param name="onErr">The non-async function to be called on an <b>Ok</b>.</param>
-        /// <typeparam name="TResult">The resulting <see cref="Result{TOk,TErr}"/> type.</typeparam>
+        /// <typeparam name="TResult">The resulting <see cref="Result{TOk,TErr}" /> type.</typeparam>
         /// <returns></returns>
         public async Task<TResult> MatchAsync<TResult>(Func<TOk, Task<TResult>> onOk, Func<TErr, TResult> onErr)
         {
             return await Match(
-                async ok => await onOk(ok),
-                err => Task.FromResult(onErr(err)));
+                async ok => await onOk(arg: ok),
+                err => Task.FromResult(onErr(arg: err)));
         }
 
         /// <summary>
-        /// An overload for <see cref="Match"/> using async functions.
+        ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
         /// <param name="onOk">The non-async function to be called on an <b>Ok</b>.</param>
         /// <param name="onErr">The async function to be called on an <b>Ok</b>.</param>
-        /// <typeparam name="TResult">The resulting <see cref="Result{TOk,TErr}"/> type.</typeparam>
+        /// <typeparam name="TResult">The resulting <see cref="Result{TOk,TErr}" /> type.</typeparam>
         /// <returns></returns>
         public async Task<TResult> MatchAsync<TResult>(Func<TOk, TResult> onOk, Func<TErr, Task<TResult>> onErr)
         {
             return await Match(
-                ok => Task.FromResult(onOk(ok)),
-                async err => await onErr(err));
+                ok => Task.FromResult(onOk(arg: ok)),
+                async err => await onErr(arg: err));
         }
     }
 }

--- a/Galaxus.Functional/(Result)/(Features)/Result.Match.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.Match.cs
@@ -74,10 +74,7 @@ namespace Galaxus.Functional
         /// <summary>
         ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
-        /// <param name="onOk">The async function to be called on an <b>Ok</b>.</param>
-        /// <param name="onErr">The async function to be called on an <b>Ok</b>.</param>
-        /// <typeparam name="TResult">The resulting <see cref="Result{TOk,TErr}" /> type.</typeparam>
-        /// <returns></returns>
+        /// <inheritdoc cref="Result{TOk,TErr}.Match{TResult}"/>
         public async Task<TResult> MatchAsync<TResult>(Func<TOk, Task<TResult>> onOk, Func<TErr, Task<TResult>> onErr)
         {
             return await Match(
@@ -88,10 +85,7 @@ namespace Galaxus.Functional
         /// <summary>
         ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
-        /// <param name="onOk">The async function to be called on an <b>Ok</b>.</param>
-        /// <param name="onErr">The non-async function to be called on an <b>Ok</b>.</param>
-        /// <typeparam name="TResult">The resulting <see cref="Result{TOk,TErr}" /> type.</typeparam>
-        /// <returns></returns>
+        /// <inheritdoc cref="Result{TOk,TErr}.Match{TResult}"/>
         public async Task<TResult> MatchAsync<TResult>(Func<TOk, Task<TResult>> onOk, Func<TErr, TResult> onErr)
         {
             return await Match(
@@ -102,10 +96,7 @@ namespace Galaxus.Functional
         /// <summary>
         ///     An overload for <see cref="Match" /> using async functions.
         /// </summary>
-        /// <param name="onOk">The non-async function to be called on an <b>Ok</b>.</param>
-        /// <param name="onErr">The async function to be called on an <b>Ok</b>.</param>
-        /// <typeparam name="TResult">The resulting <see cref="Result{TOk,TErr}" /> type.</typeparam>
-        /// <returns></returns>
+        /// <inheritdoc cref="Result{TOk,TErr}.Match{TResult}"/>
         public async Task<TResult> MatchAsync<TResult>(Func<TOk, TResult> onOk, Func<TErr, Task<TResult>> onErr)
         {
             return await Match(

--- a/Galaxus.Functional/(Result)/(Features)/Result.OrElse.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.OrElse.cs
@@ -38,7 +38,7 @@ namespace Galaxus.Functional
                 throw new ArgumentNullException(nameof(continuation));
             }
 
-            return continuation(arg: _err);
+            return continuation(_err);
         }
 
 
@@ -65,7 +65,7 @@ namespace Galaxus.Functional
                 throw new ArgumentNullException(nameof(continuation));
             }
 
-            return continuation(arg: _err);
+            return continuation(_err);
         }
     }
 }

--- a/Galaxus.Functional/(Result)/(Features)/Result.OrElse.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.OrElse.cs
@@ -6,22 +6,27 @@ namespace Galaxus.Functional
     public sealed partial class Result<TOk, TErr>
     {
         /// <summary>
-        /// Returns <paramref name="fallback"/> if <b>self</b> contains <b>Err</b>, otherwise returns the <b>Ok</b> value contained in <b>self</b>.
+        ///     Returns <paramref name="fallback" /> if <b>self</b> contains <b>Err</b>, otherwise returns the <b>Ok</b> value
+        ///     contained in <b>self</b>.
         /// </summary>
         /// <param name="fallback">
-        /// The result to return if <b>self</b> contains <b>Err</b>.
-        /// This argument is eagerly evaluated; if you are passing the result of a function call,
-        /// it is recommended to use <see cref="OrElse{TContinuationErr}"/>, which is lazily evaluated.
+        ///     The result to return if <b>self</b> contains <b>Err</b>.
+        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
+        ///     it is recommended to use <see cref="OrElse{TContinuationErr}" />, which is lazily evaluated.
         /// </param>
         public Result<TOk, TContinuationErr> Or<TContinuationErr>(Result<TOk, TContinuationErr> fallback)
-            => IsOk ? _ok : fallback;
+        {
+            return IsOk ? _ok : fallback;
+        }
 
         /// <summary>
-        /// Calls <paramref name="continuation"/> if <b>self</b> contains <b>Err</b>, otherwise returns the <b>Ok</b> value contained in <b>self</b>.
-        /// This function can be used for control flow based on <see cref="Result{TOk, TErr}"/>s.
+        ///     Calls <paramref name="continuation" /> if <b>self</b> contains <b>Err</b>, otherwise returns the <b>Ok</b> value
+        ///     contained in <b>self</b>.
+        ///     This function can be used for control flow based on <see cref="Result{TOk, TErr}" />s.
         /// </summary>
         /// <param name="continuation">The function to call if <b>self</b> contains <b>Err</b>.</param>
-        public Result<TOk, TContinuationErr> OrElse<TContinuationErr>(Func<TErr, Result<TOk, TContinuationErr>> continuation)
+        public Result<TOk, TContinuationErr> OrElse<TContinuationErr>(
+            Func<TErr, Result<TOk, TContinuationErr>> continuation)
         {
             if (IsOk)
                 return _ok;
@@ -29,17 +34,22 @@ namespace Galaxus.Functional
             if (continuation is null)
                 throw new ArgumentNullException(nameof(continuation));
 
-            return continuation(_err);
+            return continuation(arg: _err);
         }
 
 
         /// <summary>
-        /// Calls <paramref name="continuation"/> if <b>self</b> contains <b>Err</b>, otherwise returns the <b>Ok</b> value contained in <b>self</b>.
-        /// This function can be used for control flow based on <see cref="Result{TOk, TErr}"/>s.
+        ///     Calls <paramref name="continuation" /> if <b>self</b> contains <b>Err</b>, otherwise returns the <b>Ok</b> value
+        ///     contained in <b>self</b>.
+        ///     This function can be used for control flow based on <see cref="Result{TOk, TErr}" />s.
         /// </summary>
-        /// <typeparam name="TContinuationErr">The <b>Error</b> type of the <paramref name="continuation"/>'s <see cref="Result{TOk, TErr}"/>.</typeparam>
+        /// <typeparam name="TContinuationErr">
+        ///     The <b>Error</b> type of the <paramref name="continuation" />'s
+        ///     <see cref="Result{TOk, TErr}" />.
+        /// </typeparam>
         /// <param name="continuation">The function to call if <b>self</b> contains <b>Err</b>.</param>
-        public Task<Result<TOk, TContinuationErr>> OrElseAsync<TContinuationErr>(Func<TErr, Task<Result<TOk, TContinuationErr>>> continuation)
+        public Task<Result<TOk, TContinuationErr>> OrElseAsync<TContinuationErr>(
+            Func<TErr, Task<Result<TOk, TContinuationErr>>> continuation)
         {
             if (IsOk)
                 return Task.FromResult(_ok.ToOk<TOk, TContinuationErr>());
@@ -47,7 +57,7 @@ namespace Galaxus.Functional
             if (continuation is null)
                 throw new ArgumentNullException(nameof(continuation));
 
-            return continuation(_err);
+            return continuation(arg: _err);
         }
     }
 }

--- a/Galaxus.Functional/(Result)/(Features)/Result.OrElse.cs
+++ b/Galaxus.Functional/(Result)/(Features)/Result.OrElse.cs
@@ -29,10 +29,14 @@ namespace Galaxus.Functional
             Func<TErr, Result<TOk, TContinuationErr>> continuation)
         {
             if (IsOk)
+            {
                 return _ok;
+            }
 
             if (continuation is null)
+            {
                 throw new ArgumentNullException(nameof(continuation));
+            }
 
             return continuation(arg: _err);
         }
@@ -52,10 +56,14 @@ namespace Galaxus.Functional
             Func<TErr, Task<Result<TOk, TContinuationErr>>> continuation)
         {
             if (IsOk)
+            {
                 return Task.FromResult(_ok.ToOk<TOk, TContinuationErr>());
+            }
 
             if (continuation is null)
+            {
                 throw new ArgumentNullException(nameof(continuation));
+            }
 
             return continuation(arg: _err);
         }

--- a/Galaxus.Functional/(Result)/AttemptToUnwrapErrWhenResultWasOkException.cs
+++ b/Galaxus.Functional/(Result)/AttemptToUnwrapErrWhenResultWasOkException.cs
@@ -3,15 +3,15 @@ using System;
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// Thrown when an attempt was made to unwrap a <see cref="Result{TOk, TErr}"/> containing <b>Err</b>.
+    ///     Thrown when an attempt was made to unwrap a <see cref="Result{TOk, TErr}" /> containing <b>Err</b>.
     /// </summary>
     public class AttemptToUnwrapErrWhenResultWasOkException : Exception
     {
         /// <summary>
-        /// Create an <see cref="AttemptToUnwrapErrWhenResultWasOkException"/> object.
+        ///     Create an <see cref="AttemptToUnwrapErrWhenResultWasOkException" /> object.
         /// </summary>
         /// <param name="message">The message for the exception.</param>
-        public AttemptToUnwrapErrWhenResultWasOkException(string message) : base(message)
+        public AttemptToUnwrapErrWhenResultWasOkException(string message) : base(message: message)
         {
         }
     }

--- a/Galaxus.Functional/(Result)/AttemptToUnwrapErrWhenResultWasOkException.cs
+++ b/Galaxus.Functional/(Result)/AttemptToUnwrapErrWhenResultWasOkException.cs
@@ -11,7 +11,7 @@ namespace Galaxus.Functional
         ///     Create an <see cref="AttemptToUnwrapErrWhenResultWasOkException" /> object.
         /// </summary>
         /// <param name="message">The message for the exception.</param>
-        public AttemptToUnwrapErrWhenResultWasOkException(string message) : base(message: message)
+        public AttemptToUnwrapErrWhenResultWasOkException(string message) : base(message)
         {
         }
     }

--- a/Galaxus.Functional/(Result)/IError.cs
+++ b/Galaxus.Functional/(Result)/IError.cs
@@ -1,17 +1,18 @@
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// <see cref="IError"/> is an interface representing the basic expectations for error values, i.e., values of type <b>TErr</b> in <see cref="Result{TOk, TErr}"/>.
+    ///     <see cref="IError" /> is an interface representing the basic expectations for error values, i.e., values of type
+    ///     <b>TErr</b> in <see cref="Result{TOk, TErr}" />.
     /// </summary>
     public interface IError
     {
         /// <summary>
-        /// A description of the error.
+        ///     A description of the error.
         /// </summary>
         string Description { get; }
 
         /// <summary>
-        /// The lower-level cause of this error, if any.
+        ///     The lower-level cause of this error, if any.
         /// </summary>
         Option<IError> Cause { get; }
     }

--- a/Galaxus.Functional/(Result)/Result.cs
+++ b/Galaxus.Functional/(Result)/Result.cs
@@ -19,7 +19,7 @@ namespace Galaxus.Functional
         /// <param name="ok">The <b>Ok</b> value.</param>
         public static Result<TOk, TErr> FromOk(TOk ok)
         {
-            return new Result<TOk, TErr>(ok: ok);
+            return new Result<TOk, TErr>(ok);
         }
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Galaxus.Functional
         /// <param name="err">The <b>Err</b> value.</param>
         public static Result<TOk, TErr> FromErr(TErr err)
         {
-            return new Result<TOk, TErr>(err: err);
+            return new Result<TOk, TErr>(err);
         }
 
         // Note:
@@ -68,7 +68,7 @@ namespace Galaxus.Functional
         /// <returns>The result.</returns>
         public static implicit operator Result<TOk, TErr>(TOk ok)
         {
-            return new Result<TOk, TErr>(ok: ok);
+            return new Result<TOk, TErr>(ok);
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Galaxus.Functional
         /// <returns>The result.</returns>
         public static implicit operator Result<TOk, TErr>(TErr err)
         {
-            return new Result<TOk, TErr>(err: err);
+            return new Result<TOk, TErr>(err);
         }
 
         #endregion
@@ -128,11 +128,11 @@ namespace Galaxus.Functional
                     case IError error:
                         return error.Description;
                     case IEnumerable<IError> errors:
-                        return string.Join("; ", values: errors);
+                        return string.Join("; ", errors);
                     case string str:
                         return str;
                     case IEnumerable<string> strs:
-                        return string.Join("; ", values: strs);
+                        return string.Join("; ", strs);
                     default:
                         return $"Cannot unwrap \"Ok\" when the result is \"Err\": {_err.ToString()}.";
                 }
@@ -152,7 +152,7 @@ namespace Galaxus.Functional
         {
             if (IsErr)
             {
-                throw new AttemptToUnwrapErrWhenResultWasOkException(message: error);
+                throw new AttemptToUnwrapErrWhenResultWasOkException(error);
             }
 
             return _ok;
@@ -172,7 +172,7 @@ namespace Galaxus.Functional
                     throw new ArgumentNullException(nameof(error));
                 }
 
-                throw new AttemptToUnwrapErrWhenResultWasOkException(error(arg: _err));
+                throw new AttemptToUnwrapErrWhenResultWasOkException(error(_err));
             }
 
             return _ok;
@@ -231,7 +231,7 @@ namespace Galaxus.Functional
         /// <param name="value">The value to check against.</param>
         public bool Contains(TOk value)
         {
-            return Match(ok => ok.Equals(obj: value), err => false);
+            return Match(ok => ok.Equals(value), err => false);
         }
 
         /// <summary>
@@ -240,7 +240,7 @@ namespace Galaxus.Functional
         /// <param name="value">The value to check against.</param>
         public bool ContainsErr(TErr value)
         {
-            return Match(ok => false, err => err.Equals(obj: value));
+            return Match(ok => false, err => err.Equals(value));
         }
 
         #endregion
@@ -261,17 +261,17 @@ namespace Galaxus.Functional
                 return false;
             }
 
-            if (ReferenceEquals(this, objB: other))
+            if (ReferenceEquals(this, other))
             {
                 return true;
             }
 
             if (IsOk)
             {
-                return other.IsOk && _ok.Equals(obj: other._ok);
+                return other.IsOk && _ok.Equals(other._ok);
             }
 
-            return !other.IsOk && _err.Equals(obj: other._err);
+            return !other.IsOk && _err.Equals(other._err);
         }
 
         /// <summary>
@@ -287,7 +287,7 @@ namespace Galaxus.Functional
                 return rhs is null;
             }
 
-            return lhs.Equals(other: rhs);
+            return lhs.Equals(rhs);
         }
 
         /// <summary>

--- a/Galaxus.Functional/(Result)/Result.cs
+++ b/Galaxus.Functional/(Result)/Result.cs
@@ -43,7 +43,9 @@ namespace Galaxus.Functional
         private Result(TOk ok)
         {
             if (typeof(TOk).IsValueType == false && ok == null)
+            {
                 throw new ArgumentNullException(nameof(ok));
+            }
 
             _ok = ok;
             IsOk = true;
@@ -52,7 +54,9 @@ namespace Galaxus.Functional
         private Result(TErr err)
         {
             if (typeof(TErr).IsValueType == false && err == null)
+            {
                 throw new ArgumentNullException(nameof(err));
+            }
 
             _err = err;
         }
@@ -147,7 +151,9 @@ namespace Galaxus.Functional
         public TOk Unwrap(string error)
         {
             if (IsErr)
+            {
                 throw new AttemptToUnwrapErrWhenResultWasOkException(message: error);
+            }
 
             return _ok;
         }
@@ -162,7 +168,9 @@ namespace Galaxus.Functional
             if (IsErr)
             {
                 if (error is null)
+                {
                     throw new ArgumentNullException(nameof(error));
+                }
 
                 throw new AttemptToUnwrapErrWhenResultWasOkException(error(arg: _err));
             }
@@ -192,10 +200,14 @@ namespace Galaxus.Functional
         public TOk UnwrapOrElse(Func<TOk> fallback)
         {
             if (IsOk)
+            {
                 return _ok;
+            }
 
             if (fallback is null)
+            {
                 throw new ArgumentNullException(nameof(fallback));
+            }
 
             return fallback();
         }
@@ -245,12 +257,19 @@ namespace Galaxus.Functional
         public bool Equals(Result<TOk, TErr> other)
         {
             if (other is null)
+            {
                 return false;
+            }
 
             if (ReferenceEquals(this, objB: other))
+            {
                 return true;
+            }
 
-            if (IsOk) return other.IsOk && _ok.Equals(obj: other._ok);
+            if (IsOk)
+            {
+                return other.IsOk && _ok.Equals(obj: other._ok);
+            }
 
             return !other.IsOk && _err.Equals(obj: other._err);
         }
@@ -264,7 +283,9 @@ namespace Galaxus.Functional
         public static bool operator ==(Result<TOk, TErr> lhs, Result<TOk, TErr> rhs)
         {
             if (lhs is null)
+            {
                 return rhs is null;
+            }
 
             return lhs.Equals(other: rhs);
         }

--- a/Galaxus.Functional/(Result)/Result.cs
+++ b/Galaxus.Functional/(Result)/Result.cs
@@ -4,28 +4,32 @@ using System.Collections.Generic;
 namespace Galaxus.Functional
 {
     /// <summary>
-    ///     <see cref="Result{TOk, TErr}"/>s are used for returning and propagating errors.
+    ///     <see cref="Result{TOk, TErr}" />s are used for returning and propagating errors.
     ///     They're either <b>Ok</b>, representing success and containing a value,
     ///     or <b>Err</b>, representing failure and containing an error value.
-    ///     Functions return <see cref="Result{TOk, TErr}"/>s whenever errors are expected and recoverable.
+    ///     Functions return <see cref="Result{TOk, TErr}" />s whenever errors are expected and recoverable.
     /// </summary>
     public sealed partial class Result<TOk, TErr> : IEquatable<Result<TOk, TErr>>
     {
         #region Instance Initializer
 
         /// <summary>
-        /// Constructs a <see cref="Result{TOk, TErr}"/> containing <b>Ok</b>.
+        ///     Constructs a <see cref="Result{TOk, TErr}" /> containing <b>Ok</b>.
         /// </summary>
         /// <param name="ok">The <b>Ok</b> value.</param>
         public static Result<TOk, TErr> FromOk(TOk ok)
-            => new Result<TOk, TErr>(ok);
+        {
+            return new Result<TOk, TErr>(ok: ok);
+        }
 
         /// <summary>
-        /// Constructs a <see cref="Result{TOk, TErr}"/> containing <b>Err</b>.
+        ///     Constructs a <see cref="Result{TOk, TErr}" /> containing <b>Err</b>.
         /// </summary>
         /// <param name="err">The <b>Err</b> value.</param>
         public static Result<TOk, TErr> FromErr(TErr err)
-            => new Result<TOk, TErr>(err);
+        {
+            return new Result<TOk, TErr>(err: err);
+        }
 
         // Note:
         // We use private ctors here to allow TOk and TErr to be of the same type.
@@ -54,20 +58,24 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Cast a value to a <see cref="Result{TOk,TErr}"/> containing Ok.
+        ///     Cast a value to a <see cref="Result{TOk,TErr}" /> containing Ok.
         /// </summary>
         /// <param name="ok">The value to be contained.</param>
         /// <returns>The result.</returns>
         public static implicit operator Result<TOk, TErr>(TOk ok)
-            => new Result<TOk, TErr>(ok);
+        {
+            return new Result<TOk, TErr>(ok: ok);
+        }
 
         /// <summary>
-        /// Cast a value to a <see cref="Result{TOk,TErr}"/> containing Err.
+        ///     Cast a value to a <see cref="Result{TOk,TErr}" /> containing Err.
         /// </summary>
         /// <param name="err">The value to be contained.</param>
         /// <returns>The result.</returns>
         public static implicit operator Result<TOk, TErr>(TErr err)
-            => new Result<TOk, TErr>(err);
+        {
+            return new Result<TOk, TErr>(err: err);
+        }
 
         #endregion
 
@@ -77,24 +85,24 @@ namespace Galaxus.Functional
         private readonly TErr _err;
 
         /// <summary>
-        /// Returns <b>true</b> if <b>self</b> contains <b>Ok</b>.
+        ///     Returns <b>true</b> if <b>self</b> contains <b>Ok</b>.
         /// </summary>
         public bool IsOk { get; }
 
         /// <summary>
-        /// Returns <b>true</b> if <b>self</b> contains <b>Err</b>.
+        ///     Returns <b>true</b> if <b>self</b> contains <b>Err</b>.
         /// </summary>
         public bool IsErr
             => IsOk == false;
 
         /// <summary>
-        /// Discards <b>Err</b> and returns <b>Ok</b>.
+        ///     Discards <b>Err</b> and returns <b>Ok</b>.
         /// </summary>
         public Option<TOk> Ok
             => IsOk ? _ok.ToOption() : None.Value;
 
         /// <summary>
-        /// Discards <b>Ok</b> and returns <b>Err</b>.
+        ///     Discards <b>Ok</b> and returns <b>Err</b>.
         /// </summary>
         public Option<TErr> Err
             => IsOk ? None.Value : _err.ToOption();
@@ -104,8 +112,8 @@ namespace Galaxus.Functional
         #region Unwrap
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Ok</b>.
-        /// <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        ///     Unwraps <b>self</b> and returns <b>Ok</b>.
+        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
         /// </summary>
         public TOk Unwrap()
         {
@@ -116,11 +124,11 @@ namespace Galaxus.Functional
                     case IError error:
                         return error.Description;
                     case IEnumerable<IError> errors:
-                        return string.Join("; ", errors);
+                        return string.Join("; ", values: errors);
                     case string str:
                         return str;
                     case IEnumerable<string> strs:
-                        return string.Join("; ", strs);
+                        return string.Join("; ", values: strs);
                     default:
                         return $"Cannot unwrap \"Ok\" when the result is \"Err\": {_err.ToString()}.";
                 }
@@ -128,25 +136,25 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Ok</b>.
-        /// <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        ///     Unwraps <b>self</b> and returns <b>Ok</b>.
+        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
         /// </summary>
         /// <param name="error">
-        /// A custom error to use as the exception message.
-        /// This argument is eagerly evaluated; if you are passing the result of a function call,
-        /// it is recommended to use <see cref="Unwrap(Func{TErr, string})"/>, which is lazily evaluated.
+        ///     A custom error to use as the exception message.
+        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
+        ///     it is recommended to use <see cref="Unwrap(Func{TErr, string})" />, which is lazily evaluated.
         /// </param>
         public TOk Unwrap(string error)
         {
             if (IsErr)
-                throw new AttemptToUnwrapErrWhenResultWasOkException(error);
+                throw new AttemptToUnwrapErrWhenResultWasOkException(message: error);
 
             return _ok;
         }
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Ok</b>.
-        /// <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        ///     Unwraps <b>self</b> and returns <b>Ok</b>.
+        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
         /// </summary>
         /// <param name="error">A function that returns a custom error to use as the exception message.</param>
         public TOk Unwrap(Func<TErr, string> error)
@@ -156,25 +164,29 @@ namespace Galaxus.Functional
                 if (error is null)
                     throw new ArgumentNullException(nameof(error));
 
-                throw new AttemptToUnwrapErrWhenResultWasOkException(error(_err));
+                throw new AttemptToUnwrapErrWhenResultWasOkException(error(arg: _err));
             }
 
             return _ok;
         }
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns <paramref name="fallback"/> otherwise.
+        ///     Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns <paramref name="fallback" />
+        ///     otherwise.
         /// </summary>
         /// <param name="fallback">
-        /// The value to return if <b>self</b> contains <b>Err</b>.
-        /// This argument is eagerly evaluated; if you are passing the result of a function call,
-        /// it is recommended to use <see cref="UnwrapOrElse(Func{TOk})"/>, which is lazily evaluated.
+        ///     The value to return if <b>self</b> contains <b>Err</b>.
+        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
+        ///     it is recommended to use <see cref="UnwrapOrElse(Func{TOk})" />, which is lazily evaluated.
         /// </param>
         public TOk UnwrapOr(TOk fallback)
-            => IsOk ? _ok : fallback;
+        {
+            return IsOk ? _ok : fallback;
+        }
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns the result of <paramref name="fallback"/> otherwise.
+        ///     Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns the result of
+        ///     <paramref name="fallback" /> otherwise.
         /// </summary>
         /// <param name="fallback">The function to call if <b>self</b> contains <b>Err</b>.</param>
         public TOk UnwrapOrElse(Func<TOk> fallback)
@@ -189,31 +201,34 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns the default value of <typeparamref name="TOk"/> otherwise.
+        ///     Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns the default value of
+        ///     <typeparamref name="TOk" /> otherwise.
         /// </summary>
         public TOk UnwrapOrDefault()
-            => IsOk ? _ok : default;
+        {
+            return IsOk ? _ok : default;
+        }
 
         #endregion
 
         #region Contains
 
         /// <summary>
-        /// Returns true if the the result is <b>Ok</b> and contains the given value.
+        ///     Returns true if the the result is <b>Ok</b> and contains the given value.
         /// </summary>
         /// <param name="value">The value to check against.</param>
         public bool Contains(TOk value)
         {
-            return Match(ok => ok.Equals(value), err => false);
+            return Match(ok => ok.Equals(obj: value), err => false);
         }
 
         /// <summary>
-        /// Returns true if the the result is <b>Err</b> and contains the given value.
+        ///     Returns true if the the result is <b>Err</b> and contains the given value.
         /// </summary>
         /// <param name="value">The value to check against.</param>
         public bool ContainsErr(TErr value)
         {
-            return Match(ok => false, err => err.Equals(value));
+            return Match(ok => false, err => err.Equals(obj: value));
         }
 
         #endregion
@@ -222,7 +237,9 @@ namespace Galaxus.Functional
 
         /// <inheritdoc />
         public override bool Equals(object other)
-            => Equals(other as Result<TOk, TErr>);
+        {
+            return Equals(other as Result<TOk, TErr>);
+        }
 
         /// <inheritdoc />
         public bool Equals(Result<TOk, TErr> other)
@@ -230,19 +247,16 @@ namespace Galaxus.Functional
             if (other is null)
                 return false;
 
-            if (ReferenceEquals(this, other))
+            if (ReferenceEquals(this, objB: other))
                 return true;
 
-            if (IsOk)
-            {
-                return other.IsOk && _ok.Equals(other._ok);
-            }
+            if (IsOk) return other.IsOk && _ok.Equals(obj: other._ok);
 
-            return !other.IsOk && _err.Equals(other._err);
+            return !other.IsOk && _err.Equals(obj: other._err);
         }
 
         /// <summary>
-        /// Check that two results are equal.
+        ///     Check that two results are equal.
         /// </summary>
         /// <param name="lhs">Result to check against.</param>
         /// <param name="rhs">Result to check.</param>
@@ -252,25 +266,31 @@ namespace Galaxus.Functional
             if (lhs is null)
                 return rhs is null;
 
-            return lhs.Equals(rhs);
+            return lhs.Equals(other: rhs);
         }
 
         /// <summary>
-        /// Check that two results are not equal.
+        ///     Check that two results are not equal.
         /// </summary>
         /// <param name="lhs">Result to check against.</param>
         /// <param name="rhs">Result to check.</param>
         /// <returns><c>False</c> if the results are equal, <c>true</c> otherwise.</returns>
         public static bool operator !=(Result<TOk, TErr> lhs, Result<TOk, TErr> rhs)
-            => (lhs == rhs) == false;
+        {
+            return lhs == rhs == false;
+        }
 
         /// <inheritdoc />
         public override int GetHashCode()
-            => (IsOk, _ok, _err).GetHashCode();
+        {
+            return (IsOk, _ok, _err).GetHashCode();
+        }
 
         /// <inheritdoc />
         public override string ToString()
-            => Match(ok => $"Ok: {ok.ToString()}", err => $"Err: {err.ToString()}");
+        {
+            return Match(ok => $"Ok: {ok.ToString()}", err => $"Err: {err.ToString()}");
+        }
 
         #endregion
     }

--- a/Galaxus.Functional/(Result)/ResultExtensions.cs
+++ b/Galaxus.Functional/(Result)/ResultExtensions.cs
@@ -34,13 +34,17 @@ namespace Galaxus.Functional
         ///     Wraps <paramref name="self" /> into a <see cref="Result{TOk, TErr}" /> containing <b>Ok</b>.
         /// </summary>
         public static Result<TOk, TErr> ToOk<TOk, TErr>(this TOk self)
-            => Result<TOk, TErr>.FromOk(self);
+        {
+            return Result<TOk, TErr>.FromOk(self);
+        }
 
         /// <summary>
         ///     Wraps <paramref name="self" /> into a <see cref="Result{TOk, TErr}" /> containing <b>Err</b>.
         /// </summary>
         public static Result<TOk, TErr> ToErr<TOk, TErr>(this TErr self)
-            => Result<TOk, TErr>.FromErr(self);
+        {
+            return Result<TOk, TErr>.FromErr(self);
+        }
 
         #endregion
 
@@ -132,7 +136,9 @@ namespace Galaxus.Functional
         ///     Returns a subset of <paramref name="self" /> which contains all <b>Ok</b> values in <paramref name="self" />.
         /// </summary>
         public static IEnumerable<TOk> SelectOk<TOk, TErr>(this IEnumerable<Result<TOk, TErr>> self)
-            => self.Where(v => v.IsOk).Select(v => v.Unwrap());
+        {
+            return self.Where(v => v.IsOk).Select(v => v.Unwrap());
+        }
 
         /// <summary>
         ///     Returns a subset of <paramref name="self" /> which contains all <b>Ok</b> values in <paramref name="self" />.
@@ -141,13 +147,17 @@ namespace Galaxus.Functional
         public static IEnumerable<TSelection> SelectOk<TOk, TErr, TSelection>(
             this IEnumerable<Result<TOk, TErr>> self,
             Func<TOk, TSelection> selector)
-            => self.SelectOk().Select(selector);
+        {
+            return self.SelectOk().Select(selector);
+        }
 
         /// <summary>
         ///     Returns a subset of <paramref name="self" /> which contains all <b>Err</b> values in <paramref name="self" />.
         /// </summary>
         public static IEnumerable<TErr> SelectErr<TOk, TErr>(this IEnumerable<Result<TOk, TErr>> self)
-            => self.Where(v => v.IsErr).Select(v => v.Err.Unwrap());
+        {
+            return self.Where(v => v.IsErr).Select(v => v.Err.Unwrap());
+        }
 
         /// <summary>
         ///     Returns a subset of <paramref name="self" /> which contains all <b>Err</b> values in <paramref name="self" />.
@@ -156,7 +166,9 @@ namespace Galaxus.Functional
         public static IEnumerable<TSelection> SelectErr<TOk, TErr, TSelection>(
             this IEnumerable<Result<TOk, TErr>> self,
             Func<TErr, TSelection> selector)
-            => self.SelectErr().Select(selector);
+        {
+            return self.SelectErr().Select(selector);
+        }
 
         #endregion
 
@@ -299,21 +311,27 @@ namespace Galaxus.Functional
         /// </summary>
         /// <inheritdoc cref="Result{TOk,TErr}.Unwrap()"/>
         public static async Task<TOk> UnwrapAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self)
-            => (await self).Unwrap();
+        {
+            return (await self).Unwrap();
+        }
 
         /// <summary>
         ///     Async overload for <see cref="Result{TOk,TErr}.Unwrap(string)"/>
         /// </summary>
         /// <inheritdoc cref="Result{TOk,TErr}.Unwrap(string)"/>
         public static async Task<TOk> UnwrapAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, string error)
-            => (await self).Unwrap(error);
+        {
+            return (await self).Unwrap(error);
+        }
 
         /// <summary>
         ///     Async overload for <see cref="Result{TOk,TErr}.Unwrap(Func{TErr, string})"/>
         /// </summary>
         /// <inheritdoc cref="Result{TOk,TErr}.Unwrap(Func{TErr, string})"/>
         public static async Task<TOk> UnwrapAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, Func<TErr, string> error)
-            => (await self).Unwrap(error);
+        {
+            return (await self).Unwrap(error);
+        }
 
         /// <summary>
         ///     Async overload for <see cref="Result{TOk,TErr}.Unwrap(Func{TErr, string})"/>
@@ -325,7 +343,9 @@ namespace Galaxus.Functional
             if (res.IsErr)
             {
                 if (error is null)
+                {
                     throw new ArgumentNullException(nameof(error));
+                }
 
                 throw new AttemptToUnwrapErrWhenResultWasOkException(await error(res.Err.Unwrap()));
             }
@@ -338,21 +358,27 @@ namespace Galaxus.Functional
         /// </summary>
         /// <inheritdoc cref="Result{TOk,TErr}.UnwrapOr"/>
         public static async Task<TOk> UnwrapOrAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, TOk fallback)
-            => (await self).UnwrapOr(fallback);
+        {
+            return (await self).UnwrapOr(fallback);
+        }
 
         /// <summary>
         ///     Async overload for <see cref="Result{TOk,TErr}.UnwrapOr"/>
         /// </summary>
         /// <inheritdoc cref="Result{TOk,TErr}.UnwrapOr"/>
         public static async Task<TOk> UnwrapOrAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, Task<TOk> fallback)
-            => (await self).UnwrapOr(await fallback);
+        {
+            return (await self).UnwrapOr(await fallback);
+        }
 
         /// <summary>
         ///     Async overload for <see cref="Result{TOk,TErr}.UnwrapOrElse"/>
         /// </summary>
         /// <inheritdoc cref="Result{TOk,TErr}.UnwrapOrElse"/>
         public static async Task<TOk> UnwrapOrElseAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, Func<TOk> fallback)
-            => (await self).UnwrapOrElse(fallback);
+        {
+            return (await self).UnwrapOrElse(fallback);
+        }
 
         /// <summary>
         ///     Async overload for <see cref="Result{TOk,TErr}.UnwrapOrElse"/>
@@ -362,10 +388,14 @@ namespace Galaxus.Functional
         {
             var res = await self;
             if (res.IsOk)
+            {
                 return res.Unwrap();
+            }
 
             if (fallback is null)
+            {
                 throw new ArgumentNullException(nameof(fallback));
+            }
 
             return await fallback();
         }
@@ -375,7 +405,9 @@ namespace Galaxus.Functional
         /// </summary>
         /// <inheritdoc cref="Result{TOk,TErr}.UnwrapOrDefault"/>
         public static async Task<TOk> UnwrapOrDefaultAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self)
-            => (await self).UnwrapOrDefault();
+        {
+            return (await self).UnwrapOrDefault();
+        }
 
         #endregion
     }

--- a/Galaxus.Functional/(Result)/ResultExtensions.cs
+++ b/Galaxus.Functional/(Result)/ResultExtensions.cs
@@ -6,20 +6,38 @@ using System.Threading.Tasks;
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// Extensions for the result type, providing some quality of life-shorthands.
+    ///     Extensions for the result type, providing some quality of life-shorthands.
     /// </summary>
     public static class ResultExtensions
     {
+        /// <summary>
+        ///     Transposes a <see cref="Result{TOk, TErr}" /> of an <see cref="Option{T}" /> into an <see cref="Option{T}" /> of a
+        ///     <see cref="Result{TOk, TErr}" />.
+        ///     <b>Ok(None)</b> will be mapped to <b>None</b>.
+        ///     <b>Ok(Some(TOk))</b> will be mapped to <b>Some(Ok(TOk))</b>.
+        ///     <b>Err(TErr)</b> will be mapped to <b>Some(Err(TErr))</b>.
+        /// </summary>
+        public static Option<Result<TOk, TErr>> Transpose<TOk, TErr>(this Result<Option<TOk>, TErr> self)
+        {
+            return self.Match(
+                ok => ok.Match(
+                    some => some.ToOk<TOk, TErr>().ToOption(),
+                    () => None.Value
+                ),
+                err => err.ToErr<TOk, TErr>().ToOption()
+            );
+        }
+
         #region Instance Initializer
 
         /// <summary>
-        /// Wraps <paramref name="self"/> into a <see cref="Result{TOk, TErr}"/> containing <b>Ok</b>.
+        ///     Wraps <paramref name="self" /> into a <see cref="Result{TOk, TErr}" /> containing <b>Ok</b>.
         /// </summary>
         public static Result<TOk, TErr> ToOk<TOk, TErr>(this TOk self)
             => Result<TOk, TErr>.FromOk(self);
 
         /// <summary>
-        /// Wraps <paramref name="self"/> into a <see cref="Result{TOk, TErr}"/> containing <b>Err</b>.
+        ///     Wraps <paramref name="self" /> into a <see cref="Result{TOk, TErr}" /> containing <b>Err</b>.
         /// </summary>
         public static Result<TOk, TErr> ToErr<TOk, TErr>(this TErr self)
             => Result<TOk, TErr>.FromErr(self);
@@ -29,9 +47,9 @@ namespace Galaxus.Functional
         #region Auto Map
 
         /// <summary>
-        /// Automatically maps <b>Ok</b> to a different type.
+        ///     Automatically maps <b>Ok</b> to a different type.
         /// </summary>
-        /// <typeparam name="TOkFrom">The current type of <b>Ok</b>. This type must derive from <typeparamref name="TOkTo"/>.</typeparam>
+        /// <typeparam name="TOkFrom">The current type of <b>Ok</b>. This type must derive from <typeparamref name="TOkTo" />.</typeparam>
         /// <typeparam name="TOkTo">The type to map <b>Ok</b> to.</typeparam>
         /// <typeparam name="TErr">The type of <b>Err</b> which will remain untouched.</typeparam>
         public static Result<TOkTo, TErr> Map<TOkFrom, TOkTo, TErr>(this Result<TOkFrom, TErr> self)
@@ -44,10 +62,10 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Automatically maps <b>Err</b> to a different type.
+        ///     Automatically maps <b>Err</b> to a different type.
         /// </summary>
         /// <typeparam name="TOk">The type of <b>Ok</b> which will remain untouched.</typeparam>
-        /// <typeparam name="TErrFrom">The current type of <b>Err</b>. This type must derive from <typeparamref name="TErrTo"/>.</typeparam>
+        /// <typeparam name="TErrFrom">The current type of <b>Err</b>. This type must derive from <typeparamref name="TErrTo" />.</typeparam>
         /// <typeparam name="TErrTo">The type to map <b>Err</b> to.</typeparam>
         public static Result<TOk, TErrTo> MapErr<TOk, TErrFrom, TErrTo>(this Result<TOk, TErrFrom> self)
             where TErrFrom : TErrTo
@@ -63,8 +81,9 @@ namespace Galaxus.Functional
         #region Map
 
         /// <summary>
-        /// Maps a <see cref="Result{TOk, TErr}"/> to <see cref="Result{TOkTo, TErr}"/> by applying a function to a contained <b>Ok</b> value,
-        /// leaving an <b>Err</b> value untouched. This function can be used to compose the results of two functions.
+        ///     Maps a <see cref="Result{TOk, TErr}" /> to <see cref="Result{TOkTo, TErr}" /> by applying a function to a contained
+        ///     <b>Ok</b> value,
+        ///     leaving an <b>Err</b> value untouched. This function can be used to compose the results of two functions.
         /// </summary>
         /// <typeparam name="TOkTo">The type to map <b>Ok</b> to.</typeparam>
         /// <typeparam name="TOk"></typeparam>
@@ -79,8 +98,9 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Maps a <see cref="Result{TOk, TErr}"/> to <see cref="Result{TOkTo, TErr}"/> by applying a function to a contained <b>Ok</b> value,
-        /// leaving an <b>Err</b> value untouched. This function can be used to compose the results of two functions.
+        ///     Maps a <see cref="Result{TOk, TErr}" /> to <see cref="Result{TOkTo, TErr}" /> by applying a function to a contained
+        ///     <b>Ok</b> value,
+        ///     leaving an <b>Err</b> value untouched. This function can be used to compose the results of two functions.
         /// </summary>
         /// <typeparam name="TOkTo">The type to map <b>Ok</b> to.</typeparam>
         /// <typeparam name="TOk"></typeparam>
@@ -95,8 +115,9 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Maps a <see cref="Result{TOk, TErr}"/> to <see cref="Result{TOk, TErrTo}"/> by applying a function to a contained <b>Err</b> value,
-        /// leaving an <b>Ok</b> value untouched. This function can be used to compose the results of two functions.
+        ///     Maps a <see cref="Result{TOk, TErr}" /> to <see cref="Result{TOk, TErrTo}" /> by applying a function to a contained
+        ///     <b>Err</b> value,
+        ///     leaving an <b>Ok</b> value untouched. This function can be used to compose the results of two functions.
         /// </summary>
         /// <typeparam name="TErrTo">The type to map "Err" to.</typeparam>
         /// <typeparam name="TOk"></typeparam>
@@ -111,8 +132,9 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Maps a <see cref="Result{TOk, TErr}"/> to <see cref="Result{TOk, TErrTo}"/> by applying a function to a contained <b>Err</b> value,
-        /// leaving an <b>Ok</b> value untouched. This function can be used to compose the results of two functions.
+        ///     Maps a <see cref="Result{TOk, TErr}" /> to <see cref="Result{TOk, TErrTo}" /> by applying a function to a contained
+        ///     <b>Err</b> value,
+        ///     leaving an <b>Ok</b> value untouched. This function can be used to compose the results of two functions.
         /// </summary>
         /// <typeparam name="TErrTo">The type to map "Err" to.</typeparam>
         /// <typeparam name="TOk"></typeparam>
@@ -131,29 +153,31 @@ namespace Galaxus.Functional
         #region Enumerations
 
         /// <summary>
-        /// Returns a subset of <paramref name="self"/> which contains all <b>Ok</b> values in <paramref name="self"/>.
+        ///     Returns a subset of <paramref name="self" /> which contains all <b>Ok</b> values in <paramref name="self" />.
         /// </summary>
         public static IEnumerable<TOk> SelectOk<TOk, TErr>(this IEnumerable<Result<TOk, TErr>> self)
             => self.Where(v => v.IsOk).Select(v => v.Unwrap());
 
         /// <summary>
-        /// Returns a subset of <paramref name="self"/> which contains all <b>Ok</b> values in <paramref name="self"/>.
-        /// Then runs it through the <paramref name="selector"/>.
+        ///     Returns a subset of <paramref name="self" /> which contains all <b>Ok</b> values in <paramref name="self" />.
+        ///     Then runs it through the <paramref name="selector" />.
         /// </summary>
-        public static IEnumerable<TSelection> SelectOk<TOk, TErr, TSelection>(this IEnumerable<Result<TOk, TErr>> self, Func<TOk, TSelection> selector)
+        public static IEnumerable<TSelection> SelectOk<TOk, TErr, TSelection>(this IEnumerable<Result<TOk, TErr>> self,
+            Func<TOk, TSelection> selector)
             => self.SelectOk().Select(selector);
 
         /// <summary>
-        /// Returns a subset of <paramref name="self"/> which contains all <b>Err</b> values in <paramref name="self"/>.
+        ///     Returns a subset of <paramref name="self" /> which contains all <b>Err</b> values in <paramref name="self" />.
         /// </summary>
         public static IEnumerable<TErr> SelectErr<TOk, TErr>(this IEnumerable<Result<TOk, TErr>> self)
             => self.Where(v => v.IsErr).Select(v => v.Err.Unwrap());
 
         /// <summary>
-        /// Returns a subset of <paramref name="self"/> which contains all <b>Err</b> values in <paramref name="self"/>.
-        /// Then runs it through the <paramref name="selector"/>.
+        ///     Returns a subset of <paramref name="self" /> which contains all <b>Err</b> values in <paramref name="self" />.
+        ///     Then runs it through the <paramref name="selector" />.
         /// </summary>
-        public static IEnumerable<TSelection> SelectErr<TOk, TErr, TSelection>(this IEnumerable<Result<TOk, TErr>> self, Func<TErr, TSelection> selector)
+        public static IEnumerable<TSelection> SelectErr<TOk, TErr, TSelection>(this IEnumerable<Result<TOk, TErr>> self,
+            Func<TErr, TSelection> selector)
             => self.SelectErr().Select(selector);
 
         #endregion
@@ -161,7 +185,6 @@ namespace Galaxus.Functional
         #region Match
 
         /// <summary>
-        ///
         /// </summary>
         /// <param name="self"></param>
         /// <param name="onOk"></param>
@@ -179,7 +202,6 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///
         /// </summary>
         /// <param name="self"></param>
         /// <param name="onOk"></param>
@@ -197,7 +219,6 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///
         /// </summary>
         /// <param name="self"></param>
         /// <param name="onOk"></param>
@@ -215,7 +236,6 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///
         /// </summary>
         /// <param name="self"></param>
         /// <param name="onOk"></param>
@@ -233,7 +253,6 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///
         /// </summary>
         /// <param name="self"></param>
         /// <param name="onOk"></param>
@@ -254,7 +273,6 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///
         /// </summary>
         /// <param name="self"></param>
         /// <param name="onOk"></param>
@@ -279,10 +297,14 @@ namespace Galaxus.Functional
         #region AndThen
 
         /// <summary>
-        /// Calls <paramref name="continuation"/> if <b>self</b> contains <b>Ok</b>, otherwise returns the <b>Err</b> value contained in <b>self</b>.
-        /// This function can be used for control flow based on <see cref="Result{TOk, TErr}"/>s.
+        ///     Calls <paramref name="continuation" /> if <b>self</b> contains <b>Ok</b>, otherwise returns the <b>Err</b> value
+        ///     contained in <b>self</b>.
+        ///     This function can be used for control flow based on <see cref="Result{TOk, TErr}" />s.
         /// </summary>
-        /// <typeparam name="TContinuationOk">The <b>Ok</b> type of the <paramref name="continuation"/>'s <see cref="Result{TOk, TErr}"/>.</typeparam>
+        /// <typeparam name="TContinuationOk">
+        ///     The <b>Ok</b> type of the <paramref name="continuation" />'s
+        ///     <see cref="Result{TOk, TErr}" />.
+        /// </typeparam>
         /// <typeparam name="TOk"></typeparam>
         /// <typeparam name="TErr"></typeparam>
         /// <param name="self"></param>
@@ -295,10 +317,14 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Calls <paramref name="continuation"/> if <b>self</b> contains <b>Ok</b>, otherwise returns the <b>Err</b> value contained in <b>self</b>.
-        /// This function can be used for control flow based on <see cref="Result{TOk, TErr}"/>s.
+        ///     Calls <paramref name="continuation" /> if <b>self</b> contains <b>Ok</b>, otherwise returns the <b>Err</b> value
+        ///     contained in <b>self</b>.
+        ///     This function can be used for control flow based on <see cref="Result{TOk, TErr}" />s.
         /// </summary>
-        /// <typeparam name="TContinuationOk">The <b>Ok</b> type of the <paramref name="continuation"/>'s <see cref="Result{TOk, TErr}"/>.</typeparam>
+        /// <typeparam name="TContinuationOk">
+        ///     The <b>Ok</b> type of the <paramref name="continuation" />'s
+        ///     <see cref="Result{TOk, TErr}" />.
+        /// </typeparam>
         /// <typeparam name="TOk"></typeparam>
         /// <typeparam name="TErr"></typeparam>
         /// <param name="self"></param>
@@ -315,10 +341,14 @@ namespace Galaxus.Functional
         #region Or
 
         /// <summary>
-        /// Calls <paramref name="continuation"/> if <b>self</b> contains <b>Err</b>, otherwise returns the <b>Ok</b> value contained in <b>self</b>.
-        /// This function can be used for control flow based on <see cref="Result{TOk, TErr}"/>s.
+        ///     Calls <paramref name="continuation" /> if <b>self</b> contains <b>Err</b>, otherwise returns the <b>Ok</b> value
+        ///     contained in <b>self</b>.
+        ///     This function can be used for control flow based on <see cref="Result{TOk, TErr}" />s.
         /// </summary>
-        /// <typeparam name="TContinuationErr">The <b>Error</b> type of the <paramref name="continuation"/>'s <see cref="Result{TOk, TErr}"/>.</typeparam>
+        /// <typeparam name="TContinuationErr">
+        ///     The <b>Error</b> type of the <paramref name="continuation" />'s
+        ///     <see cref="Result{TOk, TErr}" />.
+        /// </typeparam>
         /// <typeparam name="TOk"></typeparam>
         /// <param name="self"></param>
         /// <param name="continuation">The function to call if <b>self</b> contains <b>Err</b>.</param>
@@ -330,10 +360,14 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Calls <paramref name="continuation"/> if <b>self</b> contains <b>Err</b>, otherwise returns the <b>Ok</b> value contained in <b>self</b>.
-        /// This function can be used for control flow based on <see cref="Result{TOk, TErr}"/>s.
+        ///     Calls <paramref name="continuation" /> if <b>self</b> contains <b>Err</b>, otherwise returns the <b>Ok</b> value
+        ///     contained in <b>self</b>.
+        ///     This function can be used for control flow based on <see cref="Result{TOk, TErr}" />s.
         /// </summary>
-        /// <typeparam name="TContinuationErr">The <b>Error</b> type of the <paramref name="continuation"/>'s <see cref="Result{TOk, TErr}"/>.</typeparam>
+        /// <typeparam name="TContinuationErr">
+        ///     The <b>Error</b> type of the <paramref name="continuation" />'s
+        ///     <see cref="Result{TOk, TErr}" />.
+        /// </typeparam>
         /// <typeparam name="TOk"></typeparam>
         /// <param name="self"></param>
         /// <param name="continuation">The function to call if <b>self</b> contains <b>Err</b>.</param>
@@ -349,36 +383,40 @@ namespace Galaxus.Functional
         #region UnwrapAsync
 
         /// <summary>
-        /// Unwraps asynchronous <b>self</b> and returns <b>Ok</b>.
-        /// <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        ///     Unwraps asynchronous <b>self</b> and returns <b>Ok</b>.
+        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
         /// </summary>
         /// <param name="self"></param>
         /// <typeparam name="TOk"></typeparam>
         /// <typeparam name="TErr"></typeparam>
-        /// <returns><b>self</b></returns>
+        /// <returns>
+        ///     <b>self</b>
+        /// </returns>
         public static async Task<TOk> UnwrapAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self) =>
             (await self).Unwrap();
 
 
         /// <summary>
-        /// Unwraps asynchronous <b>self</b> and returns <b>Ok</b>.
-        /// <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        ///     Unwraps asynchronous <b>self</b> and returns <b>Ok</b>.
+        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
         /// </summary>
         /// <param name="self"></param>
         /// <param name="error">
-        /// A custom error to use as the exception message.
-        /// This argument is eagerly evaluated; if you are passing the result of a function call,
-        /// it is recommended to use <see cref="Result{TOk, TErr}.Unwrap(Func{TErr, string})"/>, which is lazily evaluated.
+        ///     A custom error to use as the exception message.
+        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
+        ///     it is recommended to use <see cref="Result{TOk, TErr}.Unwrap(Func{TErr, string})" />, which is lazily evaluated.
         /// </param>
         /// <typeparam name="TOk"></typeparam>
         /// <typeparam name="TErr"></typeparam>
-        /// <returns><b>self</b></returns>
+        /// <returns>
+        ///     <b>self</b>
+        /// </returns>
         public static async Task<TOk> UnwrapAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, string error) =>
             (await self).Unwrap(error);
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Ok</b>.
-        /// <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        ///     Unwraps <b>self</b> and returns <b>Ok</b>.
+        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
         /// </summary>
         /// <param name="self"></param>
         /// <param name="error">A function that returns a custom error to use as the exception message.</param>
@@ -389,8 +427,8 @@ namespace Galaxus.Functional
             Func<TErr, string> error) => (await self).Unwrap(error);
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Ok</b>.
-        /// <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        ///     Unwraps <b>self</b> and returns <b>Ok</b>.
+        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
         /// </summary>
         /// <param name="self"></param>
         /// <param name="error">A function that returns a custom error to use as the exception message.</param>
@@ -413,31 +451,40 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns <paramref name="fallback"/> otherwise.
+        ///     Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns <paramref name="fallback" />
+        ///     otherwise.
         /// </summary>
         /// <param name="self"></param>
         /// <param name="fallback">
-        /// The value to return if <b>self</b> contains <b>Err</b>.
-        /// This argument is eagerly evaluated; if you are passing the result of a function call,
-        /// it is recommended to use <see cref="UnwrapOrElseAsync{TOk,TErr}(System.Threading.Tasks.Task{Galaxus.Functional.Result{TOk,TErr}},System.Func{TOk})"/>, which is lazily evaluated.
+        ///     The value to return if <b>self</b> contains <b>Err</b>.
+        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
+        ///     it is recommended to use
+        ///     <see
+        ///         cref="UnwrapOrElseAsync{TOk,TErr}(System.Threading.Tasks.Task{Galaxus.Functional.Result{TOk,TErr}},System.Func{TOk})" />
+        ///     , which is lazily evaluated.
         /// </param>
         public static async Task<TOk> UnwrapOrAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, TOk fallback) =>
             (await self).UnwrapOr(fallback);
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns <paramref name="fallback"/> otherwise.
+        ///     Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns <paramref name="fallback" />
+        ///     otherwise.
         /// </summary>
         /// <param name="self"></param>
         /// <param name="fallback">
-        /// The value to return if <b>self</b> contains <b>Err</b>.
-        /// This argument is eagerly evaluated; if you are passing the result of a function call,
-        /// it is recommended to use <see cref="UnwrapOrElseAsync{TOk,TErr}(System.Threading.Tasks.Task{Galaxus.Functional.Result{TOk,TErr}},System.Func{TOk})"/>, which is lazily evaluated.
+        ///     The value to return if <b>self</b> contains <b>Err</b>.
+        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
+        ///     it is recommended to use
+        ///     <see
+        ///         cref="UnwrapOrElseAsync{TOk,TErr}(System.Threading.Tasks.Task{Galaxus.Functional.Result{TOk,TErr}},System.Func{TOk})" />
+        ///     , which is lazily evaluated.
         /// </param>
         public static async Task<TOk> UnwrapOrAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, Task<TOk> fallback) =>
             (await self).UnwrapOr(await fallback);
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns the result of <paramref name="fallback"/> otherwise.
+        ///     Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns the result of
+        ///     <paramref name="fallback" /> otherwise.
         /// </summary>
         /// <param name="self"></param>
         /// <param name="fallback">The function to call if <b>self</b> contains <b>Err</b>.</param>
@@ -446,7 +493,8 @@ namespace Galaxus.Functional
             (await self).UnwrapOrElse(fallback);
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns the result of <paramref name="fallback"/> otherwise.
+        ///     Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns the result of
+        ///     <paramref name="fallback" /> otherwise.
         /// </summary>
         /// <param name="self"></param>
         /// <param name="fallback">The function to call if <b>self</b> contains <b>Err</b>.</param>
@@ -465,28 +513,12 @@ namespace Galaxus.Functional
 
 
         /// <summary>
-        /// Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns the default value of <typeparamref name="TOk"/> otherwise.
+        ///     Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns the default value of
+        ///     <typeparamref name="TOk" /> otherwise.
         /// </summary>
         public static async Task<TOk> UnwrapOrDefaultAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self)
             => (await self).UnwrapOrDefault();
 
         #endregion
-
-        /// <summary>
-        /// Transposes a <see cref="Result{TOk, TErr}"/> of an <see cref="Option{T}"/> into an <see cref="Option{T}"/> of a <see cref="Result{TOk, TErr}"/>.
-        /// <b>Ok(None)</b> will be mapped to <b>None</b>.
-        /// <b>Ok(Some(TOk))</b> will be mapped to <b>Some(Ok(TOk))</b>.
-        /// <b>Err(TErr)</b> will be mapped to <b>Some(Err(TErr))</b>.
-        /// </summary>
-        public static Option<Result<TOk, TErr>> Transpose<TOk, TErr>(this Result<Option<TOk>, TErr> self)
-        {
-            return self.Match(
-                ok => ok.Match(
-                    some => some.ToOk<TOk, TErr>().ToOption(),
-                    () => None.Value
-                ),
-                err => err.ToErr<TOk, TErr>().ToOption()
-            );
-        }
     }
 }

--- a/Galaxus.Functional/(Result)/ResultExtensions.cs
+++ b/Galaxus.Functional/(Result)/ResultExtensions.cs
@@ -81,15 +81,9 @@ namespace Galaxus.Functional
         #region Map
 
         /// <summary>
-        ///     Maps a <see cref="Result{TOk, TErr}" /> to <see cref="Result{TOkTo, TErr}" /> by applying a function to a contained
-        ///     <b>Ok</b> value,
-        ///     leaving an <b>Err</b> value untouched. This function can be used to compose the results of two functions.
+        ///     Async overload for <see cref="Map{TOkFrom,TOkTo,TErr}"/>
         /// </summary>
-        /// <typeparam name="TOkTo">The type to map <b>Ok</b> to.</typeparam>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <param name="self"></param>
-        /// <param name="continuation">The mapping function.</param>
+        /// <inheritdoc cref="Map{TOkFrom,TOkTo,TErr}"/>
         public static async Task<Result<TOkTo, TErr>> MapAsync<TOk, TErr, TOkTo>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, Task<TOkTo>> continuation)
@@ -98,15 +92,9 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///     Maps a <see cref="Result{TOk, TErr}" /> to <see cref="Result{TOkTo, TErr}" /> by applying a function to a contained
-        ///     <b>Ok</b> value,
-        ///     leaving an <b>Err</b> value untouched. This function can be used to compose the results of two functions.
+        ///     Async overload for <see cref="Map{TOkFrom,TOkTo,TErr}"/>
         /// </summary>
-        /// <typeparam name="TOkTo">The type to map <b>Ok</b> to.</typeparam>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <param name="self"></param>
-        /// <param name="continuation">The mapping function.</param>
+        /// <inheritdoc cref="Map{TOkFrom,TOkTo,TErr}"/>
         public static Task<Result<TOkTo, TErr>> MapAsync<TOk, TErr, TOkTo>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, TOkTo> continuation)
@@ -115,15 +103,9 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///     Maps a <see cref="Result{TOk, TErr}" /> to <see cref="Result{TOk, TErrTo}" /> by applying a function to a contained
-        ///     <b>Err</b> value,
-        ///     leaving an <b>Ok</b> value untouched. This function can be used to compose the results of two functions.
+        ///     Async overload for <see cref="MapErr{TOk,TErrFrom,TErrTo}"/>
         /// </summary>
-        /// <typeparam name="TErrTo">The type to map "Err" to.</typeparam>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <param name="self"></param>
-        /// <param name="continuation">The mapping function.</param>
+        /// <inheritdoc cref="MapErr{TOk,TErrFrom,TErrTo}"/>
         public static async Task<Result<TOk, TErrTo>> MapErrAsync<TOk, TErr, TErrTo>(
             this Task<Result<TOk, TErr>> self,
             Func<TErr, Task<TErrTo>> continuation)
@@ -132,15 +114,9 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///     Maps a <see cref="Result{TOk, TErr}" /> to <see cref="Result{TOk, TErrTo}" /> by applying a function to a contained
-        ///     <b>Err</b> value,
-        ///     leaving an <b>Ok</b> value untouched. This function can be used to compose the results of two functions.
+        ///     Async overload for <see cref="MapErr{TOk,TErrFrom,TErrTo}"/>
         /// </summary>
-        /// <typeparam name="TErrTo">The type to map "Err" to.</typeparam>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <param name="self"></param>
-        /// <param name="continuation">The mapping function.</param>
+        /// <inheritdoc cref="MapErr{TOk,TErrFrom,TErrTo}"/>
         public static Task<Result<TOk, TErrTo>> MapErrAsync<TOk, TErr, TErrTo>(
             this Task<Result<TOk, TErr>> self,
             Func<TErr, TErrTo> continuation)
@@ -162,7 +138,8 @@ namespace Galaxus.Functional
         ///     Returns a subset of <paramref name="self" /> which contains all <b>Ok</b> values in <paramref name="self" />.
         ///     Then runs it through the <paramref name="selector" />.
         /// </summary>
-        public static IEnumerable<TSelection> SelectOk<TOk, TErr, TSelection>(this IEnumerable<Result<TOk, TErr>> self,
+        public static IEnumerable<TSelection> SelectOk<TOk, TErr, TSelection>(
+            this IEnumerable<Result<TOk, TErr>> self,
             Func<TOk, TSelection> selector)
             => self.SelectOk().Select(selector);
 
@@ -176,7 +153,8 @@ namespace Galaxus.Functional
         ///     Returns a subset of <paramref name="self" /> which contains all <b>Err</b> values in <paramref name="self" />.
         ///     Then runs it through the <paramref name="selector" />.
         /// </summary>
-        public static IEnumerable<TSelection> SelectErr<TOk, TErr, TSelection>(this IEnumerable<Result<TOk, TErr>> self,
+        public static IEnumerable<TSelection> SelectErr<TOk, TErr, TSelection>(
+            this IEnumerable<Result<TOk, TErr>> self,
             Func<TErr, TSelection> selector)
             => self.SelectErr().Select(selector);
 
@@ -185,15 +163,9 @@ namespace Galaxus.Functional
         #region Match
 
         /// <summary>
-        ///     An overload for <see cref="Result{A, B}.Match{C}" /> using async functions.
+        ///     Async overload for <see cref="Result{TOk,TErr}.Match"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="onOk"></param>
-        /// <param name="onErr"></param>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <typeparam name="TResult"></typeparam>
-        /// <returns></returns>
+        /// <inheritdoc cref="Result{TOk,TErr}.Match"/>
         public static async Task<TResult> MatchAsync<TOk, TErr, TResult>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, Task<TResult>> onOk,
@@ -203,15 +175,9 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///     An overload for <see cref="Result{A, B}.Match{C}" /> using async functions.
+        ///     Async overload for <see cref="Result{TOk,TErr}.Match"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="onOk"></param>
-        /// <param name="onErr"></param>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <typeparam name="TResult"></typeparam>
-        /// <returns></returns>
+        /// <inheritdoc cref="Result{TOk,TErr}.Match"/>
         public static async Task<TResult> MatchAsync<TOk, TErr, TResult>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, TResult> onOk,
@@ -221,15 +187,9 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///     An overload for <see cref="Result{A, B}.Match{C}" /> using async functions.
+        ///     Async overload for <see cref="Result{TOk,TErr}.Match"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="onOk"></param>
-        /// <param name="onErr"></param>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <typeparam name="TResult"></typeparam>
-        /// <returns></returns>
+        /// <inheritdoc cref="Result{TOk,TErr}.Match"/>
         public static async Task<TResult> MatchAsync<TOk, TErr, TResult>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, Task<TResult>> onOk,
@@ -239,15 +199,9 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///     An overload for <see cref="Result{A, B}.Match{C}" /> using async functions.
+        ///     Async overload for <see cref="Result{TOk,TErr}.Match"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="onOk"></param>
-        /// <param name="onErr"></param>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <typeparam name="TResult"></typeparam>
-        /// <returns></returns>
+        /// <inheritdoc cref="Result{TOk,TErr}.Match"/>
         public static async Task<TResult> MatchAsync<TOk, TErr, TResult>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, TResult> onOk,
@@ -257,16 +211,9 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///     An overload for <see cref="Result{A, B}.Match{C}" /> using async functions.
+        ///     Async overload for <see cref="Result{TOk,TErr}.Match"/>, producing another result.
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="onOk"></param>
-        /// <param name="onErr"></param>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <typeparam name="TOkResult"></typeparam>
-        /// <typeparam name="TErrResult"></typeparam>
-        /// <returns></returns>
+        /// <inheritdoc cref="Result{TOk,TErr}.Match"/>
         public static async Task<Result<TOkResult, TErrResult>> MatchResultAsync<TOk, TErr, TOkResult, TErrResult>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, Task<TOkResult>> onOk,
@@ -278,16 +225,9 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///     An overload for <see cref="Result{A, B}.Match{C}" /> using async functions.
+        ///     Async overload for <see cref="Result{TOk,TErr}.Match"/>, producing another result.
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="onOk"></param>
-        /// <param name="onErr"></param>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <typeparam name="TOkResult"></typeparam>
-        /// <typeparam name="TErrResult"></typeparam>
-        /// <returns></returns>
+        /// <inheritdoc cref="Result{TOk,TErr}.Match"/>
         public static async Task<Result<TOkResult, TErrResult>> MatchResultAsync<TOk, TErr, TOkResult, TErrResult>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, Task<Result<TOkResult, TErrResult>>> onOk,
@@ -303,18 +243,9 @@ namespace Galaxus.Functional
         #region AndThen
 
         /// <summary>
-        ///     Calls <paramref name="continuation" /> if <b>self</b> contains <b>Ok</b>, otherwise returns the <b>Err</b> value
-        ///     contained in <b>self</b>.
-        ///     This function can be used for control flow based on <see cref="Result{TOk, TErr}" />s.
+        ///     Async overload for <see cref="Result{TOk,TErr}.AndThen{TContinuationOk}"/>
         /// </summary>
-        /// <typeparam name="TContinuationOk">
-        ///     The <b>Ok</b> type of the <paramref name="continuation" />'s
-        ///     <see cref="Result{TOk, TErr}" />.
-        /// </typeparam>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <param name="self"></param>
-        /// <param name="continuation">The function to call if <b>self</b> contains <b>Ok</b>.</param>
+        /// <inheritdoc cref="Result{TOk,TErr}.AndThen{TContinuationOk}"/>
         public static async Task<Result<TContinuationOk, TErr>> AndThenAsync<TOk, TErr, TContinuationOk>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, Task<Result<TContinuationOk, TErr>>> continuation)
@@ -323,18 +254,9 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///     Calls <paramref name="continuation" /> if <b>self</b> contains <b>Ok</b>, otherwise returns the <b>Err</b> value
-        ///     contained in <b>self</b>.
-        ///     This function can be used for control flow based on <see cref="Result{TOk, TErr}" />s.
+        ///     Async overload for <see cref="Result{TOk,TErr}.AndThen{TContinuationOk}"/>
         /// </summary>
-        /// <typeparam name="TContinuationOk">
-        ///     The <b>Ok</b> type of the <paramref name="continuation" />'s
-        ///     <see cref="Result{TOk, TErr}" />.
-        /// </typeparam>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <param name="self"></param>
-        /// <param name="continuation">The function to call if <b>self</b> contains <b>Ok</b>.</param>
+        /// <inheritdoc cref="Result{TOk,TErr}.AndThen{TContinuationOk}"/>
         public static Task<Result<TContinuationOk, TErr>> AndThenAsync<TOk, TErr, TContinuationOk>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, Result<TContinuationOk, TErr>> continuation)
@@ -347,17 +269,9 @@ namespace Galaxus.Functional
         #region Or
 
         /// <summary>
-        ///     Calls <paramref name="continuation" /> if <b>self</b> contains <b>Err</b>, otherwise returns the <b>Ok</b> value
-        ///     contained in <b>self</b>.
-        ///     This function can be used for control flow based on <see cref="Result{TOk, TErr}" />s.
+        ///     Async overload for <see cref="Result{TOk,TErr}.OrElse{TContinuationErr}"/>
         /// </summary>
-        /// <typeparam name="TContinuationErr">
-        ///     The <b>Error</b> type of the <paramref name="continuation" />'s
-        ///     <see cref="Result{TOk, TErr}" />.
-        /// </typeparam>
-        /// <typeparam name="TOk"></typeparam>
-        /// <param name="self"></param>
-        /// <param name="continuation">The function to call if <b>self</b> contains <b>Err</b>.</param>
+        /// <inheritdoc cref="Result{TOk,TErr}.OrElse{TContinuationErr}"/>
         public static async Task<Result<TOk, TContinuationErr>> OrElseAsync<TOk, TContinuationErr>(
             this Task<Result<TOk, TContinuationErr>> self,
             Func<TContinuationErr, Task<Result<TOk, TContinuationErr>>> continuation)
@@ -366,17 +280,9 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///     Calls <paramref name="continuation" /> if <b>self</b> contains <b>Err</b>, otherwise returns the <b>Ok</b> value
-        ///     contained in <b>self</b>.
-        ///     This function can be used for control flow based on <see cref="Result{TOk, TErr}" />s.
+        ///     Async overload for <see cref="Result{TOk,TErr}.OrElse{TContinuationErr}"/>
         /// </summary>
-        /// <typeparam name="TContinuationErr">
-        ///     The <b>Error</b> type of the <paramref name="continuation" />'s
-        ///     <see cref="Result{TOk, TErr}" />.
-        /// </typeparam>
-        /// <typeparam name="TOk"></typeparam>
-        /// <param name="self"></param>
-        /// <param name="continuation">The function to call if <b>self</b> contains <b>Err</b>.</param>
+        /// <inheritdoc cref="Result{TOk,TErr}.OrElse{TContinuationErr}"/>
         public static Task<Result<TOk, TContinuationErr>> OrElseAsync<TOk, TContinuationErr>(
             this Task<Result<TOk, TContinuationErr>> self,
             Func<TContinuationErr, Result<TOk, TContinuationErr>> continuation)
@@ -389,60 +295,31 @@ namespace Galaxus.Functional
         #region UnwrapAsync
 
         /// <summary>
-        ///     Unwraps asynchronous <b>self</b> and returns <b>Ok</b>.
-        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        ///     Async overload for <see cref="Result{TOk,TErr}.Unwrap()"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <returns>
-        ///     <b>self</b>
-        /// </returns>
-        public static async Task<TOk> UnwrapAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self) =>
-            (await self).Unwrap();
-
+        /// <inheritdoc cref="Result{TOk,TErr}.Unwrap()"/>
+        public static async Task<TOk> UnwrapAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self)
+            => (await self).Unwrap();
 
         /// <summary>
-        ///     Unwraps asynchronous <b>self</b> and returns <b>Ok</b>.
-        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        ///     Async overload for <see cref="Result{TOk,TErr}.Unwrap(string)"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="error">
-        ///     A custom error to use as the exception message.
-        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
-        ///     it is recommended to use <see cref="Result{TOk, TErr}.Unwrap(Func{TErr, string})" />, which is lazily evaluated.
-        /// </param>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <returns>
-        ///     <b>self</b>
-        /// </returns>
-        public static async Task<TOk> UnwrapAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, string error) =>
-            (await self).Unwrap(error);
+        /// <inheritdoc cref="Result{TOk,TErr}.Unwrap(string)"/>
+        public static async Task<TOk> UnwrapAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, string error)
+            => (await self).Unwrap(error);
 
         /// <summary>
-        ///     Unwraps <b>self</b> and returns <b>Ok</b>.
-        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        ///     Async overload for <see cref="Result{TOk,TErr}.Unwrap(Func{TErr, string})"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="error">A function that returns a custom error to use as the exception message.</param>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <returns></returns>
-        public static async Task<TOk> UnwrapAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self,
-            Func<TErr, string> error) => (await self).Unwrap(error);
+        /// <inheritdoc cref="Result{TOk,TErr}.Unwrap(Func{TErr, string})"/>
+        public static async Task<TOk> UnwrapAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, Func<TErr, string> error)
+            => (await self).Unwrap(error);
 
         /// <summary>
-        ///     Unwraps <b>self</b> and returns <b>Ok</b>.
-        ///     <i>Throws if <b>self</b> contains <b>Err</b>!</i>
+        ///     Async overload for <see cref="Result{TOk,TErr}.Unwrap(Func{TErr, string})"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="error">A function that returns a custom error to use as the exception message.</param>
-        /// <typeparam name="TOk"></typeparam>
-        /// <typeparam name="TErr"></typeparam>
-        /// <returns></returns>
-        public static async Task<TOk> UnwrapAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self,
-            Func<TErr, Task<string>> error)
+        /// <inheritdoc cref="Result{TOk,TErr}.Unwrap(Func{TErr, string})"/>
+        public static async Task<TOk> UnwrapAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, Func<TErr, Task<string>> error)
         {
             var res = await self;
             if (res.IsErr)
@@ -457,55 +334,31 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
-        ///     Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns <paramref name="fallback" />
-        ///     otherwise.
+        ///     Async overload for <see cref="Result{TOk,TErr}.UnwrapOr"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="fallback">
-        ///     The value to return if <b>self</b> contains <b>Err</b>.
-        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
-        ///     it is recommended to use
-        ///     <see
-        ///         cref="UnwrapOrElseAsync{TOk,TErr}(System.Threading.Tasks.Task{Galaxus.Functional.Result{TOk,TErr}},System.Func{TOk})" />
-        ///     , which is lazily evaluated.
-        /// </param>
-        public static async Task<TOk> UnwrapOrAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, TOk fallback) =>
-            (await self).UnwrapOr(fallback);
+        /// <inheritdoc cref="Result{TOk,TErr}.UnwrapOr"/>
+        public static async Task<TOk> UnwrapOrAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, TOk fallback)
+            => (await self).UnwrapOr(fallback);
 
         /// <summary>
-        ///     Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns <paramref name="fallback" />
-        ///     otherwise.
+        ///     Async overload for <see cref="Result{TOk,TErr}.UnwrapOr"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="fallback">
-        ///     The value to return if <b>self</b> contains <b>Err</b>.
-        ///     This argument is eagerly evaluated; if you are passing the result of a function call,
-        ///     it is recommended to use
-        ///     <see
-        ///         cref="UnwrapOrElseAsync{TOk,TErr}(System.Threading.Tasks.Task{Galaxus.Functional.Result{TOk,TErr}},System.Func{TOk})" />
-        ///     , which is lazily evaluated.
-        /// </param>
-        public static async Task<TOk> UnwrapOrAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, Task<TOk> fallback) =>
-            (await self).UnwrapOr(await fallback);
+        /// <inheritdoc cref="Result{TOk,TErr}.UnwrapOr"/>
+        public static async Task<TOk> UnwrapOrAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, Task<TOk> fallback)
+            => (await self).UnwrapOr(await fallback);
 
         /// <summary>
-        ///     Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns the result of
-        ///     <paramref name="fallback" /> otherwise.
+        ///     Async overload for <see cref="Result{TOk,TErr}.UnwrapOrElse"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="fallback">The function to call if <b>self</b> contains <b>Err</b>.</param>
-        public static async Task<TOk> UnwrapOrElseAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self,
-            Func<TOk> fallback) =>
-            (await self).UnwrapOrElse(fallback);
+        /// <inheritdoc cref="Result{TOk,TErr}.UnwrapOrElse"/>
+        public static async Task<TOk> UnwrapOrElseAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, Func<TOk> fallback)
+            => (await self).UnwrapOrElse(fallback);
 
         /// <summary>
-        ///     Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns the result of
-        ///     <paramref name="fallback" /> otherwise.
+        ///     Async overload for <see cref="Result{TOk,TErr}.UnwrapOrElse"/>
         /// </summary>
-        /// <param name="self"></param>
-        /// <param name="fallback">The function to call if <b>self</b> contains <b>Err</b>.</param>
-        public static async Task<TOk> UnwrapOrElseAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self,
-            Func<Task<TOk>> fallback)
+        /// <inheritdoc cref="Result{TOk,TErr}.UnwrapOrElse"/>
+        public static async Task<TOk> UnwrapOrElseAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, Func<Task<TOk>> fallback)
         {
             var res = await self;
             if (res.IsOk)
@@ -517,11 +370,10 @@ namespace Galaxus.Functional
             return await fallback();
         }
 
-
         /// <summary>
-        ///     Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns the default value of
-        ///     <typeparamref name="TOk" /> otherwise.
+        ///     Async overload for <see cref="Result{TOk,TErr}.UnwrapOrDefault"/>
         /// </summary>
+        /// <inheritdoc cref="Result{TOk,TErr}.UnwrapOrDefault"/>
         public static async Task<TOk> UnwrapOrDefaultAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self)
             => (await self).UnwrapOrDefault();
 

--- a/Galaxus.Functional/(Result)/ResultExtensions.cs
+++ b/Galaxus.Functional/(Result)/ResultExtensions.cs
@@ -185,6 +185,7 @@ namespace Galaxus.Functional
         #region Match
 
         /// <summary>
+        ///     An overload for <see cref="Result{A, B}.Match{C}" /> using async functions.
         /// </summary>
         /// <param name="self"></param>
         /// <param name="onOk"></param>
@@ -202,6 +203,7 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
+        ///     An overload for <see cref="Result{A, B}.Match{C}" /> using async functions.
         /// </summary>
         /// <param name="self"></param>
         /// <param name="onOk"></param>
@@ -219,6 +221,7 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
+        ///     An overload for <see cref="Result{A, B}.Match{C}" /> using async functions.
         /// </summary>
         /// <param name="self"></param>
         /// <param name="onOk"></param>
@@ -236,6 +239,7 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
+        ///     An overload for <see cref="Result{A, B}.Match{C}" /> using async functions.
         /// </summary>
         /// <param name="self"></param>
         /// <param name="onOk"></param>
@@ -253,6 +257,7 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
+        ///     An overload for <see cref="Result{A, B}.Match{C}" /> using async functions.
         /// </summary>
         /// <param name="self"></param>
         /// <param name="onOk"></param>
@@ -273,6 +278,7 @@ namespace Galaxus.Functional
         }
 
         /// <summary>
+        ///     An overload for <see cref="Result{A, B}.Match{C}" /> using async functions.
         /// </summary>
         /// <param name="self"></param>
         /// <param name="onOk"></param>

--- a/Galaxus.Functional/(Result)/ResultExtensions.cs
+++ b/Galaxus.Functional/(Result)/ResultExtensions.cs
@@ -5,6 +5,9 @@ using System.Threading.Tasks;
 
 namespace Galaxus.Functional
 {
+    /// <summary>
+    /// Extensions for the result type, providing some quality of life-shorthands.
+    /// </summary>
     public static class ResultExtensions
     {
         #region Instance Initializer
@@ -64,6 +67,9 @@ namespace Galaxus.Functional
         /// leaving an <b>Err</b> value untouched. This function can be used to compose the results of two functions.
         /// </summary>
         /// <typeparam name="TOkTo">The type to map <b>Ok</b> to.</typeparam>
+        /// <typeparam name="TOk"></typeparam>
+        /// <typeparam name="TErr"></typeparam>
+        /// <param name="self"></param>
         /// <param name="continuation">The mapping function.</param>
         public static async Task<Result<TOkTo, TErr>> MapAsync<TOk, TErr, TOkTo>(
             this Task<Result<TOk, TErr>> self,
@@ -77,6 +83,9 @@ namespace Galaxus.Functional
         /// leaving an <b>Err</b> value untouched. This function can be used to compose the results of two functions.
         /// </summary>
         /// <typeparam name="TOkTo">The type to map <b>Ok</b> to.</typeparam>
+        /// <typeparam name="TOk"></typeparam>
+        /// <typeparam name="TErr"></typeparam>
+        /// <param name="self"></param>
         /// <param name="continuation">The mapping function.</param>
         public static Task<Result<TOkTo, TErr>> MapAsync<TOk, TErr, TOkTo>(
             this Task<Result<TOk, TErr>> self,
@@ -90,6 +99,9 @@ namespace Galaxus.Functional
         /// leaving an <b>Ok</b> value untouched. This function can be used to compose the results of two functions.
         /// </summary>
         /// <typeparam name="TErrTo">The type to map "Err" to.</typeparam>
+        /// <typeparam name="TOk"></typeparam>
+        /// <typeparam name="TErr"></typeparam>
+        /// <param name="self"></param>
         /// <param name="continuation">The mapping function.</param>
         public static async Task<Result<TOk, TErrTo>> MapErrAsync<TOk, TErr, TErrTo>(
             this Task<Result<TOk, TErr>> self,
@@ -103,6 +115,9 @@ namespace Galaxus.Functional
         /// leaving an <b>Ok</b> value untouched. This function can be used to compose the results of two functions.
         /// </summary>
         /// <typeparam name="TErrTo">The type to map "Err" to.</typeparam>
+        /// <typeparam name="TOk"></typeparam>
+        /// <typeparam name="TErr"></typeparam>
+        /// <param name="self"></param>
         /// <param name="continuation">The mapping function.</param>
         public static Task<Result<TOk, TErrTo>> MapErrAsync<TOk, TErr, TErrTo>(
             this Task<Result<TOk, TErr>> self,
@@ -145,6 +160,16 @@ namespace Galaxus.Functional
 
         #region Match
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="onOk"></param>
+        /// <param name="onErr"></param>
+        /// <typeparam name="TOk"></typeparam>
+        /// <typeparam name="TErr"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <returns></returns>
         public static async Task<TResult> MatchAsync<TOk, TErr, TResult>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, Task<TResult>> onOk,
@@ -153,6 +178,16 @@ namespace Galaxus.Functional
             return await (await self).MatchAsync(onOk, onErr);
         }
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="onOk"></param>
+        /// <param name="onErr"></param>
+        /// <typeparam name="TOk"></typeparam>
+        /// <typeparam name="TErr"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <returns></returns>
         public static async Task<TResult> MatchAsync<TOk, TErr, TResult>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, TResult> onOk,
@@ -161,6 +196,16 @@ namespace Galaxus.Functional
             return (await self).Match(onOk, onErr);
         }
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="onOk"></param>
+        /// <param name="onErr"></param>
+        /// <typeparam name="TOk"></typeparam>
+        /// <typeparam name="TErr"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <returns></returns>
         public static async Task<TResult> MatchAsync<TOk, TErr, TResult>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, Task<TResult>> onOk,
@@ -169,6 +214,16 @@ namespace Galaxus.Functional
             return await (await self).MatchAsync(onOk, onErr);
         }
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="onOk"></param>
+        /// <param name="onErr"></param>
+        /// <typeparam name="TOk"></typeparam>
+        /// <typeparam name="TErr"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <returns></returns>
         public static async Task<TResult> MatchAsync<TOk, TErr, TResult>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, TResult> onOk,
@@ -177,6 +232,17 @@ namespace Galaxus.Functional
             return await (await self).MatchAsync(onOk, onErr);
         }
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="onOk"></param>
+        /// <param name="onErr"></param>
+        /// <typeparam name="TOk"></typeparam>
+        /// <typeparam name="TErr"></typeparam>
+        /// <typeparam name="TOkResult"></typeparam>
+        /// <typeparam name="TErrResult"></typeparam>
+        /// <returns></returns>
         public static async Task<Result<TOkResult, TErrResult>> MatchResultAsync<TOk, TErr, TOkResult, TErrResult>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, Task<TOkResult>> onOk,
@@ -187,6 +253,17 @@ namespace Galaxus.Functional
                 async err => Result<TOkResult, TErrResult>.FromErr(await onErr(err)));
         }
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="onOk"></param>
+        /// <param name="onErr"></param>
+        /// <typeparam name="TOk"></typeparam>
+        /// <typeparam name="TErr"></typeparam>
+        /// <typeparam name="TOkResult"></typeparam>
+        /// <typeparam name="TErrResult"></typeparam>
+        /// <returns></returns>
         public static async Task<Result<TOkResult, TErrResult>> MatchResultAsync<TOk, TErr, TOkResult, TErrResult>(
             this Task<Result<TOk, TErr>> self,
             Func<TOk, Task<Result<TOkResult, TErrResult>>> onOk,
@@ -206,6 +283,9 @@ namespace Galaxus.Functional
         /// This function can be used for control flow based on <see cref="Result{TOk, TErr}"/>s.
         /// </summary>
         /// <typeparam name="TContinuationOk">The <b>Ok</b> type of the <paramref name="continuation"/>'s <see cref="Result{TOk, TErr}"/>.</typeparam>
+        /// <typeparam name="TOk"></typeparam>
+        /// <typeparam name="TErr"></typeparam>
+        /// <param name="self"></param>
         /// <param name="continuation">The function to call if <b>self</b> contains <b>Ok</b>.</param>
         public static async Task<Result<TContinuationOk, TErr>> AndThenAsync<TOk, TErr, TContinuationOk>(
             this Task<Result<TOk, TErr>> self,
@@ -219,6 +299,9 @@ namespace Galaxus.Functional
         /// This function can be used for control flow based on <see cref="Result{TOk, TErr}"/>s.
         /// </summary>
         /// <typeparam name="TContinuationOk">The <b>Ok</b> type of the <paramref name="continuation"/>'s <see cref="Result{TOk, TErr}"/>.</typeparam>
+        /// <typeparam name="TOk"></typeparam>
+        /// <typeparam name="TErr"></typeparam>
+        /// <param name="self"></param>
         /// <param name="continuation">The function to call if <b>self</b> contains <b>Ok</b>.</param>
         public static Task<Result<TContinuationOk, TErr>> AndThenAsync<TOk, TErr, TContinuationOk>(
             this Task<Result<TOk, TErr>> self,
@@ -236,6 +319,8 @@ namespace Galaxus.Functional
         /// This function can be used for control flow based on <see cref="Result{TOk, TErr}"/>s.
         /// </summary>
         /// <typeparam name="TContinuationErr">The <b>Error</b> type of the <paramref name="continuation"/>'s <see cref="Result{TOk, TErr}"/>.</typeparam>
+        /// <typeparam name="TOk"></typeparam>
+        /// <param name="self"></param>
         /// <param name="continuation">The function to call if <b>self</b> contains <b>Err</b>.</param>
         public static async Task<Result<TOk, TContinuationErr>> OrElseAsync<TOk, TContinuationErr>(
             this Task<Result<TOk, TContinuationErr>> self,
@@ -249,6 +334,8 @@ namespace Galaxus.Functional
         /// This function can be used for control flow based on <see cref="Result{TOk, TErr}"/>s.
         /// </summary>
         /// <typeparam name="TContinuationErr">The <b>Error</b> type of the <paramref name="continuation"/>'s <see cref="Result{TOk, TErr}"/>.</typeparam>
+        /// <typeparam name="TOk"></typeparam>
+        /// <param name="self"></param>
         /// <param name="continuation">The function to call if <b>self</b> contains <b>Err</b>.</param>
         public static Task<Result<TOk, TContinuationErr>> OrElseAsync<TOk, TContinuationErr>(
             this Task<Result<TOk, TContinuationErr>> self,
@@ -278,13 +365,13 @@ namespace Galaxus.Functional
         /// <i>Throws if <b>self</b> contains <b>Err</b>!</i>
         /// </summary>
         /// <param name="self"></param>
-        /// <param name="error"></param>
-        /// <typeparam name="TOk"></typeparam>
         /// <param name="error">
         /// A custom error to use as the exception message.
         /// This argument is eagerly evaluated; if you are passing the result of a function call,
-        /// it is recommended to use <see cref="Unwrap(Func{TErr, string})"/>, which is lazily evaluated.
+        /// it is recommended to use <see cref="Result{TOk, TErr}.Unwrap(Func{TErr, string})"/>, which is lazily evaluated.
         /// </param>
+        /// <typeparam name="TOk"></typeparam>
+        /// <typeparam name="TErr"></typeparam>
         /// <returns><b>self</b></returns>
         public static async Task<TOk> UnwrapAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, string error) =>
             (await self).Unwrap(error);
@@ -300,7 +387,7 @@ namespace Galaxus.Functional
         /// <returns></returns>
         public static async Task<TOk> UnwrapAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self,
             Func<TErr, string> error) => (await self).Unwrap(error);
-        
+
         /// <summary>
         /// Unwraps <b>self</b> and returns <b>Ok</b>.
         /// <i>Throws if <b>self</b> contains <b>Err</b>!</i>
@@ -336,7 +423,7 @@ namespace Galaxus.Functional
         /// </param>
         public static async Task<TOk> UnwrapOrAsync<TOk, TErr>(this Task<Result<TOk, TErr>> self, TOk fallback) =>
             (await self).UnwrapOr(fallback);
-        
+
         /// <summary>
         /// Unwraps <b>self</b> and returns <b>Ok</b> if <b>self</b> contains <b>Ok</b>. Returns <paramref name="fallback"/> otherwise.
         /// </summary>

--- a/Galaxus.Functional/(Unit)/Unit.cs
+++ b/Galaxus.Functional/(Unit)/Unit.cs
@@ -3,30 +3,40 @@ using System;
 namespace Galaxus.Functional
 {
     /// <summary>
-    /// The <see cref="Unit"/> type has exactly one value, and is used when there is no other meaningful value that could be used.
-    /// It is most commonly seen in combination with <see cref="Result{TOk, TErr}"/>s which indicate failure but do not return a meaningful error.
+    ///     The <see cref="Unit" /> type has exactly one value, and is used when there is no other meaningful value that could
+    ///     be used.
+    ///     It is most commonly seen in combination with <see cref="Result{TOk, TErr}" />s which indicate failure but do not
+    ///     return a meaningful error.
     /// </summary>
     public struct Unit : IEquatable<Unit>
     {
         /// <summary>
-        /// The unit value.
+        ///     The unit value.
         /// </summary>
         public static readonly Unit Value = default;
 
         /// <inheritdoc />
         public override bool Equals(object other)
-            => other is Unit;
+        {
+            return other is Unit;
+        }
 
         /// <inheritdoc />
         public bool Equals(Unit obj)
-            => true;
+        {
+            return true;
+        }
 
         /// <inheritdoc />
         public override int GetHashCode()
-            => -1;
+        {
+            return -1;
+        }
 
         /// <inheritdoc />
         public override string ToString()
-            => "()";
+        {
+            return "()";
+        }
     }
 }

--- a/Galaxus.Functional/Galaxus.Functional.csproj
+++ b/Galaxus.Functional/Galaxus.Functional.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <WarningsAsErrors />
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <WarningsAsErrors/>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
 </Project>

--- a/Galaxus.Functional/Linq/OptionLinqExtensions.cs
+++ b/Galaxus.Functional/Linq/OptionLinqExtensions.cs
@@ -50,8 +50,7 @@ namespace Galaxus.Functional.Linq
         ///     <c>predicate</c>; otherwise, the first element in <c>source</c> that passes the test specified by <c>predicate</c>.
         /// </returns>
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
-        public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source,
-            Func<TSource, bool> predicate)
+        public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
             => source
                 .Where(predicate)
                 .Select(Option<TSource>.Some)
@@ -82,8 +81,7 @@ namespace Galaxus.Functional.Linq
         ///     function; otherwise, the last element that passes the test in the predicate function.
         /// </returns>
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
-        public static Option<TSource> LastOrNone<TSource>(this IEnumerable<TSource> source,
-            Func<TSource, bool> predicate)
+        public static Option<TSource> LastOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
             => source
                 .Where(predicate)
                 .Select(Option<TSource>.Some)
@@ -114,11 +112,10 @@ namespace Galaxus.Functional.Linq
         /// <typeparam name="TSource">The type of the elements of <c>source</c>.</typeparam>
         /// <param name="source">An <see cref="IEnumerable{T}" /> to return a single element from.</param>
         /// <param name="predicate">A function to test an element for a condition.</param>
-        /// <returns></returns>
+        /// <returns>The only element matching the <paramref name="predicate"/> or <see cref="None"/>.</returns>
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException">More than one element satisfies the condition in <c>source</c>.</exception>
-        public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source,
-            Func<TSource, bool> predicate)
+        public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
             => source
                 .Where(predicate)
                 .Select(Option<TSource>.Some)
@@ -131,9 +128,7 @@ namespace Galaxus.Functional.Linq
         /// <param name="source">The dictionary in question</param>
         /// <param name="key">The key to check if a value exists</param>
         /// <returns>The value of the dictionary or None</returns>
-        public static Option<TSome> GetValueOrNone<TKey, TSome>(
-            this IEnumerable<KeyValuePair<TKey, TSome>> source,
-            TKey key)
+        public static Option<TSome> GetValueOrNone<TKey, TSome>(this IEnumerable<KeyValuePair<TKey, TSome>> source, TKey key)
         {
             switch (source)
             {

--- a/Galaxus.Functional/Linq/OptionLinqExtensions.cs
+++ b/Galaxus.Functional/Linq/OptionLinqExtensions.cs
@@ -50,7 +50,8 @@ namespace Galaxus.Functional.Linq
         ///     <c>predicate</c>; otherwise, the first element in <c>source</c> that passes the test specified by <c>predicate</c>.
         /// </returns>
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
-        public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
+        public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source,
+            Func<TSource, bool> predicate)
             => source
                 .Where(predicate)
                 .Select(Option<TSource>.Some)
@@ -124,8 +125,8 @@ namespace Galaxus.Functional.Linq
                 .SingleOrDefault();
 
         /// <summary>
-        /// Checks a dictionary if it contains a value for a given key. If so this value is wrapped in an Option.
-        /// Else <see cref="Option{T}.None"/> is returned.
+        ///     Checks a dictionary if it contains a value for a given key. If so this value is wrapped in an Option.
+        ///     Else <see cref="Option{T}.None" /> is returned.
         /// </summary>
         /// <param name="source">The dictionary in question</param>
         /// <param name="key">The key to check if a value exists</param>

--- a/Galaxus.Functional/Linq/OptionLinqExtensions.cs
+++ b/Galaxus.Functional/Linq/OptionLinqExtensions.cs
@@ -22,9 +22,11 @@ namespace Galaxus.Functional.Linq
         /// </returns>
         /// <exception cref="ArgumentNullException"><c>source</c> is <c>null</c>.</exception>
         public static Option<TSource> ElementAtOrNone<TSource>(this IEnumerable<TSource> source, int index)
-            => source
+        {
+            return source
                 .Select(Option<TSource>.Some)
                 .ElementAtOrDefault(index);
+        }
 
         /// <summary>
         ///     Returns the first element of the sequence that satisfies a condition or <see cref="Option{T}.None" /> if the
@@ -36,7 +38,9 @@ namespace Galaxus.Functional.Linq
         ///     <c><see cref="Option{T}" />.None</c> if <c>source</c> is empty; otherwise, the first element in <c>source</c>.
         /// </returns>
         public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source)
-            => source.FirstOrNone(True);
+        {
+            return source.FirstOrNone(True);
+        }
 
         /// <summary>
         ///     Returns the first element of the sequence that satisfies a condition or <see cref="Option{T}.None" /> if the
@@ -51,10 +55,12 @@ namespace Galaxus.Functional.Linq
         /// </returns>
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
         public static Option<TSource> FirstOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
-            => source
+        {
+            return source
                 .Where(predicate)
                 .Select(Option<TSource>.Some)
                 .FirstOrDefault();
+        }
 
         /// <summary>
         ///     Returns the last element of a sequence, or <see cref="Option{T}.None" /> if the sequence contains no elements.
@@ -67,7 +73,9 @@ namespace Galaxus.Functional.Linq
         /// </returns>
         /// <exception cref="ArgumentNullException"><c>source</c> is <c>null</c>.</exception>
         public static Option<TSource> LastOrNone<TSource>(this IEnumerable<TSource> source)
-            => source.LastOrNone(True);
+        {
+            return source.LastOrNone(True);
+        }
 
         /// <summary>
         ///     Returns the last element of a sequence that satisfies a condition or <see cref="Option{T}.None" /> if no such
@@ -82,10 +90,12 @@ namespace Galaxus.Functional.Linq
         /// </returns>
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
         public static Option<TSource> LastOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
-            => source
+        {
+            return source
                 .Where(predicate)
                 .Select(Option<TSource>.Some)
                 .LastOrDefault();
+        }
 
         /// <summary>
         ///     Returns the only element of a sequence, or <see cref="Option{T}.None" /> if the sequence is empty; this method
@@ -103,7 +113,9 @@ namespace Galaxus.Functional.Linq
         /// <exception cref="ArgumentNullException"><c>source</c> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException">The input sequence contains more than one element.</exception>
         public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source)
-            => source.SingleOrNone(True);
+        {
+            return source.SingleOrNone(True);
+        }
 
         /// <summary>
         ///     Returns the only element of a sequence that satisfies a specified condition or <see cref="Option{T}.None" /> if no
@@ -116,10 +128,12 @@ namespace Galaxus.Functional.Linq
         /// <exception cref="ArgumentNullException"><c>source</c> or <c>predicate</c> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException">More than one element satisfies the condition in <c>source</c>.</exception>
         public static Option<TSource> SingleOrNone<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
-            => source
+        {
+            return source
                 .Where(predicate)
                 .Select(Option<TSource>.Some)
                 .SingleOrDefault();
+        }
 
         /// <summary>
         ///     Checks a dictionary if it contains a value for a given key. If so this value is wrapped in an Option.
@@ -145,6 +159,8 @@ namespace Galaxus.Functional.Linq
 
         // This probably should be defined publicly together with False and Identity
         private static bool True<TSource>(TSource _)
-            => true;
+        {
+            return true;
+        }
     }
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) 2018-2021 Digitec Galaxus AG
-              2018-2021 Galaxus.Functional contributors (see https://github.com/DigitecGalaxus/Galaxus.Functional/graphs/contributors)
+Copyright (c) 2018-2022 Digitec Galaxus AG
+              2018-2022 Galaxus.Functional contributors (see https://github.com/DigitecGalaxus/Galaxus.Functional/graphs/contributors)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Introduction
 
-`Galaxus.Functional` is a package that aims to bring FP-style features to C#. Note though, that this is not true functional programming;
-this package contains some useful abstractions often found in functional languages.
+`Galaxus.Functional` is a package that aims to bring FP-style features to C#. Note though, that this is not true functional programming; this package
+contains some useful abstractions often found in functional languages.
 
 The style is greatly inspired by the way Rust does this. If you have worked with Rust's [std::option](https://doc.rust-lang.org/std/option/index.html)
 or [std::result](https://doc.rust-lang.org/std/result/index.html), you will probably feel right at home.
@@ -14,8 +14,8 @@ There currently are the following abstractions found inside `Galaxus.Functional`
 
 #### Option
 
-A type used to explicitly mark the presence or absence of a value. This is an alternative to checking for `null` and is similar to
-e.g. Haskell's `Maybe` or Java's `Optional`.
+A type used to explicitly mark the presence or absence of a value. This is an alternative to checking for `null` and is similar to e.g.
+Haskell's `Maybe` or Java's `Optional`.
 
 #### Unit
 
@@ -27,8 +27,8 @@ A type that can be one of several variants, sort of like a discriminated union o
 
 #### Result
 
-A type that explicitly propagates success or error to the caller, similar to used explicitly annotated exceptions. It can be seen
-as a specialization of an `Either` with the second variant being an error.
+A type that explicitly propagates success or error to the caller, similar to used explicitly annotated exceptions. It can be seen as a specialization
+of an `Either` with the second variant being an error.
 
 ## Contribute
 


### PR DESCRIPTION
Resolves #7 and #14 

I've crafted a (rather basic) .editorconfig from what I could gather. It's not perfect, it's not complete - but it's cross-IDE (no Rider, Resharper, Visual Studio or Visual Studio Code specific properties). I've let it run across all files - seems to work good enough.

At the same time, I've taken care of all the xml doc-warnings. In a lot of cases, I've just `<inheritdoc/>`'d the base documentation - most of the cases were async overloads.