### PR TITLE
Add GitHub workflow for NuGet publish

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -3,8 +3,8 @@ name: Publish NuGet Packages
 on:
   push:
     tags:
-      - '*.*.*'
-      - '*.*.*-*'
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
 
 jobs:
   build-and-publish:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,26 @@
+name: Publish DG.Functional NuGet Package
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build-and-publish:
+    name: Build and Publish NuGet
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 8.0
+    - name: Install Dependencies
+      run: dotnet restore
+    - name: Build and Pack NuGet Package
+      run: dotnet pack --configuration Release --output ./artifacts ./Galaxus.Functional
+    - name: Publish to NuGet
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: dotnet nuget push ./artifacts/*.nupkg --source https://api.nuget.org/v3/index.json --api-key $NUGET_API_KEY

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -3,7 +3,8 @@ name: Publish NuGet Packages
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - '*.*.*'
+      - '*.*.*-*'
 
 jobs:
   build-and-publish:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -23,14 +23,16 @@ jobs:
     - name: Build Solution
       run: |
         dotnet build --configuration Release \
+          --no-restore \
           -p:CI_BUILD=true \
           -p:Version=${{env.VERSION}} \
-          -p:AssemblyVersion=${{env.VERSION}} \
-          -p:FileVersion=${{env.VERSION}}
+          -p:PackageVersion=${{env.VERSION}} \
     - name: Pack NuGet Packages
       run: |
         dotnet pack --configuration Release \
+          --no-build \
           -p:CI_BUILD=true \
+          -p:Version=${{env.VERSION}} \
           -p:PackageVersion=${{env.VERSION}} \
           --output ./artifacts
     - name: Publish to NuGet

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,4 +1,4 @@
-name: Publish DG.Functional NuGet Package
+name: Publish NuGet Packages
 
 on:
   push:
@@ -15,11 +15,24 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8.0
+        dotnet-version: 9.0
+    - name: Extract Version from Tag
+      run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
     - name: Install Dependencies
       run: dotnet restore
-    - name: Build and Pack NuGet Package
-      run: dotnet pack --configuration Release --output ./artifacts ./Galaxus.Functional
+    - name: Build Solution
+      run: |
+        dotnet build --configuration Release \
+          -p:CI_BUILD=true \
+          -p:Version=${{env.VERSION}} \
+          -p:AssemblyVersion=${{env.VERSION}} \
+          -p:FileVersion=${{env.VERSION}}
+    - name: Pack NuGet Packages
+      run: |
+        dotnet pack --configuration Release \
+          -p:CI_BUILD=true \
+          -p:PackageVersion=${{env.VERSION}} \
+          --output ./artifacts
     - name: Publish to NuGet
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -327,4 +327,40 @@ ASALocalRun/
 *.nvuser
 
 # MFractors (Xamarin productivity tool) working folder 
-.mfractor/
+.mfractor/# Created by https://www.toptal.com/developers/gitignore/api/macos
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+# End of https://www.toptal.com/developers/gitignore/api/macos
+

--- a/Galaxus.Functional/Galaxus.Functional.csproj
+++ b/Galaxus.Functional/Galaxus.Functional.csproj
@@ -7,4 +7,11 @@
         <PackageTags>functional option either result digitec galaxus digitecgalaxus</PackageTags>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="MinVer" Version="6.0.0">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+    </ItemGroup>
+
 </Project>

--- a/Galaxus.Functional/Galaxus.Functional.csproj
+++ b/Galaxus.Functional/Galaxus.Functional.csproj
@@ -7,11 +7,4 @@
         <PackageTags>functional option either result digitec galaxus digitecgalaxus</PackageTags>
     </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="MinVer" Version="6.0.0">
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
-    </ItemGroup>
-
 </Project>

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) 2018-2023 Digitec Galaxus AG
-              2018-2023 Galaxus.Functional contributors (see https://github.com/DigitecGalaxus/Galaxus.Functional/graphs/contributors)
+Copyright (c) 2018-2024 Digitec Galaxus AG
+              2018-2024 Galaxus.Functional contributors (see https://github.com/DigitecGalaxus/Galaxus.Functional/graphs/contributors)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Package.props
+++ b/Package.props
@@ -22,7 +22,7 @@
         <PackageId>$(AssemblyName)</PackageId>
         <PackageVersion>0.0.0</PackageVersion> <!-- Will be passed to the build -->
         <Authors>Digitec Galaxus AG</Authors>
-        <Copyright>2018-2023 Digitec Galaxus AG</Copyright>
+        <Copyright>2018-2024 Digitec Galaxus AG</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/DigitecGalaxus/Galaxus.Functional</PackageProjectUrl>
         <RepositoryUrl>https://github.com/DigitecGalaxus/Galaxus.Functional</RepositoryUrl>


### PR DESCRIPTION
What I did:

- updated copyright year
- ~~added `MinVer` package to automatically determine version number from Git tags~~
- added GitHub workflow to react to new releases using tag pattern, pushes to NuGet

What would still need to be done in order to use this pipeline is 

- [x] generate an API key on [nuget.org](https://www.nuget.org/account/apikeys) with an account that can manage the package
- [x] add the API key as [a (repository) secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository)  with the name `NUGET_API_KEY`