### PR TITLE
[#24] Rename unwrapping-exceptions

### DIFF
--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/OptionLinqExtensionsTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/OptionLinqExtensionsTests.cs
@@ -51,7 +51,7 @@ public class OptionLinqExtensionsTests
         var composition = sequence.ElementAtOrNone(index);
 
         Assert.IsTrue(composition.IsSome);
-        Assert.Throws<AssertionException>(() => sequence.ToList());
+        Assert.Throws<AssertionException>(() => _ = sequence.ToList());
     }
 
     [Test]
@@ -93,7 +93,7 @@ public class OptionLinqExtensionsTests
         var composition = sequence.FirstOrNone();
 
         Assert.IsTrue(composition.IsSome);
-        Assert.Throws<AssertionException>(() => sequence.ToList());
+        Assert.Throws<AssertionException>(() => _ = sequence.ToList());
     }
 
     [Test]
@@ -169,11 +169,7 @@ public class OptionLinqExtensionsTests
     [Test]
     public void SingleOrNone_EmptyList_ReturnsNone()
     {
-        // ReSharper disable once CollectionNeverUpdated.Local
-        // This is intentional
-        var list4 = new List<int>();
-
-        var none = list4.SingleOrNone();
+        var none = new List<int>().SingleOrNone();
 
         Assert.IsTrue(none.IsNone);
     }
@@ -184,7 +180,7 @@ public class OptionLinqExtensionsTests
         var sequence = new YieldElementsThenFail<string>("Hello world", 2);
 
         Assert.Throws<InvalidOperationException>(() => sequence.SingleOrNone());
-        Assert.Throws<AssertionException>(() => sequence.ToList());
+        Assert.Throws<AssertionException>(() => _ = sequence.ToList());
     }
 
     [Test]
@@ -205,11 +201,8 @@ public class OptionLinqExtensionsTests
     [Test]
     public void GetValueOrNone_WithoutValue_ReturnsNone()
     {
-        // Arrange
-        var bestFriends = new Dictionary<string, string>();
-
         // Act
-        var bestFriendOrNone = bestFriends.GetValueOrNone("The Grinch");
+        var bestFriendOrNone = new Dictionary<string, string>().GetValueOrNone("The Grinch");
 
         // Assert
         Assert.That(bestFriendOrNone, Is.EqualTo(Option<string>.None));

--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/UnwrapAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/UnwrapAsyncTests.cs
@@ -32,7 +32,7 @@ public class UnwrapAsyncTests
         }
 
         // assert
-        Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(Act);
+        Assert.ThrowsAsync<TriedToUnwrapNoneException>(Act);
     }
 
     [Test]
@@ -90,7 +90,7 @@ public class UnwrapAsyncTests
         }
 
         // assert
-        Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(Act);
+        Assert.ThrowsAsync<TriedToUnwrapNoneException>(Act);
     }
 
     [Test]
@@ -151,7 +151,7 @@ public class UnwrapAsyncTests
             {
                 await none.UnwrapAsync("YOLO");
             }
-            catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
+            catch (TriedToUnwrapNoneException ex)
             {
                 Assert.AreEqual("YOLO", ex.Message);
                 throw;
@@ -159,7 +159,7 @@ public class UnwrapAsyncTests
         }
 
         // assert
-        Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(Act);
+        Assert.ThrowsAsync<TriedToUnwrapNoneException>(Act);
     }
 
     [Test]
@@ -228,7 +228,7 @@ public class UnwrapAsyncTests
                     return "YOLO";
                 });
             }
-            catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
+            catch (TriedToUnwrapNoneException ex)
             {
                 Assert.AreEqual("YOLO", ex.Message);
                 throw;
@@ -236,7 +236,7 @@ public class UnwrapAsyncTests
         }
 
         // assert
-        Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(Act);
+        Assert.ThrowsAsync<TriedToUnwrapNoneException>(Act);
         Assert.IsTrue(invoked);
     }
 
@@ -306,7 +306,7 @@ public class UnwrapAsyncTests
                     return await Task.FromResult("YOLO");
                 });
             }
-            catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
+            catch (TriedToUnwrapNoneException ex)
             {
                 Assert.AreEqual("YOLO", ex.Message);
                 throw;
@@ -314,7 +314,7 @@ public class UnwrapAsyncTests
         }
 
         // assert
-        Assert.ThrowsAsync<AttemptToUnwrapNoneWhenOptionContainedSomeException>(Act);
+        Assert.ThrowsAsync<TriedToUnwrapNoneException>(Act);
         Assert.IsTrue(invoked);
     }
 
@@ -551,7 +551,7 @@ public class UnwrapAsyncTests
         }
 
         // act
-        var hello = await some.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+        var hello = await some.UnwrapOrElseAsync(Continuation);
 
         // assert
         Assert.AreEqual("hello", hello);
@@ -569,7 +569,7 @@ public class UnwrapAsyncTests
         }
 
         // act
-        var world = await none.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+        var world = await none.UnwrapOrElseAsync(Continuation);
 
         // assert
         Assert.AreEqual("world", world);
@@ -587,7 +587,7 @@ public class UnwrapAsyncTests
         }
 
         // act
-        await someTask.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+        await someTask.UnwrapOrElseAsync(Continuation);
 
         // assert
         Assert.AreEqual(TaskStatus.RanToCompletion, someTask.Status);
@@ -607,7 +607,7 @@ public class UnwrapAsyncTests
         async Task Act()
         {
             await Task.FromException<Option<string>>(new ArgumentException())
-                .UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+                .UnwrapOrElseAsync(Continuation);
         }
 
         // assert
@@ -631,7 +631,7 @@ public class UnwrapAsyncTests
         }
 
         // act
-        var hello = await some.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+        var hello = await some.UnwrapOrElseAsync(Continuation);
 
         // assert
         Assert.AreEqual("hello", hello);
@@ -655,7 +655,7 @@ public class UnwrapAsyncTests
         }
 
         // act
-        var world = await none.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+        var world = await none.UnwrapOrElseAsync(Continuation);
 
         // assert
         Assert.AreEqual("world", world);

--- a/Galaxus.Functional.Tests/(Option)/OptionTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionTests.cs
@@ -63,14 +63,14 @@ public class OptionTests
 
         {
             var called = false;
-            some.Match(s => called = true, () => Assert.Fail());
+            some.Match(_ => called = true, Assert.Fail);
             Assert.IsTrue(called);
         }
 
         {
             var called = false;
 
-            var number = some.Match(s =>
+            var number = some.Match(_ =>
                 {
                     called = true;
                     return 666;
@@ -87,7 +87,7 @@ public class OptionTests
 
         {
             var called = false;
-            some.IfSome(s => called = true);
+            some.IfSome(_ => called = true);
             Assert.IsTrue(called);
         }
     }
@@ -99,14 +99,14 @@ public class OptionTests
 
         {
             var called = false;
-            none.Match(s => Assert.Fail(), () => called = true);
+            none.Match(_ => Assert.Fail(), () => called = true);
             Assert.IsTrue(called);
         }
 
         {
             var called = false;
 
-            var number = none.Match(s =>
+            var number = none.Match(_ =>
                 {
                     Assert.Fail();
                     throw new InvalidOperationException();
@@ -123,7 +123,7 @@ public class OptionTests
 
         {
             var called = false;
-            none.IfSome(s => called = true);
+            none.IfSome(_ => called = true);
             Assert.IsFalse(called);
         }
     }
@@ -136,7 +136,7 @@ public class OptionTests
         Assert.Throws<ArgumentNullException>(() => { 0.ToOption().IfSome(null); });
 
         // NONE
-        Assert.Throws<ArgumentNullException>(() => { Option<int>.None.Match(v => { }, null); });
+        Assert.Throws<ArgumentNullException>(() => { Option<int>.None.Match(_ => { }, null); });
 
         // SOME and NONE with return value
         Assert.Throws<ArgumentNullException>(() => { _ = 0.ToOption().Match(null, () => 0); });
@@ -496,7 +496,7 @@ public class OptionTests
     {
         Assert.AreEqual(true.ToString(), true.ToOption().Map(b => b.ToString()).Unwrap());
 
-        Assert.AreEqual(Option<string>.None, Option<string>.None.Map(b => "foobar"));
+        Assert.AreEqual(Option<string>.None, Option<string>.None.Map(_ => "foobar"));
 
         Assert.Throws<ArgumentNullException>(() => "Foobar".ToOption().Map<string>(null));
     }

--- a/Galaxus.Functional.Tests/(Option)/OptionTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionTests.cs
@@ -383,7 +383,7 @@ public class OptionTests
         var none = Option<string>.None;
 
         Assert.AreEqual("hello", some.Unwrap());
-        Assert.Throws<AttemptToUnwrapNoneWhenOptionContainedSomeException>(() => none.Unwrap());
+        Assert.Throws<TriedToUnwrapNoneException>(() => none.Unwrap());
     }
 
     [Test]
@@ -399,13 +399,13 @@ public class OptionTests
         var none = Option<string>.None;
 
         Assert.AreEqual("hello", some.Unwrap("YOLO"));
-        Assert.Throws<AttemptToUnwrapNoneWhenOptionContainedSomeException>(() =>
+        Assert.Throws<TriedToUnwrapNoneException>(() =>
         {
             try
             {
                 none.Unwrap("YOLO");
             }
-            catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
+            catch (TriedToUnwrapNoneException ex)
             {
                 Assert.AreEqual("YOLO", ex.Message);
                 throw;
@@ -430,7 +430,7 @@ public class OptionTests
         {
             var none = Option<string>.None;
             var invoked = false;
-            Assert.Throws<AttemptToUnwrapNoneWhenOptionContainedSomeException>(() =>
+            Assert.Throws<TriedToUnwrapNoneException>(() =>
             {
                 try
                 {
@@ -440,7 +440,7 @@ public class OptionTests
                         return "YOLO";
                     });
                 }
-                catch (AttemptToUnwrapNoneWhenOptionContainedSomeException ex)
+                catch (TriedToUnwrapNoneException ex)
                 {
                     Assert.AreEqual("YOLO", ex.Message);
                     throw;

--- a/Galaxus.Functional.Tests/(Result)/ResultExtensions/AndThenAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultExtensions/AndThenAsyncTests.cs
@@ -22,7 +22,7 @@ public class AndThenAsyncTests
         async Task Act()
         {
             await Task.FromException<Result<string, string>>(new ArgumentException())
-                .AndThenAsync((Func<string, Task<Result<string, string>>>)Continuation);
+                .AndThenAsync(Continuation);
         }
 
         // assert
@@ -48,7 +48,7 @@ public class AndThenAsyncTests
         async Task Act()
         {
             await Task.FromCanceled<Result<string, string>>(cancellationTokenSource.Token)
-                .AndThenAsync((Func<string, Task<Result<string, string>>>)Continuation);
+                .AndThenAsync(Continuation);
         }
 
         // assert
@@ -68,7 +68,7 @@ public class AndThenAsyncTests
         }
 
         var resultTask = Task.FromResult(Result<string, string>.FromOk(initialResult))
-            .AndThenAsync((Func<string, Result<string, string>>)Continuation);
+            .AndThenAsync(Continuation);
 
         // act
         await resultTask;

--- a/Galaxus.Functional.Tests/(Result)/ResultExtensions/MapAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultExtensions/MapAsyncTests.cs
@@ -20,7 +20,7 @@ public class MapAsyncTests
         }
 
         var resultTask = Task.FromResult(Result<string, string>.FromOk(initialResult))
-            .MapAsync((Func<string, string>)Continuation);
+            .MapAsync(Continuation);
 
         // act
         await resultTask;
@@ -44,7 +44,7 @@ public class MapAsyncTests
         async Task Act()
         {
             await Task.FromException<Result<string, string>>(new ArgumentException())
-                .MapAsync((Func<string, Task<string>>)Continuation);
+                .MapAsync(Continuation);
         }
 
         // assert
@@ -70,7 +70,7 @@ public class MapAsyncTests
         async Task Act()
         {
             await Task.FromCanceled<Result<string, string>>(cancellationTokenSource.Token)
-                .MapAsync((Func<string, Task<string>>)Continuation);
+                .MapAsync(Continuation);
         }
 
         // assert
@@ -90,7 +90,7 @@ public class MapAsyncTests
         }
 
         var resultTask = Task.FromResult(Result<string, string>.FromErr(initialResult))
-            .MapErrAsync((Func<string, string>)Continuation);
+            .MapErrAsync(Continuation);
 
         // act
         await resultTask;
@@ -114,7 +114,7 @@ public class MapAsyncTests
         async Task Act()
         {
             await Task.FromException<Result<string, string>>(new ArgumentException())
-                .MapErrAsync((Func<string, Task<string>>)Continuation);
+                .MapErrAsync(Continuation);
         }
 
         // assert
@@ -140,7 +140,7 @@ public class MapAsyncTests
         async Task Act()
         {
             await Task.FromCanceled<Result<string, string>>(cancellationTokenSource.Token)
-                .MapErrAsync((Func<string, Task<string>>)Continuation);
+                .MapErrAsync(Continuation);
         }
 
         // assert

--- a/Galaxus.Functional.Tests/(Result)/ResultExtensions/OrElseAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultExtensions/OrElseAsyncTests.cs
@@ -22,7 +22,7 @@ public class OrElseAsyncTests
         async Task Act()
         {
             await Task.FromException<Result<string, string>>(new ArgumentException())
-                .OrElseAsync((Func<string, Task<Result<string, string>>>)Continuation);
+                .OrElseAsync(Continuation);
         }
 
         // assert
@@ -48,7 +48,7 @@ public class OrElseAsyncTests
         async Task Act()
         {
             await Task.FromCanceled<Result<string, string>>(cancellationTokenSource.Token)
-                .OrElseAsync((Func<string, Task<Result<string, string>>>)Continuation);
+                .OrElseAsync(Continuation);
         }
 
         // assert
@@ -68,7 +68,7 @@ public class OrElseAsyncTests
         }
 
         var resultTask = Task.FromResult(Result<string, string>.FromErr(initialResult))
-            .OrElseAsync((Func<string, Result<string, string>>)Continuation);
+            .OrElseAsync(Continuation);
 
         // act
         await resultTask;

--- a/Galaxus.Functional.Tests/(Result)/ResultExtensions/UnwrapAsyncTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultExtensions/UnwrapAsyncTests.cs
@@ -32,7 +32,7 @@ public class UnwrapAsyncTests
         }
 
         // assert
-        Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(Act);
+        Assert.ThrowsAsync<TriedToUnwrapErrException>(Act);
     }
 
     [Test]
@@ -90,7 +90,7 @@ public class UnwrapAsyncTests
             {
                 await err.UnwrapAsync("YOLO");
             }
-            catch (AttemptToUnwrapErrWhenResultWasOkException ex)
+            catch (TriedToUnwrapErrException ex)
             {
                 Assert.AreEqual("YOLO", ex.Message);
                 throw;
@@ -98,7 +98,7 @@ public class UnwrapAsyncTests
         }
 
         // assert
-        Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(Act);
+        Assert.ThrowsAsync<TriedToUnwrapErrException>(Act);
     }
 
     [Test]
@@ -138,7 +138,7 @@ public class UnwrapAsyncTests
         var invoked = false;
 
         // act
-        var hello = await ok.UnwrapAsync(err =>
+        var hello = await ok.UnwrapAsync(_ =>
         {
             invoked = true;
             return "YOLO";
@@ -161,13 +161,13 @@ public class UnwrapAsyncTests
         {
             try
             {
-                await err.UnwrapAsync(e =>
+                await err.UnwrapAsync(_ =>
                 {
                     invoked = true;
                     return "YOLO";
                 });
             }
-            catch (AttemptToUnwrapErrWhenResultWasOkException ex)
+            catch (TriedToUnwrapErrException ex)
             {
                 Assert.AreEqual("YOLO", ex.Message);
                 throw;
@@ -175,7 +175,7 @@ public class UnwrapAsyncTests
         }
 
         // assert
-        Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(Act);
+        Assert.ThrowsAsync<TriedToUnwrapErrException>(Act);
         Assert.IsTrue(invoked);
     }
 
@@ -186,7 +186,7 @@ public class UnwrapAsyncTests
         var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
 
         // act
-        await okTask.UnwrapAsync(err => "Arthur Dent");
+        await okTask.UnwrapAsync(_ => "Arthur Dent");
 
         // assert
         Assert.AreEqual(TaskStatus.RanToCompletion, okTask.Status);
@@ -201,7 +201,7 @@ public class UnwrapAsyncTests
         // act
         async Task Act()
         {
-            await failingTask.UnwrapAsync(err => "Arthur Dent");
+            await failingTask.UnwrapAsync(_ => "Arthur Dent");
         }
 
         // arrange
@@ -216,7 +216,7 @@ public class UnwrapAsyncTests
         var invoked = false;
 
         // act
-        var hello = await ok.UnwrapAsync(async err =>
+        var hello = await ok.UnwrapAsync(async _ =>
         {
             invoked = true;
             return await Task.FromResult("YOLO");
@@ -239,13 +239,13 @@ public class UnwrapAsyncTests
         {
             try
             {
-                await err.UnwrapAsync(async e =>
+                await err.UnwrapAsync(async _ =>
                 {
                     invoked = true;
                     return await Task.FromResult("YOLO");
                 });
             }
-            catch (AttemptToUnwrapErrWhenResultWasOkException ex)
+            catch (TriedToUnwrapErrException ex)
             {
                 Assert.AreEqual("YOLO", ex.Message);
                 throw;
@@ -253,7 +253,7 @@ public class UnwrapAsyncTests
         }
 
         // arrange
-        Assert.ThrowsAsync<AttemptToUnwrapErrWhenResultWasOkException>(Act);
+        Assert.ThrowsAsync<TriedToUnwrapErrException>(Act);
         Assert.IsTrue(invoked);
     }
 
@@ -264,7 +264,7 @@ public class UnwrapAsyncTests
         var okTask = Task.FromResult("Ford Prefect".ToOk<string, int>());
 
         // act
-        await okTask.UnwrapAsync(async err => await Task.FromResult("Arthur Dent"));
+        await okTask.UnwrapAsync(async _ => await Task.FromResult("Arthur Dent"));
 
         // assert
         Assert.AreEqual(TaskStatus.RanToCompletion, okTask.Status);
@@ -279,7 +279,7 @@ public class UnwrapAsyncTests
         // act
         async Task Act()
         {
-            await failingTask.UnwrapAsync(async err => await Task.FromResult("Arthur Dent"));
+            await failingTask.UnwrapAsync(async _ => await Task.FromResult("Arthur Dent"));
         }
 
         // assert
@@ -519,7 +519,7 @@ public class UnwrapAsyncTests
         }
 
         // act
-        var hello = await ok.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+        var hello = await ok.UnwrapOrElseAsync(Continuation);
 
         // assert
         Assert.AreEqual("hello", hello);
@@ -537,7 +537,7 @@ public class UnwrapAsyncTests
         }
 
         // act
-        var world = await err.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+        var world = await err.UnwrapOrElseAsync(Continuation);
 
         // assert
         Assert.AreEqual("world", world);
@@ -555,7 +555,7 @@ public class UnwrapAsyncTests
         }
 
         // act
-        await okTask.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+        await okTask.UnwrapOrElseAsync(Continuation);
 
         // assert
         Assert.AreEqual(TaskStatus.RanToCompletion, okTask.Status);
@@ -575,7 +575,7 @@ public class UnwrapAsyncTests
         // act
         async Task Act()
         {
-            await failingTask.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+            await failingTask.UnwrapOrElseAsync(Continuation);
         }
 
         // assert
@@ -599,7 +599,7 @@ public class UnwrapAsyncTests
         }
 
         // act
-        var hello = await ok.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+        var hello = await ok.UnwrapOrElseAsync(Continuation);
 
         // assert
         Assert.AreEqual("hello", hello);
@@ -623,7 +623,7 @@ public class UnwrapAsyncTests
         }
 
         // act
-        var world = await err.UnwrapOrElseAsync((Func<Task<string>>)Continuation);
+        var world = await err.UnwrapOrElseAsync(Continuation);
 
         // assert
         Assert.AreEqual("world", world);

--- a/Galaxus.Functional.Tests/(Result)/ResultTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultTests.cs
@@ -70,7 +70,7 @@ public class ResultTests
             {
                 called = true;
                 Assert.AreEqual("hello", ok);
-            }, err => Assert.Fail());
+            }, _ => Assert.Fail());
             Assert.IsTrue(called);
         }
 
@@ -82,7 +82,7 @@ public class ResultTests
                 called = true;
                 Assert.AreEqual("hello", ok);
                 return 666;
-            }, err =>
+            }, _ =>
             {
                 Assert.Fail();
                 throw new InvalidOperationException();
@@ -104,7 +104,7 @@ public class ResultTests
 
         {
             var called = false;
-            result.IfErr(err => called = true);
+            result.IfErr(_ => called = true);
             Assert.IsFalse(called);
         }
     }
@@ -116,7 +116,7 @@ public class ResultTests
 
         {
             var called = false;
-            result.Match(ok => Assert.Fail(), err =>
+            result.Match(_ => Assert.Fail(), err =>
             {
                 Assert.AreEqual(99, err);
                 called = true;
@@ -127,7 +127,7 @@ public class ResultTests
         {
             var called = false;
 
-            var number = result.Match(ok =>
+            var number = result.Match(_ =>
                 {
                     Assert.Fail();
                     throw new InvalidOperationException();
@@ -155,7 +155,7 @@ public class ResultTests
 
         {
             var called = false;
-            result.IfOk(ok => called = true);
+            result.IfOk(_ => called = true);
             Assert.IsFalse(called);
         }
     }
@@ -164,15 +164,15 @@ public class ResultTests
     public void ResultMatchWithNullMatchPatternThrows()
     {
         // OK
-        Assert.Throws<ArgumentNullException>(() => { 0.ToOk<int, string>().Match(null, err => { }); });
+        Assert.Throws<ArgumentNullException>(() => { 0.ToOk<int, string>().Match(null, _ => { }); });
         Assert.Throws<ArgumentNullException>(() => { 0.ToOk<int, string>().IfOk(null); });
 
         // ERR
-        Assert.Throws<ArgumentNullException>(() => { "hello".ToErr<int, string>().Match(v => { }, null); });
+        Assert.Throws<ArgumentNullException>(() => { "hello".ToErr<int, string>().Match(_ => { }, null); });
         Assert.Throws<ArgumentNullException>(() => { "hello".ToErr<int, string>().IfErr(null); });
 
         // OK and ERR with return value
-        Assert.Throws<ArgumentNullException>(() => { _ = 0.ToOk<int, string>().Match(null, err => 0); });
+        Assert.Throws<ArgumentNullException>(() => { _ = 0.ToOk<int, string>().Match(null, _ => 0); });
         Assert.Throws<ArgumentNullException>(() => { _ = "hello".ToErr<int, string>().Match(v => v, null); });
     }
 
@@ -267,13 +267,13 @@ public class ResultTests
     {
         const string initialResult = "a";
         const string continuationResult = "b";
-        Func<string, Task<Result<string, string>>> continuation = s =>
+        Func<string, Task<Result<string, string>>> continuation = _ =>
             Task.FromResult(Result<string, string>.FromErr(continuationResult));
         var result = await Result<string, string>.FromErr(initialResult)
             .OrElseAsync(continuation);
 
         result.Match(
-            ok => Assert.Fail(),
+            _ => Assert.Fail(),
             err => Assert.AreEqual(continuationResult, err));
     }
 
@@ -282,7 +282,7 @@ public class ResultTests
     {
         const string initialResult = "a";
         const string continuationResult = "b";
-        Func<string, Task<Result<string, string>>> continuation = s =>
+        Func<string, Task<Result<string, string>>> continuation = _ =>
             Task.FromResult(Result<string, string>.FromErr(continuationResult));
 
         var result = await Result<string, string>.FromOk(initialResult)
@@ -290,7 +290,7 @@ public class ResultTests
 
         result.Match(
             ok => Assert.AreEqual(initialResult, ok),
-            err => Assert.Fail());
+            _ => Assert.Fail());
     }
 
     [Test]
@@ -371,7 +371,7 @@ public class ResultTests
         {
             var ok = "hello".ToOk<string, int>();
             var invoked = false;
-            Assert.AreEqual("hello", ok.Unwrap(err =>
+            Assert.AreEqual("hello", ok.Unwrap(_ =>
             {
                 invoked = true;
                 return "YOLO";
@@ -386,7 +386,7 @@ public class ResultTests
             {
                 try
                 {
-                    err.Unwrap(err_ =>
+                    err.Unwrap(_ =>
                     {
                         invoked = true;
                         return "YOLO";
@@ -524,25 +524,25 @@ public class ResultTests
         {
             var invoked = false;
             Assert.AreEqual(Result<int, int>.FromOk(9),
-                Result<int, int>.FromOk(3).AndThen(i => invoked = true).AndThen(Square));
+                Result<int, int>.FromOk(3).AndThen(_ => invoked = true).AndThen(Square));
             Assert.IsTrue(invoked);
         }
         {
             var invoked = false;
             Assert.AreEqual(Result<int, int>.FromErr(3),
-                Result<int, int>.FromOk(3).AndThen(i => invoked = true).AndThen(Error));
+                Result<int, int>.FromOk(3).AndThen(_ => invoked = true).AndThen(Error));
             Assert.IsTrue(invoked);
         }
         {
             var invoked = false;
             Assert.AreEqual(Result<int, int>.FromErr(3),
-                Result<int, int>.FromOk(3).AndThen(Error).AndThen(i => invoked = true));
+                Result<int, int>.FromOk(3).AndThen(Error).AndThen(_ => invoked = true));
             Assert.IsFalse(invoked);
         }
         {
             var invoked = false;
             Assert.AreEqual(Result<int, int>.FromErr(5),
-                Result<int, int>.FromErr(5).AndThen(Square).AndThen(i => invoked = true));
+                Result<int, int>.FromErr(5).AndThen(Square).AndThen(_ => invoked = true));
             Assert.IsFalse(invoked);
         }
     }
@@ -579,7 +579,7 @@ public class ResultTests
 
         Result<Unit, int> Nop(Result<string, int> x)
         {
-            return x.Match(ok => Result<Unit, int>.FromOk(Unit.Value), err => err);
+            return x.Match(_ => Result<Unit, int>.FromOk(Unit.Value), err => err);
         }
 
         var nextResult = success.AndThen(s => Nop(s));
@@ -592,7 +592,7 @@ public class ResultTests
     {
         const string initialResult = "a";
         const string continuationResult = "b";
-        Func<string, Task<Result<string, string>>> continuation = s =>
+        Func<string, Task<Result<string, string>>> continuation = _ =>
             Task.FromResult(Result<string, string>.FromOk(continuationResult));
         var result = await Result<string, string>.FromOk(initialResult)
             .AndThenAsync(continuation);
@@ -604,7 +604,7 @@ public class ResultTests
     {
         const string initialError = "a";
         const string continuationResult = "b";
-        Func<string, Task<Result<string, string>>> continuation = s =>
+        Func<string, Task<Result<string, string>>> continuation = _ =>
             Task.FromResult(Result<string, string>.FromOk(continuationResult));
         var result = await Result<string, string>.FromErr(initialError)
             .AndThenAsync(continuation);
@@ -616,7 +616,7 @@ public class ResultTests
     {
         const string initialResult = "a";
         const string continuationResult = "b";
-        Func<string, Task<string>> continuation = s => Task.FromResult(continuationResult);
+        Func<string, Task<string>> continuation = _ => Task.FromResult(continuationResult);
         var result = await Result<string, string>.FromOk(initialResult)
             .MapAsync(continuation);
         Assert.AreEqual(continuationResult, result.Ok.UnwrapOrDefault());
@@ -627,7 +627,7 @@ public class ResultTests
     {
         const string initialError = "a";
         const string continuationResult = "b";
-        Func<string, Task<string>> continuation = s => Task.FromResult(continuationResult);
+        Func<string, Task<string>> continuation = _ => Task.FromResult(continuationResult);
         var result = await Result<string, string>.FromErr(initialError)
             .MapAsync(continuation);
         Assert.IsTrue(result.IsErr);
@@ -637,7 +637,7 @@ public class ResultTests
     public void MapAsync_ContinuationThrowsException_CorrectExceptionIsPropagated()
     {
         const string initialResult = "a";
-        Func<string, Task<string>> continuation = s => Task.FromException<string>(new ArgumentException());
+        Func<string, Task<string>> continuation = _ => Task.FromException<string>(new ArgumentException());
 
         Assert.ThrowsAsync<ArgumentException>(async () =>
         {
@@ -651,7 +651,7 @@ public class ResultTests
     {
         const string initialError = "a";
         const string continuationResult = "b";
-        Func<string, Task<string>> continuation = s => Task.FromResult(continuationResult);
+        Func<string, Task<string>> continuation = _ => Task.FromResult(continuationResult);
         var result = await Result<string, string>.FromErr(initialError)
             .MapErrAsync(continuation);
         Assert.AreEqual(continuationResult, result.Err.UnwrapOrDefault());
@@ -662,7 +662,7 @@ public class ResultTests
     {
         const string initialResult = "a";
         const string continuationResult = "b";
-        Func<string, Task<string>> continuation = s => Task.FromResult(continuationResult);
+        Func<string, Task<string>> continuation = _ => Task.FromResult(continuationResult);
         var result = await Result<string, string>.FromOk(initialResult)
             .MapErrAsync(continuation);
         Assert.IsTrue(result.IsOk);
@@ -672,7 +672,7 @@ public class ResultTests
     public void MapErrAsync_ContinuationThrowsException_CorrectExceptionIsPropagated()
     {
         const string initialResult = "a";
-        Func<string, Task<string>> continuation = s => Task.FromException<string>(new ArgumentException());
+        Func<string, Task<string>> continuation = _ => Task.FromException<string>(new ArgumentException());
 
         Assert.ThrowsAsync<ArgumentException>(async () =>
         {
@@ -685,8 +685,8 @@ public class ResultTests
     public void MatchAsync_ContinuationThrowsException_CorrectExceptionIsPropagated()
     {
         const string initialResult = "a";
-        Func<string, Task<string>> continuationOk = s => Task.FromException<string>(new ArgumentException());
-        Func<string, Task<string>> continuationErr = s => Task.FromResult("b");
+        Func<string, Task<string>> continuationOk = _ => Task.FromException<string>(new ArgumentException());
+        Func<string, Task<string>> continuationErr = _ => Task.FromResult("b");
 
         Assert.ThrowsAsync<ArgumentException>(async () =>
         {

--- a/Galaxus.Functional.Tests/(Result)/ResultTests.cs
+++ b/Galaxus.Functional.Tests/(Result)/ResultTests.cs
@@ -341,7 +341,7 @@ public class ResultTests
         var err = 99.ToErr<string, int>();
 
         Assert.AreEqual("hello", ok.Unwrap());
-        Assert.Throws<AttemptToUnwrapErrWhenResultWasOkException>(() => err.Unwrap());
+        Assert.Throws<TriedToUnwrapErrException>(() => err.Unwrap());
     }
 
     [Test]
@@ -351,13 +351,13 @@ public class ResultTests
         var err = 99.ToErr<string, int>();
 
         Assert.AreEqual("hello", ok.Unwrap("YOLO"));
-        Assert.Throws<AttemptToUnwrapErrWhenResultWasOkException>(() =>
+        Assert.Throws<TriedToUnwrapErrException>(() =>
         {
             try
             {
                 err.Unwrap("YOLO");
             }
-            catch (AttemptToUnwrapErrWhenResultWasOkException ex)
+            catch (TriedToUnwrapErrException ex)
             {
                 Assert.AreEqual("YOLO", ex.Message);
                 throw;
@@ -382,7 +382,7 @@ public class ResultTests
         {
             var err = 0.ToErr<string, int>();
             var invoked = false;
-            Assert.Throws<AttemptToUnwrapErrWhenResultWasOkException>(() =>
+            Assert.Throws<TriedToUnwrapErrException>(() =>
             {
                 try
                 {
@@ -392,7 +392,7 @@ public class ResultTests
                         return "YOLO";
                     });
                 }
-                catch (AttemptToUnwrapErrWhenResultWasOkException ex)
+                catch (TriedToUnwrapErrException ex)
                 {
                     Assert.AreEqual("YOLO", ex.Message);
                     throw;

--- a/Galaxus.Functional.Tests/Galaxus.Functional.Tests.csproj
+++ b/Galaxus.Functional.Tests/Galaxus.Functional.Tests.csproj
@@ -6,13 +6,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NUnit" Version="3.13.2"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
+        <PackageReference Include="NUnit" Version="3.13.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Galaxus.Functional\Galaxus.Functional.csproj"/>
+        <ProjectReference Include="..\Galaxus.Functional\Galaxus.Functional.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Galaxus.Functional.Tests/Helpers/YieldElementsThenFail.cs
+++ b/Galaxus.Functional.Tests/Helpers/YieldElementsThenFail.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 
@@ -25,7 +26,7 @@ internal class YieldElementsThenFail<T> : IEnumerable<T>
         Assert.Fail("Sequence was unexpectedly enumerated.");
     }
 
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+    IEnumerator IEnumerable.GetEnumerator()
     {
         return GetEnumerator();
     }

--- a/Galaxus.Functional/(Option)/Option.cs
+++ b/Galaxus.Functional/(Option)/Option.cs
@@ -143,7 +143,7 @@ namespace Galaxus.Functional
         {
             if (IsSome == false)
             {
-                throw new AttemptToUnwrapNoneWhenOptionContainedSomeException(error);
+                throw new TriedToUnwrapNoneException(error);
             }
 
             return _some;
@@ -163,7 +163,7 @@ namespace Galaxus.Functional
                     throw new ArgumentNullException(nameof(error));
                 }
 
-                throw new AttemptToUnwrapNoneWhenOptionContainedSomeException(error());
+                throw new TriedToUnwrapNoneException(error());
             }
 
             return _some;

--- a/Galaxus.Functional/(Option)/OptionExtensions.cs
+++ b/Galaxus.Functional/(Option)/OptionExtensions.cs
@@ -186,7 +186,7 @@ namespace Galaxus.Functional
                     throw new ArgumentNullException(nameof(error));
                 }
 
-                throw new AttemptToUnwrapNoneWhenOptionContainedSomeException(await error());
+                throw new TriedToUnwrapNoneException(await error());
             }
 
             return res.Unwrap();

--- a/Galaxus.Functional/(Option)/TriedToUnwrapNoneException.cs
+++ b/Galaxus.Functional/(Option)/TriedToUnwrapNoneException.cs
@@ -5,13 +5,13 @@ namespace Galaxus.Functional
     /// <summary>
     ///     Thrown when an attempt was made to unwrap an <see cref="Option{T}" /> containing <see cref="None" />.
     /// </summary>
-    public class AttemptToUnwrapNoneWhenOptionContainedSomeException : Exception
+    public sealed class TriedToUnwrapNoneException : Exception
     {
         /// <summary>
-        ///     Create an <see cref="AttemptToUnwrapNoneWhenOptionContainedSomeException" /> object.
+        ///     Create an <see cref="TriedToUnwrapNoneException" /> object.
         /// </summary>
         /// <param name="message">The message for the exception.</param>
-        public AttemptToUnwrapNoneWhenOptionContainedSomeException(string message) : base(message)
+        public TriedToUnwrapNoneException(string message) : base(message)
         {
         }
     }

--- a/Galaxus.Functional/(Result)/Result.cs
+++ b/Galaxus.Functional/(Result)/Result.cs
@@ -152,7 +152,7 @@ namespace Galaxus.Functional
         {
             if (IsErr)
             {
-                throw new AttemptToUnwrapErrWhenResultWasOkException(error);
+                throw new TriedToUnwrapErrException(error);
             }
 
             return _ok;
@@ -172,7 +172,7 @@ namespace Galaxus.Functional
                     throw new ArgumentNullException(nameof(error));
                 }
 
-                throw new AttemptToUnwrapErrWhenResultWasOkException(error(_err));
+                throw new TriedToUnwrapErrException(error(_err));
             }
 
             return _ok;

--- a/Galaxus.Functional/(Result)/ResultExtensions.cs
+++ b/Galaxus.Functional/(Result)/ResultExtensions.cs
@@ -347,7 +347,7 @@ namespace Galaxus.Functional
                     throw new ArgumentNullException(nameof(error));
                 }
 
-                throw new AttemptToUnwrapErrWhenResultWasOkException(await error(res.Err.Unwrap()));
+                throw new TriedToUnwrapErrException(await error(res.Err.Unwrap()));
             }
 
             return res.Unwrap();

--- a/Galaxus.Functional/(Result)/TriedToUnwrapErrException.cs
+++ b/Galaxus.Functional/(Result)/TriedToUnwrapErrException.cs
@@ -5,7 +5,7 @@ namespace Galaxus.Functional
     /// <summary>
     ///     Thrown when an attempt was made to unwrap a <see cref="Result{TOk, TErr}" /> containing <b>Err</b>.
     /// </summary>
-    public class TriedToUnwrapErrException : Exception
+    public sealed class TriedToUnwrapErrException : Exception
     {
         /// <summary>
         ///     Create an <see cref="TriedToUnwrapErrException" /> object.

--- a/Galaxus.Functional/(Result)/TriedToUnwrapErrException.cs
+++ b/Galaxus.Functional/(Result)/TriedToUnwrapErrException.cs
@@ -5,13 +5,13 @@ namespace Galaxus.Functional
     /// <summary>
     ///     Thrown when an attempt was made to unwrap a <see cref="Result{TOk, TErr}" /> containing <b>Err</b>.
     /// </summary>
-    public class AttemptToUnwrapErrWhenResultWasOkException : Exception
+    public class TriedToUnwrapErrException : Exception
     {
         /// <summary>
-        ///     Create an <see cref="AttemptToUnwrapErrWhenResultWasOkException" /> object.
+        ///     Create an <see cref="TriedToUnwrapErrException" /> object.
         /// </summary>
         /// <param name="message">The message for the exception.</param>
-        public AttemptToUnwrapErrWhenResultWasOkException(string message) : base(message)
+        public TriedToUnwrapErrException(string message) : base(message)
         {
         }
     }

--- a/Galaxus.Functional/Galaxus.Functional.csproj
+++ b/Galaxus.Functional/Galaxus.Functional.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <WarningsAsErrors/>
+        <WarningsAsErrors />
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 


### PR DESCRIPTION
* Renamed `AttemptToUnwrapNoneWhenOptionContainedSomeException` to `TriedToUnwrapNoneException`
* Renamed `AttemptToUnwrapErrWhenResultWasOkException` to `TriedToUnwrapErrException`
* Removed redundant code (e.g. type declarations for lambdas)